### PR TITLE
ファイル名で環境変数を参照する機能の不具合を修正した.

### DIFF
--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -630,7 +630,7 @@ public class CobolFile {
 				}
 				if(c == '$') {
 					int i;
-					for(i = 1; ; i++) {
+					for(i = 1; src_i + i < src.length; i++) {
 						char d = (char)src[src_i + i];
 						if(!Character.isLetterOrDigit(d) && d != '_' && c != '-') {
 							break;
@@ -678,7 +678,7 @@ public class CobolFile {
 
 			file_open_name = new String(file_open_name_bytes);
 		}
-
+		
 		boolean was_not_exist = false;
 		if(this.organization == COB_ORG_INDEXED) {
 			//TODO INDEXファイル実装時に
@@ -768,7 +768,9 @@ public class CobolFile {
 				break;
 			}
 		} catch(IOException e) {
-			this.file.setChannel(fp, null);
+			if(fp != null) {
+				this.file.setChannel(fp, null);
+			}
 			if(Files.notExists(Paths.get(filename))) {
 				return ENOENT;
 			} else {


### PR DESCRIPTION
SELECT F ASSIGN TO "$FILENAME" や
SELECT F ASSIGN TO EXTERNAL FILENAME
等で外部の環境変数(上記の例ではFILENAME)を参照する際の不具合を修正した。