### PR TITLE
SORT文INPUT/OUTPUT PROCEDUREオプション,RETURN文,RELEASE文の追加

### DIFF
--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -3084,93 +3084,97 @@ joutput_sort_proc (struct cb_sort_proc *p)
 	} else {
 		joutput_line ("/* PERFORM %s THRU %s */", lb->name, le->name);
 	}
-	joutput_line ("frame_ptr++;");
-	joutput_line ("memset (frame_ptr, 0, sizeof (struct cob_frame));");
-	if (cb_flag_stack_check) {
-		joutput_line ("if (unlikely(frame_ptr == frame_overflow))");
-		joutput_line ("    cob_fatal_error (COB_FERROR_STACK);");
-	}
-	joutput_line ("frame_ptr->perform_through = %d;", le->id);
-	joutput_prefix ();
-	joutput ("frame_ptr->current_sort_merge_file = ");
-	joutput_param (p->sort_file, 0);
-	joutput (";\n");
+	//joutput_line ("frame_ptr++;");
+	//joutput_line ("memset (frame_ptr, 0, sizeof (struct cob_frame));");
+	//if (cb_flag_stack_check) {
+	//	joutput_line ("if (unlikely(frame_ptr == frame_overflow))");
+	//	joutput_line ("    cob_fatal_error (COB_FERROR_STACK);");
+	//}
+	//joutput_line ("frame_ptr->perform_through = %d;", le->id);
+	//joutput_prefix ();
+	//joutput ("frame_ptr->current_sort_merge_file = ");
+	//joutput_param (p->sort_file, 0);
+	//joutput (";\n");
 #ifndef	__GNUC__
-	l = cobc_malloc (sizeof (struct label_list));
-	l->next = label_cache;
-	l->id = cb_id;
-	if (label_cache == NULL) {
-		l->call_num = 0;
-	} else {
-		l->call_num = label_cache->call_num + 1;
-	}
-	label_cache = l;
-	joutput_line ("frame_ptr->return_address = %d;", l->call_num);
-	joutput_prefix ();
-	joutput ("if (unlikely(*(int*)(");
-	joutput_param (p->sort_return, 0);
-	joutput (") != 0))\n");
-	joutput_prefix ();
-	joutput_line ("goto %s%d;", CB_PREFIX_LABEL, cb_id);
-	joutput_line ("goto %s%d;", CB_PREFIX_LABEL, lb->id);
-	joutput_line ("%s%d:", CB_PREFIX_LABEL, cb_id);
+	//l = cobc_malloc (sizeof (struct label_list));
+	//l->next = label_cache;
+	//l->id = cb_id;
+	//if (label_cache == NULL) {
+	//	l->call_num = 0;
+	//} else {
+	//	l->call_num = label_cache->call_num + 1;
+	//}
+	//label_cache = l;
+	//joutput_line ("frame_ptr->return_address = %d;", l->call_num);
+	//joutput_prefix ();
+	//joutput ("if (unlikely(*(int*)(");
+	//joutput_param (p->sort_return, 0);
+	//joutput (") != 0))\n");
+	//joutput_prefix ();
+	//joutput_line ("goto %s%d;", CB_PREFIX_LABEL, cb_id);
+	//joutput_line ("goto %s%d;", CB_PREFIX_LABEL, lb->id);
+	//joutput_line ("%s%d:", CB_PREFIX_LABEL, cb_id);
 #elif	COB_USE_SETJMP
-	joutput_line ("if (setjmp (frame_ptr->return_address) == 0)");
-	joutput_line ("  goto %s%d;", CB_PREFIX_LABEL, lb->id);
+	//joutput_line ("if (setjmp (frame_ptr->return_address) == 0)");
+	//joutput_line ("  goto %s%d;", CB_PREFIX_LABEL, lb->id);
 #else
-	joutput_line ("frame_ptr->return_address = &&%s%d;",
-		     CB_PREFIX_LABEL, cb_id);
-	joutput_prefix ();
-	joutput ("if (unlikely(*(int*)(");
-	joutput_param (p->sort_return, 0);
-	joutput (") != 0))\n");
-	joutput_prefix ();
-	joutput_line ("goto %s%d;", CB_PREFIX_LABEL, cb_id);
-	joutput_line ("goto %s%d;", CB_PREFIX_LABEL, lb->id);
-	joutput_line ("%s%d:", CB_PREFIX_LABEL, cb_id);
+	//joutput_line ("frame_ptr->return_address = &&%s%d;",
+	//	     CB_PREFIX_LABEL, cb_id);
+	//joutput_prefix ();
+	//joutput ("if (unlikely(*(int*)(");
+	//joutput_param (p->sort_return, 0);
+	//joutput (") != 0))\n");
+	//joutput_prefix ();
+	//joutput_line ("goto %s%d;", CB_PREFIX_LABEL, cb_id);
+	//joutput_line ("goto %s%d;", CB_PREFIX_LABEL, lb->id);
+	//joutput_line ("%s%d:", CB_PREFIX_LABEL, cb_id);
 #endif
-	cb_id++;
-	joutput_line ("frame_ptr--;");
+	//joutput_line ("/* perform call */");
+	joutput_line("entryFunc(%d, %d);", lb->id, le->id);
+	//cb_id++;
+	//joutput_line ("frame_ptr--;");
 }
 
 static void
 joutput_sort_proc_escape (struct cb_sort_proc *p)
 {
-	joutput ("    if (*(int*)(");
+	joutput_indent ("if (");
 	joutput_param (p->sort_return, 0);
-	joutput (") != 0)\n");
-	joutput ("      {\n");
-	joutput ("        while (frame_ptr->current_sort_merge_file != ");
+	joutput (".intValue() != 0)\n");
+	joutput ("{\n");
+	joutput_indent ("  while (frame_ptr->current_sort_merge_file != ");
 	joutput_param (p->sort_file, 0);
 	joutput (")\n");
-	joutput ("             --frame_ptr;\n");
-	joutput ("    ");
-#ifndef	__GNUC__
-	joutput_line ("goto P_switch;");
-#elif	COB_USE_SETJMP
-	joutput_line ("longjmp (frame_ptr->return_address, 1);");
-#else
-	joutput_line ("goto *frame_ptr->return_address;");
-#endif
-	joutput ("      }\n");
+	joutput_line ("    --frame_ptr;\n");
+//#ifndef	__GNUC__
+//	joutput_line ("goto P_switch;");
+//#elif	COB_USE_SETJMP
+//	joutput_line ("longjmp (frame_ptr->return_address, 1);");
+//#else
+//	joutput_line ("goto *frame_ptr->return_address;");
+//#endif
+    
+	joutput_line ("}");
 }
 
 static void
 joutput_file_return (struct cb_return *p)
 {
-	joutput_sort_proc_escape (&(p->proc));
-	joutput_prefix ();
+	//joutput_sort_proc_escape (&(p->proc));
+    joutput_prefix();
+	joutput ("CobolFileSort.performReturn(");
 	joutput_param (p->proc.sort_file, 0);
-	joutput ("sortReturn();\n");
+	joutput (");\n");
 }
 
 static void
 joutput_file_release (struct cb_release *p)
 {
-	joutput_sort_proc_escape (&(p->proc));
-	joutput_prefix ();
+	//joutput_sort_proc_escape (&(p->proc));
+    joutput_prefix();
+	joutput ("CobolFileSort.performRelease(");
 	joutput_param (p->proc.sort_file, 0);
-	joutput ("sortRelease();\n");
+	joutput (");\n");
 }
 
 static void

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolFrame.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolFrame.java
@@ -18,26 +18,62 @@
  */
 
 package jp.osscons.opensourcecobol.libcobj.common;
+import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
 /**
  * opensource COBOLのcob_frameに対応するクラス
  */
 public class CobolFrame {
 	private int performThrough;
+	private int returnAddress;
+	private CobolFile currentSortMergeFile;
 
 	/**
 	 * performThroughのgetter
 	 * @return this.performThrough
 	 */
 	public int getPerformThrough() {
-		return performThrough;
+		return this.performThrough;
 	}
 
 	/**
 	 * performThroughのsetter
 	 * @param performThrough this.performThroughに設定する値
-	 */
+	 */	
 	public void setPerformThrough(int performThrough) {
 		this.performThrough = performThrough;
+	}
+	
+	/**
+	 * returnAddressのgetter
+	 * @return this.performThrough
+	 */
+	public int getReturnAddress() {
+		return this.returnAddress;
+	}
+
+	/**
+	 * returnAddressのsetter
+	 * @param returnAddress this.returnAddressに設定する値
+	 */	
+	public void setReturnAddress(int returnAddress) {
+		this.returnAddress = returnAddress;
+	}	
+
+	
+	/**
+	 * returnAddressのgetter
+	 * @return this.performThrough
+	 */
+	public CobolFile getCurrentSortMergeFile() {
+		return this.currentSortMergeFile;
+	}
+
+	/**
+	 * returnAddressのsetter
+	 * @param returnAddress this.returnAddressに設定する値
+	 */	
+	public void setCurrentSortMergeFile(CobolFile currentSortMergeFile) {
+		this.currentSortMergeFile = currentSortMergeFile;
 	}
 }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -34,27 +34,29 @@ import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 
 public class CobolFileSort {
-	protected static int COBSORTEND = 1;
-	protected static int COBSORTABORT = 2;
-	protected static int COBSORTFILEERR = 3;
-	protected static int COBSORTNOTOPEN = 4;
+	protected final static int COBSORTEND = 1;
+	protected final static int COBSORTABORT = 2;
+	protected final static int COBSORTFILEERR = 3;
+	protected final static int COBSORTNOTOPEN = 4;
 
-	protected static int COB_ASCENDING = 0;
-	protected static int COB_DESCENDING = 1;
+	protected final static int COB_ASCENDING = 0;
+	protected final static int COB_DESCENDING = 1;
 
 	private static String cob_process_id = "";
 	private static int cob_iteration = 0;
 
-	protected static int cob_sort_memory = 128*1024*1024;
+	protected static int cob_sort_memory = 128 * 1024 * 1024;
 
-	//Javaの標準ライブラリでソートするならtrue
+	// Javaの標準ライブラリでソートするならtrue
 	private static boolean SORT_STD_LIB = true;
 	private static List<CobolDataStorage> dataList;
 
 	/**
 	 * libcob/fileio.cのsort_cmpsの実装
+	 * 
 	 * @param s1
 	 * @param s2
 	 * @param size
@@ -62,17 +64,17 @@ public class CobolFileSort {
 	 * @return
 	 */
 	private static int sortCmps(CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
-		if(col != null) {
-			for(int i=0; i<size; ++i) {
+		if (col != null) {
+			for (int i = 0; i < size; ++i) {
 				int ret = col.getByte(s1.getByte(i)) - col.getByte(s2.getByte(i));
-				if(ret != 0) {
+				if (ret != 0) {
 					return ret;
 				}
 			}
 		} else {
-			for(int i=0; i<size; ++i) {
+			for (int i = 0; i < size; ++i) {
 				int ret = s1.getByte(i) - s2.getByte(i);
-				if(ret != 0) {
+				if (ret != 0) {
 					return ret;
 				}
 			}
@@ -81,25 +83,26 @@ public class CobolFileSort {
 	}
 
 	private static void uniqueCopy(CobolDataStorage s1, CobolDataStorage s2, int size) {
-		for(int i=0; i<size; ++i)  {
+		for (int i = 0; i < size; ++i) {
 			s1.setByte(s2.getByte(i));
 		}
 	}
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_compareの実装
+	 * 
 	 * @param k1
 	 * @param k2
 	 * @param pointer
 	 * @return
 	 */
-	private static int  sortCompare(CobolItem k1, CobolItem k2, CobolFile pointer) {
+	private static int sortCompare(CobolItem k1, CobolItem k2, CobolFile pointer) {
 		CobolFile f = pointer;
 		long u1;
 		long u2;
 		int cmp;
 
-		for(int i=0; i<f.nkeys; i++) {
+		for (int i = 0; i < f.nkeys; i++) {
 			AbstractCobolField src = f.keys[i].getField();
 
 			CobolDataStorage d1 = k1.getItem().copy();
@@ -111,12 +114,12 @@ public class CobolFileSort {
 			AbstractCobolField f1 = CobolFieldFactory.makeCobolField(src.getSize(), d1, src.getAttribute());
 			AbstractCobolField f2 = CobolFieldFactory.makeCobolField(src.getSize(), d2, src.getAttribute());
 
-			if(f1.getAttribute().isTypeNumeric()) {
+			if (f1.getAttribute().isTypeNumeric()) {
 				cmp = f1.numericCompareTo(f2);
 			} else {
 				cmp = sortCmps(f1.getDataStorage(), f2.getDataStorage(), f1.getSize(), f.sort_collating);
 			}
-			if(cmp != 0) {
+			if (cmp != 0) {
 				return (f.keys[i].getFlag() == COB_ASCENDING) ? cmp : -cmp;
 			}
 		}
@@ -131,20 +134,22 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_free_listの実装
+	 * 
 	 * @param q
 	 */
 	private static void cob_free_list(CobolItem q) {
-		//nothing to do
+		// nothing to do
 	}
 
 	/**
 	 * libcob/fileio.cのcob_new_itemの実装
+	 * 
 	 * @param hp
 	 * @return
 	 */
 	private static CobolItem newItem(CobolSort hp) {
 		CobolItem q;
-		if(hp.getEmpty() != null) {
+		if (hp.getEmpty() != null) {
 			q = hp.getEmpty();
 			hp.setEmpty(q.getNext());
 		} else {
@@ -155,17 +160,17 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_tmpfileの実装
+	 * 
 	 * @return
 	 */
 	private static FileIO tmpfile() {
 		String s;
 		FileIO fp = new FileIO();
-		if((s = System.getenv("TMPDIR")) == null &&
-				(s = System.getenv("TMP")) == null &&
-				(s = System.getenv("TEMP")) == null) {
+		if ((s = System.getenv("TMPDIR")) == null && (s = System.getenv("TMP")) == null
+				&& (s = System.getenv("TEMP")) == null) {
 			s = "/tmp";
 		}
-		if(cob_process_id.equals("")) {
+		if (cob_process_id.equals("")) {
 			cob_process_id = java.lang.management.ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
 		}
 		String filename = String.format("%s/cobsort_%s_%d", s, cob_process_id, cob_iteration);
@@ -176,30 +181,27 @@ public class CobolFileSort {
 		}
 		FileChannel fc = null;
 		try {
-			fc = FileChannel.open(Paths.get(filename),
-					StandardOpenOption.READ,
-					StandardOpenOption.WRITE,
-					StandardOpenOption.CREATE,
-					StandardOpenOption.TRUNCATE_EXISTING);
-		} catch(IOException e) {
+			fc = FileChannel.open(Paths.get(filename), StandardOpenOption.READ, StandardOpenOption.WRITE,
+					StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
 			return null;
 		}
 		fp.setChannel(fc, null);
 		return fp;
 	}
 
-
 	/**
 	 * libcob/fileio.cのcob_get_temp_fileの実装
+	 * 
 	 * @param hp
 	 * @param n
 	 * @return
 	 */
 	private static boolean getTempFile(CobolSort hp, int n) {
-		if(hp.getFile()[n].getFp() == null) {
+		if (hp.getFile()[n].getFp() == null) {
 			hp.getFile()[n].setFp(tmpfile());
-			if(hp.getFile()[n].getFp() == null) {
-				//TODO 暫定実装
+			if (hp.getFile()[n].getFp() == null) {
+				// TODO 暫定実装
 				System.out.println("SORT is unable to auire temporary file");
 				System.exit(0);
 			}
@@ -212,6 +214,7 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_sort_queuesの実装
+	 * 
 	 * @param hp
 	 * @return
 	 */
@@ -223,40 +226,38 @@ public class CobolFileSort {
 		int n;
 		int[] end_of_block = new int[2];
 
-		while(hp.getQueue()[source + 1].getCount() != 0) {
+		while (hp.getQueue()[source + 1].getCount() != 0) {
 			destination = source ^ 2;
 			hp.getQueue()[destination].setCount(0);
 			hp.getQueue()[destination + 1].setCount(0);
 			hp.getQueue()[destination].setFirst(null);
 			hp.getQueue()[destination + 1].setFirst(null);
-			for(;;) {
+			for (;;) {
 				end_of_block[0] = hp.getQueue()[source].getCount() == 0 ? 1 : 0;
-				end_of_block[1] = hp.getQueue()[source + 1].getFirst() == null ? 1 : 0;
-				if(end_of_block[0] != 0 && end_of_block[1] != 0) {
+				end_of_block[1] = hp.getQueue()[source + 1].getCount() == 0 ? 1 : 0;
+				if (end_of_block[0] != 0 && end_of_block[1] != 0) {
 					break;
 				}
-				while(end_of_block[0] == 0 || end_of_block[1] == 0) {
-					if(end_of_block[0] != 0) {
+				while (end_of_block[0] == 0 || end_of_block[1] == 0) {
+					if (end_of_block[0] != 0) {
 						move = 1;
-					} else if(end_of_block[1] != 0) {
+					} else if (end_of_block[1] != 0) {
 						move = 0;
 					} else {
-						n = sortCompare(
-								hp.getQueue()[source].getFirst(),
-								hp.getQueue()[source + 1].getFirst(),
+						n = sortCompare(hp.getQueue()[source].getFirst(), hp.getQueue()[source + 1].getFirst(),
 								hp.getPointer());
 						move = n < 0 ? 0 : 1;
 					}
 					q = hp.getQueue()[source + move].getFirst();
-					if(q.getEndOfBlock() != 0) {
+					if (q.getEndOfBlock() != 0) {
 						end_of_block[move] = 1;
 					}
 					q = hp.getQueue()[source + move].getFirst();
-					if(q.getEndOfBlock() != 0) {
+					if (q.getEndOfBlock() != 0) {
 						end_of_block[move] = 1;
 					}
 					hp.getQueue()[source + move].setFirst(q.getNext());
-					if(hp.getQueue()[destination].getFirst() == null) {
+					if (hp.getQueue()[destination].getFirst() == null) {
 						hp.getQueue()[destination].setFirst(q);
 					} else {
 						hp.getQueue()[destination].getLast().setNext(q);
@@ -277,24 +278,25 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_read_itemの実装
+	 * 
 	 * @param hp
 	 * @param n
 	 * @return
 	 */
 	private static int readItem(CobolSort hp, int n) {
 		FileIO fp = hp.getFile()[n].getFp();
-		if(fp.getc() != 0) {
+		if (fp.getc() != 0) {
 			hp.getQueue()[n].getFirst().setEndOfBlock(1);
 		} else {
 			hp.getQueue()[n].getFirst().setEndOfBlock(0);
 			try {
-				if(fp.read(hp.getQueue()[n].getFirst().getUnique(), 8) != 8) {
+				if (fp.read(hp.getQueue()[n].getFirst().getUnique(), 8) != 8) {
 					return 1;
 				}
-				if(fp.read(hp.getQueue()[n].getFirst().getItem(), hp.getSize()) != hp.getSize()) {
+				if (fp.read(hp.getQueue()[n].getFirst().getItem(), hp.getSize()) != hp.getSize()) {
 					return 1;
 				}
-			} catch(IOException e) {
+			} catch (IOException e) {
 				return 1;
 			}
 		}
@@ -303,6 +305,7 @@ public class CobolFileSort {
 
 	/**
 	 * writeBlock内で使う補助メソッド
+	 * 
 	 * @param fp
 	 * @param q
 	 * @param hp
@@ -310,14 +313,14 @@ public class CobolFileSort {
 	 */
 	private static boolean writeItem(FileIO fp, CobolItem q, CobolSort hp) {
 		byte[] blockByteData = new byte[1];
-		blockByteData[0] =q.getBlockByte();
-		if(fp.write(blockByteData, 1, 1) != 1) {
+		blockByteData[0] = q.getBlockByte();
+		if (fp.write(blockByteData, 1, 1) != 1) {
 			return true;
 		}
-		if(fp.write(q.getUnique(), 8, 1) != 1) {
+		if (fp.write(q.getUnique(), 8, 1) != 1) {
 			return true;
 		}
-		if(fp.write(q.getItem(), hp.getSize(), 1) != 1) {
+		if (fp.write(q.getItem(), hp.getSize(), 1) != 1) {
 			return true;
 		}
 		return false;
@@ -325,18 +328,19 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_write_blockの実装
+	 * 
 	 * @param hp
 	 * @param n
 	 * @return
 	 */
 	private static int writeBlock(CobolSort hp, int n) {
 		FileIO fp = hp.getFile()[hp.getDestinationFile()].getFp();
-		for(;;) {
+		for (;;) {
 			CobolItem q = hp.getQueue()[n].getFirst();
-			if(q == null) {
+			if (q == null) {
 				break;
 			}
-			if(writeItem(fp, q, hp)) {
+			if (writeItem(fp, q, hp)) {
 				return 1;
 			}
 			hp.getQueue()[n].setFirst(q.getNext());
@@ -344,9 +348,8 @@ public class CobolFileSort {
 			hp.setEmpty(q);
 		}
 		hp.getQueue()[n].setCount(0);
-		hp.getFile()[hp.getDestinationFile()].setCount(
-				hp.getFile()[hp.getDestinationFile()].getCount() + 1);
-		if(fp.putc((byte)1) != 1) {
+		hp.getFile()[hp.getDestinationFile()].setCount(hp.getFile()[hp.getDestinationFile()].getCount() + 1);
+		if (fp.putc((byte) 1) != 1) {
 			return 1;
 		}
 		return 0;
@@ -354,6 +357,7 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_copy_checkの実装
+	 * 
 	 * @param from
 	 */
 	private static void copyCheck(CobolFile to, CobolFile from) {
@@ -361,102 +365,102 @@ public class CobolFileSort {
 		CobolDataStorage fromptr = from.record.getDataStorage();
 		int tosize = to.record.getSize();
 		int fromsize = from.record.getSize();
-		if(tosize > fromsize) {
-			for(int i=0; i<fromsize; ++i) {
+		if (tosize > fromsize) {
+			for (int i = 0; i < fromsize; ++i) {
 				toptr.setByte(i, fromptr.getByte(i));
 			}
-			for(int i=0; i<tosize - fromsize; ++i) {
-				toptr.setByte(fromsize + i, (byte)' ');
+			for (int i = 0; i < tosize - fromsize; ++i) {
+				toptr.setByte(fromsize + i, (byte) ' ');
 			}
 		} else {
-			for(int i=0; i<tosize; ++i) {
-					toptr.setByte(i, fromptr.getByte(i));
+			for (int i = 0; i < tosize; ++i) {
+				toptr.setByte(i, fromptr.getByte(i));
 			}
 		}
 	}
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_processの実装
+	 * 
 	 * @param hp
 	 * @return
 	 */
 	private static int sortProcess(CobolSort hp) {
 		hp.setRetrieving(1);
 		int n = sortQueues(hp);
-		if(hp.getFilesUsed() == 0) {
+		if (hp.getFilesUsed() == 0) {
 			hp.setRetrievalQueue(n);
 			return 0;
 		}
-		if(writeBlock(hp, n) != 0) {
+		if (writeBlock(hp, n) != 0) {
 			return COBSORTFILEERR;
 		}
-		for(int i=0; i<4; i++) {
+		for (int i = 0; i < 4; i++) {
 			hp.getQueue()[i].setFirst(hp.getEmpty());
 			hp.setEmpty(hp.getEmpty().getNext());
 			hp.getQueue()[i].getFirst().setNext(null);
 		}
 		hp.getFile()[0].getFp().rewind();
 		hp.getFile()[1].getFp().rewind();
-		if(getTempFile(hp, 2)) {
+		if (getTempFile(hp, 2)) {
 			return COBSORTFILEERR;
 		}
-		if(getTempFile(hp, 3)) {
+		if (getTempFile(hp, 3)) {
 			return COBSORTFILEERR;
 		}
 		int source = 0;
-		while(hp.getFile()[source].getCount() > 1) {
+		while (hp.getFile()[source].getCount() > 1) {
 			int destination = source ^ 2;
 			hp.getFile()[destination].setCount(0);
 			hp.getFile()[destination + 1].setCount(0);
-			while(hp.getFile()[source].getCount() > 0) {
-				if(readItem(hp,  source) != 0) {
+			while (hp.getFile()[source].getCount() > 0) {
+				if (readItem(hp, source) != 0) {
 					return COBSORTFILEERR;
 				}
-				if(hp.getFile()[source + 1].getCount() > 0) {
-					if(readItem(hp, source + 1) != 0) {
+				if (hp.getFile()[source + 1].getCount() > 0) {
+					if (readItem(hp, source + 1) != 0) {
 						return COBSORTFILEERR;
 					}
 				} else {
 					hp.getQueue()[source + 1].getFirst().setEndOfBlock(1);
 				}
-				while(hp.getQueue()[source].getFirst().getEndOfBlock() == 0 ||
-					hp.getQueue()[source + 1].getFirst().getEndOfBlock() == 0) {
+				while (hp.getQueue()[source].getFirst().getEndOfBlock() == 0
+						|| hp.getQueue()[source + 1].getFirst().getEndOfBlock() == 0) {
 					int move;
-					if(hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
+					if (hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
 						move = 1;
-					} else if(hp.getQueue()[source + 1].getFirst().getEndOfBlock() != 0) {
+					} else if (hp.getQueue()[source + 1].getFirst().getEndOfBlock() != 0) {
 						move = 0;
 					} else {
-						int res = sortCompare(hp.getQueue()[source].getFirst(),
-								hp.getQueue()[source + 1].getFirst(),
+						int res = sortCompare(hp.getQueue()[source].getFirst(), hp.getQueue()[source + 1].getFirst(),
 								hp.getPointer());
 						move = res < 0 ? 0 : 1;
 					}
-					if(writeItem(hp.getFile()[destination].getFp(), hp.getQueue()[source + move].getFirst(), hp)) {
+					if (writeItem(hp.getFile()[destination].getFp(), hp.getQueue()[source + move].getFirst(), hp)) {
 						return COBSORTFILEERR;
 					}
-					if(readItem(hp, source + move) != 0) {
+					if (readItem(hp, source + move) != 0) {
 						return COBSORTFILEERR;
 					}
 				}
 				hp.getFile()[destination].setCount(hp.getFile()[destination].getCount() + 1);
-				if(hp.getFile()[destination].getFp().putc((byte)1) != 1) {
+				if (hp.getFile()[destination].getFp().putc((byte) 1) != 1) {
 					return COBSORTFILEERR;
 				}
-				hp.getFile()[source].setCount(hp.getFile()[source].getCount()  - 1);
-				hp.getFile()[source + 1].setCount(hp.getFile()[source + 1].getCount()  - 1);
+				hp.getFile()[source].setCount(hp.getFile()[source].getCount() - 1);
+				hp.getFile()[source + 1].setCount(hp.getFile()[source + 1].getCount() - 1);
 				destination ^= 1;
 			}
-			source  = destination & 2;
-			for(int i=0; i<4; ++i) {
+			source = destination & 2;
+			for (int i = 0; i < 4; ++i) {
 				hp.getFile()[i].getFp().rewind();
 			}
 		}
 		hp.setRetrievalQueue(source);
-		if(readItem(hp, source) != 0) {
+		if (readItem(hp, source) != 0) {
 			return COBSORTFILEERR;
 		}
-		if(readItem(hp, source + 1) != 0) {
+		if (readItem(hp, source + 1) != 0) {
 			return COBSORTFILEERR;
 		}
 		return 0;
@@ -464,121 +468,139 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_submitの実装
+	 * 
 	 * @param p
 	 * @return
 	 */
 	private static int sortSubmit(CobolFile f, CobolDataStorage p) {
 
-		if(SORT_STD_LIB) {
+		if (SORT_STD_LIB) {
 			dataList.add(new CobolDataStorage(p.getData()));
 			return 0;
 		} else {
-		CobolSort hp = f.filex;
-		if(hp == null) {
-			return COBSORTNOTOPEN;
-		}
-		if(hp.getRetrieving() != 0) {
-			return COBSORTABORT;
-		}
-		if(hp.getQueue()[0].getCount() + hp.getQueue()[1].getCount() >= hp.getMemory()) {
-			if(hp.getFilesUsed() == 0) {
-				if(getTempFile(hp, 0)) {
+			CobolSort hp = f.filex;
+			if (hp == null) {
+				return COBSORTNOTOPEN;
+			}
+			if (hp.getRetrieving() != 0) {
+				return COBSORTABORT;
+			}
+			if (hp.getQueue()[0].getCount() + hp.getQueue()[1].getCount() >= hp.getMemory()) {
+				if (hp.getFilesUsed() == 0) {
+					if (getTempFile(hp, 0)) {
+						return COBSORTFILEERR;
+					}
+					if (getTempFile(hp, 1)) {
+						return COBSORTFILEERR;
+					}
+					hp.setFilesUsed(1);
+					hp.setDestinationFile(0);
+				}
+				int n = sortQueues(hp);
+				if (writeBlock(hp, n) != 0) {
 					return COBSORTFILEERR;
 				}
-				if(getTempFile(hp, 1)) {
-					return COBSORTFILEERR;
-				}
-				hp.setFilesUsed(1);
-				hp.setDestinationFile(0);
+				hp.setDestinationFile(hp.getDestinationFile() ^ 1);
 			}
-			int n = sortQueues(hp);
-			if(writeBlock(hp, n) != 0) {
-				return COBSORTFILEERR;
+
+			CobolItem q = newItem(hp);
+			if (f.record_size != null) {
+				q.setRecordSize(f.record_size.getInt());
+			} else {
+				q.setRecordSize(hp.getSize());
 			}
-			hp.setDestinationFile(hp.getDestinationFile() ^ 1);
-		}
+			q.setEndOfBlock(1);
 
-		CobolItem q = newItem(hp);
-		if(f.record_size != null) {
-			q.setRecordSize(f.record_size.getInt());
-		} else {
-			q.setRecordSize(hp.getSize());
-		}
-		q.setEndOfBlock(1);
+			{
+				byte[] bytes = new byte[8];
+				ByteBuffer buf = ByteBuffer.wrap(bytes);
+				buf.putInt(hp.getUnique());
+				uniqueCopy(q.getUnique(), new CobolDataStorage(bytes), 8);
+			}
 
-		{
-			byte[] bytes = new byte[8];
-			ByteBuffer buf = ByteBuffer.wrap(bytes);
-			buf.putInt(hp.getUnique());
-			uniqueCopy(q.getUnique(), new CobolDataStorage(bytes), 8);
-		}
+			hp.setUnique(hp.getUnique() + 1);
 
-		hp.setUnique(hp.getUnique() + 1);
+			byte[] arr = p.getByteArray(0, hp.getSize());
+			q.setItem(new CobolDataStorage(arr));
 
-		byte[] arr = p.getByteArray(0, hp.getSize());
-		q.setItem(new CobolDataStorage(arr));
-
-		MemoryStruct z;
-		if(hp.getQueue()[0].getCount() <= hp.getQueue()[1].getCount()) {
-			z = hp.getQueue()[0];
-		} else {
-			z = hp.getQueue()[1];
-		}
-		q.setNext(z.getFirst());
-		z.setFirst(q);
-		z.setCount(z.getCount() + 1);
-		return 0;
+			MemoryStruct z;
+			if (hp.getQueue()[0].getCount() <= hp.getQueue()[1].getCount()) {
+				z = hp.getQueue()[0];
+			} else {
+				z = hp.getQueue()[1];
+			}
+			q.setNext(z.getFirst());
+			z.setFirst(q);
+			z.setCount(z.getCount() + 1);
+			return 0;
 		}
 	}
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_retrieveの実装
+	 * 
 	 * @param p
 	 * @return
 	 */
 	private static int sortRetrieve(CobolFile f, CobolDataStorage p) {
 		CobolSort hp = f.filex;
-		if(hp == null) {
+		if (hp == null) {
 			return COBSORTNOTOPEN;
 		}
 
-		if(hp.getRetrieving() == 0) {
+		if (SORT_STD_LIB) {
+			if(hp.getRetrieving() == 0) {
+				memorySort(f);
+				hp.setRetrieving(1);
+			}
+			if (dataList.isEmpty()) {
+				return COBSORTEND;
+			}
+			CobolDataStorage storage = dataList.remove(0);
+			p.setBytes(storage, hp.getSize());
+			if (f.record_size != null) {
+				f.record_size.setInt(hp.getSize());
+			}
+			return 0;
+		}
+
+		if (hp.getRetrieving() == 0) {
 			int res = sortProcess(hp);
-			if(res != 0) {
+			if (res != 0) {
 				return res;
 			}
 		}
-		if(hp.getFilesUsed() != 0) {
+
+		if (hp.getFilesUsed() != 0) {
 			int source = hp.getRetrievalQueue();
 			int move;
-			if(hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
-				if(hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
+			if (hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
+				if (hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
 					return COBSORTEND;
 				}
 				move = 1;
-			} else if(hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
+			} else if (hp.getQueue()[source].getFirst().getEndOfBlock() != 0) {
 				move = 0;
 			} else {
-				int res = sortCompare(hp.getQueue()[source].getFirst(),
-						hp.getQueue()[source + 1].getFirst(),
+				int res = sortCompare(hp.getQueue()[source].getFirst(), hp.getQueue()[source + 1].getFirst(),
 						hp.getPointer());
 				move = res < 0 ? 0 : 1;
 			}
-			for(int i=0; i<hp.getSize(); ++i) {
+			for (int i = 0; i < hp.getSize(); ++i) {
 				p.setByte(i, hp.getQueue()[source + move].getFirst().getItem().getByte(i));
 			}
-			if(readItem(hp, source + move) != 0) {
+			if (readItem(hp, source + move) != 0) {
 				return COBSORTFILEERR;
 			}
 		} else {
 			MemoryStruct z = hp.getQueue()[hp.getRetrievalQueue()];
-			if(z.getFirst() == null) {
+			if (z.getFirst() == null) {
 				return COBSORTEND;
 			}
-			for(int i=0; i<hp.getSize(); ++i) {
+			for (int i = 0; i < hp.getSize(); ++i) {
 				p.setByte(i, z.getFirst().getItem().getByte(i));
 			}
-			if(f.record_size != null) {
+			if (f.record_size != null) {
 				f.record_size.setInt(z.getFirst().getRecordSize());
 			}
 			CobolItem next = z.getFirst().getNext();
@@ -596,7 +618,7 @@ public class CobolFileSort {
 				long u2;
 				int cmp;
 
-				for(int i=0; i<f.nkeys; i++) {
+				for (int i = 0; i < f.nkeys; i++) {
 					AbstractCobolField src = f.keys[i].getField();
 
 					CobolDataStorage d1 = data1.copy();
@@ -608,12 +630,12 @@ public class CobolFileSort {
 					AbstractCobolField f1 = CobolFieldFactory.makeCobolField(src.getSize(), d1, src.getAttribute());
 					AbstractCobolField f2 = CobolFieldFactory.makeCobolField(src.getSize(), d2, src.getAttribute());
 
-					if(f1.getAttribute().isTypeNumeric()) {
+					if (f1.getAttribute().isTypeNumeric()) {
 						cmp = f1.numericCompareTo(f2);
 					} else {
 						cmp = sortCmps(f1.getDataStorage(), f2.getDataStorage(), f1.getSize(), f.sort_collating);
 					}
-					if(cmp != 0) {
+					if (cmp != 0) {
 						return (f.keys[i].getFlag() == COB_ASCENDING) ? cmp : -cmp;
 					}
 				}
@@ -624,12 +646,14 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_initの実装
+	 * 
 	 * @param nkeys
 	 * @param collating_sequence
 	 * @param sort_return
 	 * @param fnstatus
 	 */
-	public static void sortInit(CobolFile f, int nkeys, CobolDataStorage collating_sequence, CobolDataStorage sort_return, AbstractCobolField fnstatus) {
+	public static void sortInit(CobolFile f, int nkeys, CobolDataStorage collating_sequence,
+			CobolDataStorage sort_return, AbstractCobolField fnstatus) {
 		int sizeOfSizeT = 8;
 		CobolSort p = new CobolSort();
 		p.setFnstatus(fnstatus);
@@ -639,16 +663,16 @@ public class CobolFileSort {
 		p.setPointer(f);
 		p.setSortReturn(sort_return);
 		sort_return.set(0);
-		//opensource COBOLでsizeof(struct cobitem) == 32だっため,32を使用した
+		// opensource COBOLでsizeof(struct cobitem) == 32だっため,32を使用した
 		p.setMemory(cob_sort_memory / (p.getSize() + 32));
 		dataList = new ArrayList<CobolDataStorage>();
 		f.filex = p;
 		f.keys = new CobolFileKey[nkeys];
-		for(int i=0; i<nkeys; ++i) {
+		for (int i = 0; i < nkeys; ++i) {
 			f.keys[i] = new CobolFileKey();
 		}
 		f.nkeys = 0;
-		if(collating_sequence != null) {
+		if (collating_sequence != null) {
 			f.sort_collating = collating_sequence;
 		} else {
 			f.sort_collating = CobolModule.getCurrentModule().collating_sequence;
@@ -659,17 +683,20 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_initの実装
+	 * 
 	 * @param nkeys
 	 * @param collating_sequence
 	 * @param sort_return
 	 * @param fnstatus
 	 */
-	public static void sortInit(CobolFile f, int nkeys, int collating_sequence, CobolDataStorage sort_return, AbstractCobolField fnstatus) {
+	public static void sortInit(CobolFile f, int nkeys, int collating_sequence, CobolDataStorage sort_return,
+			AbstractCobolField fnstatus) {
 		sortInit(f, nkeys, null, sort_return, fnstatus);
 	}
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_init_keyの実装
+	 * 
 	 * @param flag
 	 * @param field
 	 * @param offset
@@ -683,18 +710,19 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_usingの実装
+	 * 
 	 * @param data_file
 	 */
 	public static void sortUsing(CobolFile sort_file, CobolFile data_file) {
 		data_file.open(CobolFile.COB_OPEN_INPUT, 0, null);
-		for(;;) {
+		for (;;) {
 			data_file.read(null, null, CobolFile.COB_READ_NEXT);
-			if(data_file.file_status[0] != (byte)'0') {
+			if (data_file.file_status[0] != (byte) '0') {
 				break;
 			}
 			copyCheck(sort_file, data_file);
 			int ret = sortSubmit(sort_file, sort_file.record.getDataStorage());
-			if(ret != 0) {
+			if (ret != 0) {
 				break;
 			}
 		}
@@ -703,21 +731,22 @@ public class CobolFileSort {
 
 	/**
 	 * libcob/fileio.cのcob_file_sort_givingの実装
+	 * 
 	 * @param varcnt
 	 * @param fbase
 	 */
 	public static void sortGiving(CobolFile sort_file, int varcnt, CobolFile... fbase) {
-		if(SORT_STD_LIB) {
-			for(int i=0; i<varcnt; i++) {
+		if (SORT_STD_LIB) {
+			for (int i = 0; i < varcnt; i++) {
 				fbase[i].open(CobolFile.COB_OPEN_OUTPUT, 0, null);
 			}
 
 			int cnt_rec = 0;
 			memorySort(sort_file);
-			for(CobolDataStorage d : dataList) {
-				for(int i=0; i<varcnt; i++) {
+			for (CobolDataStorage d : dataList) {
+				for (int i = 0; i < varcnt; i++) {
 					int opt;
-					if(fbase[i].special != 0 || fbase[i].organization == CobolFile.COB_ORG_LINE_SEQUENTIAL) {
+					if (fbase[i].special != 0 || fbase[i].organization == CobolFile.COB_ORG_LINE_SEQUENTIAL) {
 						opt = CobolFile.COB_WRITE_BEFORE | CobolFile.COB_WRITE_LINES | 1;
 					} else {
 						opt = 0;
@@ -731,48 +760,47 @@ public class CobolFileSort {
 			sort_file.file_status[0] = '1';
 			sort_file.file_status[1] = '0';
 
-			for(int i=0; i<varcnt; i++) {
+			for (int i = 0; i < varcnt; i++) {
 				fbase[i].close(CobolFile.COB_CLOSE_NORMAL, null);
 			}
 			CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD %d.", cnt_rec));
 
 		} else {
 
-
-		for(int i=0; i<varcnt; i++) {
-			fbase[i].open(CobolFile.COB_OPEN_OUTPUT, 0, null);
-		}
-		int cnt_rec = 0;
-		for(;;) {
-			int ret = sortRetrieve(sort_file, sort_file.record.getDataStorage());
-			if(ret != 0) {
-				if(ret == COBSORTEND) {
-					sort_file.file_status[0] = '1';
-				 	sort_file.file_status[1] = '0';
-				} else {
-					CobolSort hp = sort_file.filex;
-					hp.getSortReturn().set(16);
-					sort_file.file_status[0] = '3';
-				 	sort_file.file_status[1] = '0';
-				}
-				break;
+			for (int i = 0; i < varcnt; i++) {
+				fbase[i].open(CobolFile.COB_OPEN_OUTPUT, 0, null);
 			}
-			for(int i=0; i<varcnt; i++) {
-				int opt;
-				if(fbase[i].special != 0 || fbase[i].organization == CobolFile.COB_ORG_LINE_SEQUENTIAL) {
-					opt = CobolFile.COB_WRITE_BEFORE | CobolFile.COB_WRITE_LINES | 1;
-				} else {
-					opt = 0;
+			int cnt_rec = 0;
+			for (;;) {
+				int ret = sortRetrieve(sort_file, sort_file.record.getDataStorage());
+				if (ret != 0) {
+					if (ret == COBSORTEND) {
+						sort_file.file_status[0] = '1';
+						sort_file.file_status[1] = '0';
+					} else {
+						CobolSort hp = sort_file.filex;
+						hp.getSortReturn().set(16);
+						sort_file.file_status[0] = '3';
+						sort_file.file_status[1] = '0';
+					}
+					break;
 				}
-				copyCheck(fbase[i], sort_file);
-				fbase[i].write(fbase[i].record, opt, null);
+				for (int i = 0; i < varcnt; i++) {
+					int opt;
+					if (fbase[i].special != 0 || fbase[i].organization == CobolFile.COB_ORG_LINE_SEQUENTIAL) {
+						opt = CobolFile.COB_WRITE_BEFORE | CobolFile.COB_WRITE_LINES | 1;
+					} else {
+						opt = 0;
+					}
+					copyCheck(fbase[i], sort_file);
+					fbase[i].write(fbase[i].record, opt, null);
+				}
+				cnt_rec++;
 			}
-			cnt_rec++;
-		}
-		for(int i=0; i<varcnt; i++) {
-			fbase[i].close(CobolFile.COB_CLOSE_NORMAL, null);
-		}
-		CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD %d.", cnt_rec));
+			for (int i = 0; i < varcnt; i++) {
+				fbase[i].close(CobolFile.COB_CLOSE_NORMAL, null);
+			}
+			CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD %d.", cnt_rec));
 		}
 	}
 
@@ -783,12 +811,12 @@ public class CobolFileSort {
 		AbstractCobolField fnstatus = null;
 		CobolSort hp = f.filex;
 
-		if(hp != null) {
+		if (hp != null) {
 			fnstatus = hp.getFnstatus();
 			cob_free_list(hp.getEmpty());
-			for(int i=0; i<4; ++i) {
+			for (int i = 0; i < 4; ++i) {
 				cob_free_list(hp.getQueue()[i].getFirst());
-				if(hp.getFile()[i].getFp() != null) {
+				if (hp.getFile()[i].getFp() != null) {
 					hp.getFile()[i].getFp().close();
 				}
 			}
@@ -796,5 +824,57 @@ public class CobolFileSort {
 		f.filex = null;
 		f.saveStatus(CobolFile.COB_STATUS_00_SUCCESS, fnstatus);
 		return;
+	}
+
+	/**
+	 * libcob/fileio.cのcob_file_releaseの実装
+	 */
+	public static void performRelease(CobolFile f) {
+		AbstractCobolField fnstatus = null;
+		CobolSort hp = f.filex;
+
+		if (hp != null) {
+			fnstatus = hp.getFnstatus();
+		}
+
+		int ret = CobolFileSort.sortSubmit(f, f.record.getDataStorage());
+		switch (ret) {
+		case 0:
+			f.saveStatus(CobolFile.COB_STATUS_00_SUCCESS, fnstatus);
+			return;
+		default:
+			if (hp != null) {
+				hp.getSortReturn().set(16);
+			}
+			f.saveStatus(CobolFile.COB_STATUS_30_PERMANENT_ERROR, fnstatus);
+			return;
+		}
+	}
+
+	/**
+	 * libcob/fileio.cのcob_file_returnの実装
+	 */
+	public static void performReturn(CobolFile f) {
+		AbstractCobolField fnstatus = null;
+		CobolSort hp = f.filex;
+		if (hp != null) {
+			fnstatus = hp.getFnstatus();
+		}
+
+		int ret = CobolFileSort.sortRetrieve(f, f.record.getDataStorage());
+		switch (ret) {
+		case 0:
+			f.saveStatus(CobolFile.COB_STATUS_00_SUCCESS, fnstatus);
+			return;
+		case CobolFileSort.COBSORTEND:
+			f.saveStatus(CobolFile.COB_STATUS_10_END_OF_FILE, fnstatus);
+			return;
+		default:
+			if (hp != null) {
+				hp.getSortReturn().set(16);
+			}
+			f.saveStatus(CobolFile.COB_STATUS_30_PERMANENT_ERROR, fnstatus);
+			return;
+		}
 	}
 }


### PR DESCRIPTION
未開発であったSORT文のINPUT PROCEDURE / OUTPUT PROCEDUREオプション及びRETURN文,RELEASE文を実装した。
これによりソート前後の処理を記述できるようになった。