### PR TITLE
Replace Berkeley DB Java Edition with SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,3 @@ Not Implemented.
 Known bugs
 
 * Cannot call inline programs.
-* Read wrong data from indexed files with alternate duplicate keys in some cases.

--- a/README_JP.md
+++ b/README_JP.md
@@ -24,7 +24,7 @@ java [PROGRAM-ID]
 
 ## The progress of the development
 
-下記の実装済みリストにある機能は[NIST COBOL85 test suite](https://www.itl.nist.gov/div897/ctg/cobol_form.htm)でテストされており,**969** のテストケースをパスしています.
+下記の実装済みリストにある機能は[NIST COBOL85 test suite](https://www.itl.nist.gov/div897/ctg/cobol_form.htm)でテストされており,**999%** のテストケースをパスしています.
 
 実装済み
 
@@ -44,4 +44,3 @@ java [PROGRAM-ID]
 既知の不具合
 
 * 同一ソースコード内の別プログラムのCALLができない.
-* DUPLICATE指定されたALTERNATE KEY付きのINDEXEDファイルに対するREAD文の不具合.

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -668,7 +668,7 @@ public class CobolFile {
 		
 		boolean was_not_exist = false;
 		if(this.organization == COB_ORG_INDEXED) {
-			if(!Files.isDirectory(Paths.get(file_open_name))) {
+			if(!Files.exists(Paths.get(file_open_name))) {
 				was_not_exist = true;
 				if(mode != COB_OPEN_OUTPUT && !this.flag_optional &&
 					(mode != COB_OPEN_I_O || System.getenv(COB_IO_CREATES).equals("yes")) &&

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -1,30 +1,32 @@
+/**
+ * INDEXED File implementation.
+ * The backend storage library is SQLite.
+ */
+
 package jp.osscons.opensourcecobol.libcobj.file;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.sqlite.SQLiteErrorCode;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Properties;
 
-import com.sleepycat.bind.ByteArrayBinding;
-import com.sleepycat.je.Cursor;
-import com.sleepycat.je.CursorConfig;
-import com.sleepycat.je.Database;
-import com.sleepycat.je.DatabaseConfig;
-import com.sleepycat.je.DatabaseEntry;
-import com.sleepycat.je.DatabaseNotFoundException;
-import com.sleepycat.je.Environment;
-import com.sleepycat.je.EnvironmentConfig;
-import com.sleepycat.je.EnvironmentFailureException;
-import com.sleepycat.je.EnvironmentLockedException;
-import com.sleepycat.je.Get;
-import com.sleepycat.je.LockConflictException;
-import com.sleepycat.je.LockMode;
-import com.sleepycat.je.OperationFailureException;
-import com.sleepycat.je.OperationResult;
-import com.sleepycat.je.OperationStatus;
-import com.sleepycat.je.Put;
-import com.sleepycat.je.ReadOptions;
-import com.sleepycat.je.Transaction;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteErrorCode;
 
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
@@ -32,16 +34,17 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 public class CobolIndexedFile extends CobolFile {
 	private static int rlo_size = 0;
 	private static byte[] record_lock_object;
+	private Optional<IndexedCursor> cursor;
+	private boolean updateWhileReading = false;
+	private boolean indexedFirstRead = true;
+	private boolean callStart = false;
 
-	private final static int COB_EQ = 1;
-	private final static int COB_LT = 2;
-	private final static int COB_LE = 3;
-	private final static int COB_GT = 4;
-	private final static int COB_GE = 5;
-	private final static int COB_NE = 6;
-
-	private Environment env;// bdb_env
-	private Transaction txn;
+	public final static int COB_EQ = 1;
+	public final static int COB_LT = 2;
+	public final static int COB_LE = 3;
+	public final static int COB_GT = 4;
+	public final static int COB_GE = 5;
+	public final static int COB_NE = 6;
 
 	public CobolIndexedFile(String select_name, byte[] file_status, AbstractCobolField assign,
 			AbstractCobolField record, AbstractCobolField record_size, int record_min, int record_max, int nkeys,
@@ -56,66 +59,71 @@ public class CobolIndexedFile extends CobolFile {
 				flag_needs_top,
 				file_version);
 	}
-
-	/**
-	 * DBT_SETマクロの実装
-	 * @param key
-	 * @param field
-	 */
-	private DatabaseEntry DBT_SET(AbstractCobolField field) {
-		return new DatabaseEntry(field.getDataStorage().getByteArray(0, field.getSize()));
+	
+	private static String getIndexName(int index) {
+		return String.format("index%d", index);
 	}
-
-	/**
-	 * libcob/fileio.cのtest_record_lockの実装
-	 * @param key
-	 * @return
-	 */
-	private int test_record_lock(DatabaseEntry key) {
-		return 0;
+	
+	private static String getSubIndexName(int index) {
+		return String.format("subindex%d", index);
 	}
-
-	/**
-	 * libcob/fileio.cのlock_recordの実装
-	 * @param key
-	 * @return
-	 */
-	private int lock_record(DatabaseEntry key) {
-		return 0;
+	
+	public static String getTableName(int index) {
+		return String.format("table%d", index);
 	}
-
+	
+	public static String getCursorName(int index) {
+		return String.format("cursor%d", index);
+	}
+	
+	private static String getConstraintName(int index) {
+		return String.format("constraint%d", index);
+	}
+	
 	/**
-	 * libcob/fileio.cのindexed_openの実装
+	 * Equivalent to DBT_SET in libcob/fileio.c
+	 */
+	private byte[] DBT_SET(AbstractCobolField field) {
+		return field.getDataStorage().getByteArray(0, field.getSize());
+	}
+	
+	/**
+	 * Equivalent to indexed_open in libcob/fileio.c
 	 */
 	@Override
 	public int open_(String filename, int mode, int sharing) {
 		IndexedFile p = new IndexedFile();
 		
-		File dir = new File(filename);
-		if(!dir.exists()) {
-			if (mode == COB_OPEN_OUTPUT || mode == COB_OPEN_I_O || mode == COB_OPEN_EXTEND) {
-				dir.mkdir();
-			} else {
-				return ENOENT;
+		SQLiteConfig config = new SQLiteConfig();
+		config.setReadOnly(mode == COB_OPEN_INPUT);
+		
+		if(mode == COB_OPEN_OUTPUT) {
+			Path path = Paths.get(filename);
+			try {
+				Files.deleteIfExists(path);
+			} catch (IOException e) {
+				return COB_STATUS_30_PERMANENT_ERROR;
 			}
 		}
 
-		Properties prop = new Properties();
-		prop.setProperty("je.freeDisk", "104857600");
-		EnvironmentConfig envConf = new EnvironmentConfig(prop);
-		envConf.setTransactional(true);
+		boolean fileExists = new java.io.File(filename).exists();
 
-		if (mode == COB_OPEN_INPUT) {
-			envConf.setReadOnly(true);
-		} else {
-			envConf.setAllowCreate(true);
+		p.connection = null;
+		try {
+			p.connection = DriverManager.getConnection("jdbc:sqlite:"+ filename, config.toProperties());
+			p.connection.setAutoCommit(false);
+		} catch(SQLException e) {
+			int errorCode = e.getErrorCode();
+			if(errorCode == SQLiteErrorCode.SQLITE_BUSY.code) {
+				return COB_STATUS_61_FILE_SHARING;
+			} else {
+				return ENOENT;
+			}
+		} catch (Exception e) {
+			return COB_STATUS_30_PERMANENT_ERROR;
 		}
 
-		p.db = new Database[this.nkeys];
-		p.sub_db = new Database[this.nkeys - 1];
-		p.cursor = new Cursor[this.nkeys];
 		p.filenamelen = filename.length();
-		p.last_readkey = new CobolDataStorage[2 * this.nkeys];
 		p.last_dupno = new int[this.nkeys];
 		p.rewrite_sec_key = new int[this.nkeys];
 
@@ -126,131 +134,73 @@ public class CobolIndexedFile extends CobolFile {
 			}
 		}
 
-		try {
-			env = new Environment(new File(filename), envConf);
-		} catch (EnvironmentLockedException e) {
-			return COB_STATUS_61_FILE_SHARING;
-		} catch (Exception e) {
-			return COB_STATUS_30_PERMANENT_ERROR;
-		}
-
 		for (int i = 0; i < this.nkeys; ++i) {
-			if (i == 0) {
-				runtime_buffer = filename;
-			} else {
-				runtime_buffer = String.format("%s.%d", filename, i);
-			}
-			String subDbName = String.format("%s.sub.%d", filename, i);
+			String tableName = getTableName(i);
 
-			DatabaseConfig dbConf = new DatabaseConfig();
-			if (mode == COB_OPEN_INPUT) {
-				dbConf.setReadOnly(true);
-			} else {
-				dbConf.setAllowCreate(true);
-			}
-			dbConf.setSortedDuplicates(true);
-			dbConf.setTransactional(true);
-
-			if (mode == COB_OPEN_OUTPUT) {
+			if (mode == COB_OPEN_OUTPUT || (!fileExists && (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O))) {
 				try {
-					env.removeDatabase(null, runtime_buffer);
-					if(i > 0) {
-						env.removeDatabase(null, subDbName);
+					Statement statement = p.connection.createStatement();
+					if(i == 0) {
+						statement.execute(String.format("create table %s (key blob not null primary key, value blob not null)", tableName));
+					} else {
+						if(this.keys[i].getFlag() == 0) {
+							statement.execute(String.format(
+								"create table %s (key blob not null primary key, value blob not null,"
+								+ " constraint %s foreign key (value) references %s (key))"
+								, tableName, getConstraintName(i), getTableName(0)));
+						} else {
+							statement.execute(String.format(
+								"create table %s (key blob not null, value blob not null, dupNo integer not null,"
+								+ " constraint %s foreign key (value) references %s (key))"
+								, tableName, getConstraintName(i), getTableName(0)));
+						}
+						statement.execute(String.format("create index %s on %s(value)", getSubIndexName(i), tableName));
 					}
-				} catch (DatabaseNotFoundException e) {
+					statement.execute(String.format("create index %s on %s(key)", getIndexName(i), tableName));
+				} catch (SQLException e) {
+					return COB_STATUS_30_PERMANENT_ERROR;
 				}
 			}
-
-			try {
-				p.db[i] = env.openDatabase(null, runtime_buffer, dbConf);
-				if(i > 0) {
-					p.sub_db[i-1] = env.openDatabase(null, subDbName, dbConf);
-				}
-			} catch (OperationFailureException | EnvironmentFailureException | IllegalStateException
-					| IllegalArgumentException e) {
-				e.printStackTrace();
-				for (int j = 0; j<i; ++j) {
-					p.db[j].close();
-				}
-				return COB_STATUS_30_PERMANENT_ERROR;
-			}
-
-			p.last_readkey[i] = new CobolDataStorage(maxsize);
-			p.last_readkey[this.nkeys + i] = new CobolDataStorage(maxsize);
 		}
+
 		p.temp_key = new CobolDataStorage(maxsize + 4);
 		this.filei = p;
 		p.key_index = 0;
 		p.last_key = null;
-
-		p.key = new DatabaseEntry();
-		p.data = new DatabaseEntry();
 
 		p.filename = filename;
 		p.write_cursor_open = false;
 		p.record_locked = false;
 
 		p.key = DBT_SET(this.keys[0].getField());
-		p.cursor[0] = p.db[0].openCursor(null, null);
-		boolean seqError = false;
-		try {
-			p.cursor[0].getFirst(p.key, p.data, null);
-		} catch (OperationFailureException | EnvironmentFailureException | IllegalStateException
-				| IllegalArgumentException e) {
-			seqError = true;
-		}
-
-		p.cursor[0].close();
-		p.cursor[0] = null;
-
-		if (seqError) {
-			p.data = new DatabaseEntry(new byte[0]);
-		} else {
-			byte[] keyData = p.key.getData();
-			p.last_readkey[0].memcpy(keyData, keyData.length);
-		}
+		this.updateWhileReading = false;
+		this.indexedFirstRead = true;
+		this.callStart = false;
 
 		return 0;
 	}
 
 	/**
-	 * libcob/fileio.cのindexed_closeの実装
+	 * Equivalent to indexed_close in libcob/fileio.c
 	 */
 	@Override
 	public int close_(int opt) {
 		IndexedFile p = this.filei;
-
-		for (int i = 0; i < this.nkeys; ++i) {
-			if (p.cursor[i] != null) {
-				p.cursor[i].close();
-			}
-		}
-
-		for (int i = this.nkeys - 1; i >= 0; i--) {
-			if (p.db[i] != null) {
-				p.db[i].close();
-			}
-		}
 		
-		for(int i=0; i<this.nkeys - 1; ++i) {
-			if(p.sub_db[i] != null) {
-				p.sub_db[i].close();
-			}
-		}
+		this.closeCursor();
 
-		env.close();
+		try {
+			p.connection.close();
+		} catch (SQLException e){
+			return COB_STATUS_30_PERMANENT_ERROR;
+		}
 		return COB_STATUS_00_SUCCESS;
 	}
 
 	/**
-	 * libcob/fileio.cのindexed_start_internalの実装
-	 * @param cond
-	 * @param key
-	 * @param read_opts
-	 * @param test_lock
-	 * @return
+	 * Equivalent to indexed_start_internal in libcob/fileio.c
 	 */
-	public int indexed_start_internal(int cond, AbstractCobolField key, int read_opts, boolean test_lock) {
+	public int indexed_start_internal(int cond, AbstractCobolField key, int read_opts, boolean test_lock) {		
 		IndexedFile p = this.filei;
 		for (p.key_index = 0; p.key_index < this.nkeys; p.key_index++) {
 			int size = this.keys[p.key_index].getField().getSize();
@@ -261,520 +211,292 @@ public class CobolIndexedFile extends CobolFile {
 
 		p.key = DBT_SET(key);
 
-		CursorConfig cursorConfig = new CursorConfig();
-		ReadOptions readOptions = new ReadOptions();
-		if ((read_opts & (COB_READ_LOCK | COB_READ_WAIT_LOCK)) != 0) {
-			readOptions.setLockMode(LockMode.DEFAULT);
+		boolean isDuplicate = this.keys[p.key_index].getFlag() != 0;
+		boolean isPrimary = p.key_index == 0;
+
+		this.cursor = IndexedCursor.createCursor(p.connection, p.key, p.key_index, isDuplicate, cond);
+		if(this.cursor.isEmpty()) {
+			return COB_STATUS_30_PERMANENT_ERROR;
+		}
+
+		IndexedCursor cursor = this.cursor.get();
+		Optional<FetchResult> optionalResult = cursor.next();
+		if(optionalResult.isPresent()) {
+			FetchResult result = optionalResult.get();
+			p.key = result.key;
+			p.data = result.value;
+			this.indexedFirstRead = false;
+			return COB_STATUS_00_SUCCESS;
 		} else {
-			cursorConfig.setReadUncommitted(true);
-			readOptions.setLockMode(LockMode.READ_UNCOMMITTED);
-		}
-
-		if (p.key_index != 0) {
-			p.cursor[0] = p.db[0].openCursor(null, cursorConfig);
-		}
-		p.cursor[p.key_index] = p.db[p.key_index].openCursor(null, cursorConfig);
-		try {
-			OperationResult result = p.cursor[p.key_index].get(p.key, p.data, Get.SEARCH_GTE, readOptions);
-			int ret = result != null ? 0 : 1;
-
-			switch (cond) {
-			case COB_EQ:
-				if (ret == 0) {
-					ret = new CobolDataStorage(p.key.getData()).memcmp(key.getDataStorage(), key.getSize());
-				}
-				break;
-			case COB_LT:
-				if (ret != 0) {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.LAST, readOptions);
-				} else {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.PREV, readOptions);
-				}
-				ret = result != null ? 0 : 1;
-				break;
-			case COB_LE:
-				if (ret != 0) {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.LAST, readOptions);
-				} else if (new CobolDataStorage(p.key.getData()).memcmp(key.getDataStorage(), key.getSize()) != 0) {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.PREV, readOptions);
-				} else if (this.keys[p.key_index].getFlag() != 0) {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.NEXT_NO_DUP, readOptions);
-					if (result == null) {
-						result = p.cursor[p.key_index].get(p.key, p.data, Get.LAST, readOptions);
-					} else {
-						result = p.cursor[p.key_index].get(p.key, p.data, Get.PREV, readOptions);
-					}
-				}
-				ret = result != null ? 0 : 1;
-				break;
-			case COB_GT:
-				while (ret == 0
-						&& new CobolDataStorage(p.key.getData()).memcmp(key.getDataStorage(), key.getSize()) == 0) {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.NEXT, readOptions);
-					ret = result != null ? 0 : 1;
-				}
-				break;
-			case COB_GE:
-				break;
-			}
-
-			int dupno = 0;
-
-			if (ret == 0 && p.key_index > 0) {
-				p.temp_key.memcpy(p.key.getData(), this.keys[p.key_index].getField().getSize());
-				if (this.keys[p.key_index].getFlag() != 0) {
-					dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4).getInt();
-				}
-				p.key = new DatabaseEntry(p.data.getData());
-				p.key.setSize(this.keys[0].getField().getSize());
-				result = p.db[0].get(null, p.key, p.data, Get.SEARCH, readOptions);
-				ret = result != null ? 0 : 1;
-			}
-
-			//TODO 注意 ロック処理を削除した
-
-			if (ret == 0) {
-				if (p.key_index == 0) {
-					p.last_readkey[0].memcpy(p.key.getData(), this.keys[0].getField().getSize());
-				} else {
-					p.last_readkey[p.key_index].memcpy(p.temp_key, this.keys[p.key_index].getField().getSize());
-					p.last_readkey[p.key_index + this.nkeys].memcpy(p.key.getData(), this.keys[0].getField().getSize());
-					if (this.keys[p.key_index].getFlag() != 0) {
-						p.last_dupno[p.key_index] = dupno;
-					}
-				}
-			}
-
-			this.discardCursors(p);
-			return ret == 0 ? COB_STATUS_00_SUCCESS : COB_STATUS_23_KEY_NOT_EXISTS;
-		} catch (LockConflictException e) {
-			this.discardCursors(p);
-			return COB_STATUS_51_RECORD_LOCKED;
+			return COB_STATUS_23_KEY_NOT_EXISTS;
 		}
 	}
 
 	@Override
 	/**
-	 * libcob/fileio.cのindexed_startの実装
+	 * Equivalent to libcob/fileio.c in indexed_start
 	 */
 	public int start_(int cond, AbstractCobolField key) {
-		return indexed_start_internal(cond, key, 0, false);
+		int ret = indexed_start_internal(cond, key, 0, false);
+		if(ret == COB_STATUS_00_SUCCESS) {
+			this.callStart = true;
+		}
+		return ret;
 	}
 
 	@Override
 	/**
-	 * libcob/fileio.cのindexed_readの実装
+	 * Equivalent to indexed_read in libcob/fileio.c
 	 */
 	public int read_(AbstractCobolField key, int readOpts) {
 		IndexedFile p = this.filei;
 		boolean test_lock = false;
-
-		if (env != null) {
-			this.unlock_record();
-			test_lock = true;
-		}
-
+		this.callStart = false;
 		int ret = this.indexed_start_internal(COB_EQ, key, readOpts, test_lock);
 		if (ret != COB_STATUS_00_SUCCESS) {
 			return ret;
 		}
 
-		this.record.setSize(p.data.getSize());
-		this.record.getDataStorage().memcpy(p.data.getData(), p.data.getSize());
+		this.record.setSize(p.data.length);
+		this.record.getDataStorage().memcpy(p.data, p.data.length);
 
 		return COB_STATUS_00_SUCCESS;
 	}
 
 	/**
-	 * libcob/fileio.cのindexed_read_nextの実装
+	 * Equivalent to indexed_read_next in libcob/fileio.c
 	 */
 	@Override
 	public int readNext(int readOpts) {
 		IndexedFile p = this.filei;
-		int ret = 0;
-		OperationResult result;
-		int dupno = 0;
-		int file_changed = 0;
-		boolean read_nextprev = false;
-
-		if (env != null) {
-			this.unlock_record();
+		if(this.callStart) {
+			this.callStart = false;
+			this.indexedFirstRead = false;
+			this.record.setSize(p.data.length);
+			this.record.getDataStorage().memcpy(p.data, p.data.length);		
+			return COB_STATUS_00_SUCCESS;
 		}
-
-		Get nextprev = Get.NEXT;
-		if ((readOpts & COB_READ_PREVIOUS) != 0) {
-			if (this.flag_end_of_file) {
-				nextprev = Get.LAST;
-			} else {
-				nextprev = Get.PREV;
+		
+		boolean isDuplicate = this.keys[p.key_index].getFlag() != 0;
+		if(this.indexedFirstRead || this.flag_begin_of_file) {
+			this.cursor = IndexedCursor.createCursor(p.connection, p.key, p.key_index, isDuplicate, COB_GE);
+			if(this.cursor.isEmpty()) {
+				return COB_STATUS_30_PERMANENT_ERROR;
 			}
-		} else if (this.flag_begin_of_file) {
-			nextprev = Get.FIRST;
+			this.cursor.get().moveToFirst();
+		} else if(this.flag_end_of_file) {
+			this.cursor = IndexedCursor.createCursor(p.connection, p.key, p.key_index, isDuplicate, COB_LE);
+			if(this.cursor.isEmpty()) {
+				return COB_STATUS_30_PERMANENT_ERROR;
+			}
+			this.cursor.get().moveToLast();		
+		} else if(this.updateWhileReading) {
+			this.updateWhileReading = false;
+			if(this.cursor.isEmpty()) {
+				return COB_STATUS_30_PERMANENT_ERROR;
+			}
+			IndexedCursor oldCursor = this.cursor.get();
+			Optional<IndexedCursor> newCursor = oldCursor.reloadCursor();
+			if(newCursor.isEmpty()) {
+				this.cursor = Optional.of(oldCursor);
+			} else {
+				oldCursor.close();
+				this.cursor = newCursor;
+			}
+		}
+		
+		if(this.cursor.isEmpty()) {
+			return COB_STATUS_30_PERMANENT_ERROR;
 		}
 
-		CursorConfig cursorConfig = new CursorConfig();
-		ReadOptions readOptions = new ReadOptions();
-		LockMode lockMode;
-		if ((readOpts & (COB_READ_LOCK | COB_READ_WAIT_LOCK)) != 0) {
-			readOptions.setLockMode(LockMode.DEFAULT);
-			lockMode = LockMode.DEFAULT;
+		IndexedCursor cursor = this.cursor.get();
+
+		final CursorReadOption cursorOpt;
+		if((readOpts & COB_READ_PREVIOUS) != 0) {
+			cursorOpt = CursorReadOption.PREV;
+			cursor.setComparator(COB_LE);
 		} else {
-			cursorConfig.setReadUncommitted(true);
-			readOptions.setLockMode(LockMode.READ_UNCOMMITTED);
-			lockMode = LockMode.READ_UNCOMMITTED;
+			cursorOpt = CursorReadOption.NEXT;
+			cursor.setComparator(COB_GE);
 		}
 
-		if (p.key_index != 0) {
-			p.cursor[0] = p.db[0].openCursor(null, cursorConfig);
-		}
-		p.cursor[p.key_index] = p.db[p.key_index].openCursor(null, cursorConfig);
+		Optional<FetchResult> optionalResult = cursor.read(cursorOpt);
+		
 
-		if (this.flag_first_read != 0) {
-			if (p.data == null || p.data.getSize() == 0 || (this.flag_first_read == 2 && nextprev == Get.PREV)) {
-				this.discardCursors(p);
-				return COB_STATUS_10_END_OF_FILE;
-			}
+		this.indexedFirstRead = false;
 
-			p.key = new DatabaseEntry(
-					p.last_readkey[p.key_index].getByteArray(0, this.keys[p.key_index].getField().getSize()));
-			try {
-				result = p.cursor[p.key_index].get(p.key, p.data, Get.SEARCH, readOptions);
-				ret = result != null ? 0 : 1;
-			} catch(LockConflictException e) {
-				this.discardCursors(p);
-				return COB_STATUS_51_RECORD_LOCKED;
-			}
+		if(optionalResult.isEmpty()) {
+			return COB_STATUS_10_END_OF_FILE;
+		} else {
+			FetchResult result = optionalResult.get();
+			p.key = result.key;
+			p.data = result.value;
+			
+			this.record.setSize(p.data.length);
+			this.record.getDataStorage().memcpy(p.data, p.data.length);
 
-			if (ret == 0 && p.key_index > 0) {
-				if (this.keys[p.key_index].getFlag() != 0) {
-					dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4).getInt();
-					while (ret == 0 &&
-							p.last_readkey[p.key_index].memcmp(p.key.getData(), p.key.getSize()) == 0 &&
-							dupno < p.last_dupno[p.key_index]) {
-						try {
-							result = p.cursor[p.key_index].get(p.key, p.data, Get.NEXT, readOptions);
-							ret = result != null ? 0 : 1;
-						} catch(LockConflictException e) {
-							this.discardCursors(p);
-							return COB_STATUS_51_RECORD_LOCKED;
-						}
-						dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4).getInt();
-					}
-					if (ret == 0 &&
-							p.last_readkey[p.key_index].memcmp(p.key.getData(), p.key.getSize()) == 0 &&
-							dupno == p.last_dupno[p.key_index]) {
-						ret = p.last_readkey[p.key_index + this.nkeys].memcmp(p.data.getData(),
-								this.keys[0].getField().getSize());
-					} else {
-						ret = 1;
-					}
-				} else {
-					ret = p.last_readkey[p.key_index + this.nkeys].memcmp(p.data.getData(),
-							this.keys[0].getField().getSize());
-				}
-				if (ret == 0) {
-					p.key = new DatabaseEntry(p.last_readkey[p.key_index + this.nkeys].getByteArray(0,
-							this.keys[0].getField().getSize()));
-					try {
-						result = p.db[0].get(null, p.key, p.data, Get.SEARCH, readOptions);
-						ret = result != null ? 0 : 1;
-					} catch(LockConflictException e) {
-						this.discardCursors(p);
-						return COB_STATUS_51_RECORD_LOCKED;
-					}
-				}
-			}
-			file_changed = ret;
-		}
-		if (this.flag_first_read == 0 || file_changed != 0) {
-			if (nextprev == Get.FIRST || nextprev == Get.LAST) {
-				read_nextprev = true;
-			} else {
-				p.key = new DatabaseEntry(
-						p.last_readkey[p.key_index].getByteArray(0, this.keys[p.key_index].getField().getSize()));
-				try {
-					result = p.cursor[p.key_index].get(p.key, p.data, Get.SEARCH_GTE, readOptions);
-				} catch(LockConflictException e) {
-					this.discardCursors(p);
-					return COB_STATUS_51_RECORD_LOCKED;
-				}
-
-				ret = result != null ? 0 : 1;
-
-				if (ret != 0) {
-					if (nextprev == Get.PREV) {
-						nextprev = Get.LAST;
-						read_nextprev = true;
-					} else {
-						this.discardCursors(p);
-						return COB_STATUS_10_END_OF_FILE;
-					}
-				} else {
-					if (p.last_readkey[p.key_index].memcmp(p.key.getData(), p.key.getSize()) == 0) {
-						if (p.key_index > 0 && this.keys[p.key_index].getFlag() != 0) {
-							dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4)
-									.getInt();
-							while (ret == 0 &&
-									p.last_readkey[p.key_index].memcmp(p.key.getData(), p.key.getSize()) == 0 &&
-									dupno < p.last_dupno[p.key_index]) {
-
-								try {
-									result = p.cursor[p.key_index].get(p.key, p.data, Get.NEXT, readOptions);
-								} catch(LockConflictException e) {
-									this.discardCursors(p);
-									return COB_STATUS_51_RECORD_LOCKED;
-								}
-
-								ret = result != null ? 0 : 1;
-								dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4)
-										.getInt();
-							}
-							if (ret != 0) {
-								if (nextprev == Get.PREV) {
-									nextprev = Get.LAST;
-									read_nextprev = true;
-								} else {
-									this.discardCursors(p);
-									return COB_STATUS_10_END_OF_FILE;
-								}
-							} else {
-								if (p.last_readkey[p.key_index].memcmp(p.key.getData(), p.key.getSize()) == 0 &&
-										dupno == p.last_dupno[p.key_index]) {
-									read_nextprev = true;
-								} else {
-									read_nextprev = nextprev == Get.PREV;
-								}
-							}
-						} else {
-							read_nextprev = true;
-						}
-					} else {
-						read_nextprev = nextprev == Get.PREV;
-					}
-				}
-			}
-			if (read_nextprev) {
-				try {
-					result = p.cursor[p.key_index].get(p.key, p.data, nextprev, readOptions);
-				} catch(LockConflictException e) {
-					this.discardCursors(p);
-					return COB_STATUS_51_RECORD_LOCKED;
-				}
-
-				ret = result != null ? 0 : 1;
-				if (ret != 0) {
-					this.discardCursors(p);
-					return COB_STATUS_10_END_OF_FILE;
-				}
-			}
-
-			if (p.key_index > 0) {
-				p.temp_key.memcpy(p.key.getData(), p.key.getSize());
-				if (this.keys[p.key_index].getFlag() != 0) {
-					dupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4).getInt();
-				}
-				p.key = new DatabaseEntry(p.data.getData());
-				p.key.setSize(this.keys[0].getField().getSize());
-				try {
-					if (p.db[0].get(null, p.key, p.data, Get.SEARCH, readOptions) == null) {
-						p.cursor[p.key_index].close();
-						p.cursor[p.key_index] = null;
-						p.cursor[0].close();
-						p.cursor[0] = null;
-						return COB_STATUS_23_KEY_NOT_EXISTS;
-					}
-				} catch(LockConflictException e) {
-					p.cursor[p.key_index].close();
-					p.cursor[p.key_index] = null;
-					p.cursor[0].close();
-					p.cursor[0] = null;
-					return COB_STATUS_51_RECORD_LOCKED;
-				}
-			}
-			if (p.key_index == 0) {
-				p.last_readkey[0].memcpy(p.key.getData(), p.key.getSize());
-			} else {
-				p.last_readkey[p.key_index].memcpy(p.temp_key, this.keys[p.key_index].getField().getSize());
-				p.last_readkey[p.key_index + this.nkeys].memcpy(p.key.getData(),
-						this.keys[0].getField().getSize());
-				if (this.keys[p.key_index].getFlag() != 0) {
-					p.last_dupno[p.key_index] = dupno;
-				}
-			}
-		}
-
-		this.discardCursors(p);
-
-		this.record.setSize(p.data.getSize());
-		this.record.getDataStorage().memcpy(p.data.getData(), p.data.getSize());
-		return COB_STATUS_00_SUCCESS;
-	}
-
-
-	/**
-	 * libcob/fileio.cにはない関数
-	 * 複数回出現するカーソルを閉じる処理をまとめた
-	 */
-	private void discardCursors(IndexedFile p) {
-		p.cursor[p.key_index].close();
-		p.cursor[p.key_index] = null;
-		if (p.key_index != 0) {
-			p.cursor[0].close();
-			p.cursor[0] = null;
+			return COB_STATUS_00_SUCCESS;
 		}
 	}
+	
+	private void closeCursor() {
+		if(this.cursor != null) {
+			if(this.cursor.isPresent()) {
+				this.cursor.get().close();
+			}
+		}
+	}
+	
+	private boolean keyExistsInTable(IndexedFile p, int index, byte[] key) {	
+		try {
+			String query = String.format(
+				"select * from %s where key = ?",
+				getTableName(index));
 
+			PreparedStatement selectStatement = p.connection.prepareStatement(query);
+			selectStatement.setBytes(1, key);
+			selectStatement.setFetchSize(0);
+			ResultSet rs = selectStatement.executeQuery();
+			return rs.next();
+		} catch(SQLException e) {
+			return false;
+		}
+	}
+	
+	private boolean isDuplicateColumn(int index) {
+		return this.keys[index].getFlag() != 0;
+	}
+	
+	private int getNextKeyDupNo(Connection conn, int index, byte[] key) {
+		try {
+			PreparedStatement selectStatement = conn.prepareStatement(
+				String.format("select ifnull(max(dupNo), -1) from %s", getTableName(index)));
+			ResultSet rs = selectStatement.executeQuery();
+			return rs.getInt(1) + 1;
+		} catch(SQLException e) {
+			return 0;
+		}
+	}
+	
+	private int returnWith(IndexedFile p, boolean close_cursor, int index, int returnCode) {
+		if (close_cursor) {
+			this.closeCursor();
+			p.write_cursor_open = false;
+		}
+		return returnCode;
+	}
+	
 	/**
-	 * libcob/fileio.cのindexed_write_internalの実装
-	 * @param rewrite
-	 * @param opt
-	 * @return
+	 * Equivalent to indexed_write_internal in libcob/fileio.c
 	 */
 	private int indexed_write_internal(boolean rewrite, int opt) {
 		IndexedFile p = this.filei;
 
 		boolean close_cursor;
-		this.txn = env.beginTransaction(null, null);
-		p.cursor[0] = p.db[0].openCursor(this.txn, null);
 		p.write_cursor_open = true;
 		close_cursor = true;
 		
 		if (this.nkeys > 1 && !rewrite) {
 			if (this.check_alt_keys(false)) {
-				if (close_cursor) {
-					p.cursor[0].close();
-					p.cursor[0] = null;
-					p.write_cursor_open = false;
-				}
-				this.txn.abort();
-				return COB_STATUS_22_KEY_EXISTS;
+				return returnWith(p, close_cursor, 0, COB_STATUS_22_KEY_EXISTS);
 			}
 			p.key = DBT_SET(this.keys[0].getField());
 		}
 
-		if (p.cursor[0].get(p.key, p.data, Get.SEARCH, null) != null) {
-			if (close_cursor) {
-				p.cursor[0].close();
-				p.cursor[0] = null;
-				p.write_cursor_open = false;
-			}
-			this.txn.abort();
+		if(keyExistsInTable(p, 0, p.key)) {
 			return COB_STATUS_22_KEY_EXISTS;
 		}
 
-		p.data = new DatabaseEntry(this.record.getDataStorage().getByteArray(0, this.record.getSize()));
+		// insert into the primary table
+		p.data = DBT_SET(this.record);
 		try {
-			p.cursor[0].put(p.key, p.data);
-		} catch (LockConflictException e) {
-			if (close_cursor) {
-				p.cursor[0].close();
-				p.cursor[0] = null;
-				p.write_cursor_open = false;
-			}		
-			this.txn.abort();
-			return COB_STATUS_51_RECORD_LOCKED;
-		}		
+			PreparedStatement insertStatement = p.connection.prepareStatement(
+				String.format("insert into %s values (?, ?)", getTableName(0)));
+			insertStatement.setBytes(1, p.key);
+			insertStatement.setBytes(2, p.data);
+			insertStatement.execute();
+			p.connection.commit();
+		} catch (SQLException e) {
+			return returnWith(p, close_cursor, 0, COB_STATUS_51_RECORD_LOCKED);
+		}
 
 		p.data = p.key;
-		Put flags;
-		DatabaseEntry subKey = DBT_SET(this.keys[0].getField());
-		for (int i = 1; i < this.nkeys; i++) {
 
-			flags = Put.OVERWRITE;
-			if (this.keys[i].getFlag() != 0) {
-				int dupno = this.get_dupno(i);
-				p.temp_key.memcpy(this.keys[0].getField().getDataStorage(), this.keys[0].getField().getFieldSize());
-				p.temp_key.getSubDataStorage(this.keys[0].getField().getSize()).set(dupno);
-				p.data = new DatabaseEntry(p.temp_key.getByteArray(0, this.keys[0].getField().getSize() + 4));
-			}
+		//insert into sub tables
+		for (int i = 1; i < this.nkeys; i++) {
 
 			p.key = DBT_SET(this.keys[i].getField());
 			try {
-				DatabaseEntry subData = DBT_SET(this.keys[i].getField());
-				boolean writeFail = p.db[i].put(this.txn, p.key, p.data, flags, null) == null;
-				byte[] b = subKey.getData();
-				OperationResult result = p.sub_db[i-1].put(this.txn, subKey, subData, Put.OVERWRITE, null);
-				writeFail |= result == null;
-				if(writeFail) {
-					if (close_cursor) {
-						p.cursor[0].close();
-						p.cursor[0] = null;
-						p.write_cursor_open = false;
-					}
-					this.txn.abort();
-					return COB_STATUS_22_KEY_EXISTS;
+				if(!isDuplicateColumn(i) && keyExistsInTable(p, i, p.key)) {
+					return returnWith(p, close_cursor, 0, COB_STATUS_22_KEY_EXISTS);
 				}
-			} catch (LockConflictException e) {
-				if (close_cursor) {
-					p.cursor[0].close();
-					p.cursor[0] = null;
-					p.write_cursor_open = false;
-				}				
-				this.txn.abort();
-				return COB_STATUS_51_RECORD_LOCKED;
-			} catch (OperationFailureException e) {
-				if (close_cursor) {
-					p.cursor[0].close();
-					p.cursor[0] = null;
-					p.write_cursor_open = false;
+
+				PreparedStatement insertStatement;
+				if(isDuplicateColumn(i)) {
+					int dupNo = getNextKeyDupNo(p.connection, i, p.key);
+					insertStatement = p.connection.prepareStatement(
+							String.format("insert into %s values (?, ?, ?)", getTableName(i)));
+					insertStatement.setBytes(1, p.key);
+					insertStatement.setBytes(2, p.data);
+					insertStatement.setInt(3, dupNo);
+				} else {
+					insertStatement = p.connection.prepareStatement(
+							String.format("insert into %s values (?, ?)", getTableName(i)));
+					insertStatement.setBytes(1, p.key);
+					insertStatement.setBytes(2, p.data);
 				}
-				this.txn.abort();
-				return COB_STATUS_22_KEY_EXISTS;
+				insertStatement.execute();
+				p.connection.commit();
+			} catch (SQLException e) {
+				return returnWith(p, close_cursor, 0, COB_STATUS_51_RECORD_LOCKED);
 			}
 		}
 
-		if (close_cursor) {
-			p.cursor[0].close();
-			p.cursor[0] = null;
-			p.write_cursor_open = false;
-		}
-		this.txn.commit();
+		this.updateWhileReading = true;
 
-		return COB_STATUS_00_SUCCESS;
+		return returnWith(p, close_cursor, 0, COB_STATUS_00_SUCCESS);
 	}
 
 	/**
-	 * libcob/fileio.cのindexed_writeの実装
+	 * Equivalent to indexed_write in libcob/fileio.c
 	 */
 	@Override
 	public int write_(int opt) {
 		IndexedFile p = this.filei;
-
+		
 		p.key = DBT_SET(this.keys[0].getField());
 		if (p.last_key == null) {
-			p.last_key = new CobolDataStorage(p.key.getSize());
+			p.last_key = new CobolDataStorage(p.key.length);
 
 		} else if (this.access_mode == COB_ACCESS_SEQUENTIAL) {
-			byte[] keyBytes = p.key.getData();
+			byte[] keyBytes = p.key;
 			if (p.last_key.memcmp(keyBytes, keyBytes.length) > 0) {
 				return COB_STATUS_21_KEY_INVALID;
 			}
 		}
 
-		byte[] keyBytes = p.key.getData();
+		byte[] keyBytes = p.key;
 		p.last_key.memcpy(keyBytes, keyBytes.length);
-
+		
 		return indexed_write_internal(false, opt);
 	}
 
 	/**
-	 * libcob/fileio.cのcheck_alt_keysの実装
-	 * @param rewrite
-	 * @return
+	 * Equivalent to check_alt_keys in libcob/fileio.c
 	 */
 	private boolean check_alt_keys(boolean rewrite) {
 		IndexedFile p = this.filei;
+		
+		byte[] primaryKey = DBT_SET(this.keys[0].getField());
 		for (int i = 1; i < this.nkeys; ++i) {
 			if (this.keys[i].getFlag() == 0) {
 				p.key = DBT_SET(this.keys[i].getField());
-				if (p.db[i].get(null, p.key, p.data, Get.SEARCH, null) != null) {
-					if (rewrite) {
-						byte[] dataBytes = p.data.getData();
-						if (this.keys[0].getField().getDataStorage().memcmp(dataBytes,
-								this.keys[0].getField().getSize()) != 0) {
-							return true;
-						}
-					} else {
+				if(rewrite) {
+					if(checkTable(p, i, p.key, primaryKey)) {
+						return true;
+					}
+				} else {
+					if(keyExistsInTable(p, i, p.key)) {
 						return true;
 					}
 				}
@@ -782,65 +504,40 @@ public class CobolIndexedFile extends CobolFile {
 		}
 		return false;
 	}
+	
+	private static boolean checkTable(IndexedFile p, int index, byte[] key, byte[] primaryKey) {
+		try {
+			String query = String.format(
+				"select key from %s " +
+				"where key = ? and value = ?",
+				getTableName(index));
 
-	/**
-	 * TODO ロック処理実装
-	 * libcob/fileio.cのunlock_recordの実装
-	 * @return
-	 */
-	private int unlock_record() {
-		IndexedFile p = this.filei;
-		if (!p.record_locked) {
-			return 0;
+			PreparedStatement selectStatement = p.connection.prepareStatement(query);
+			selectStatement.setBytes(1, key);
+			selectStatement.setBytes(2, primaryKey);
+			selectStatement.setFetchSize(0);
+			ResultSet rs = selectStatement.executeQuery();
+			return rs.next();
+		} catch(SQLException e) {
+			return false;
 		}
-		p.record_lock = false;
-		return 0;
-	}
-
-	/**
-	 * libcob/fileio.cのget_dupnoの実装
-	 * @param i
-	 * @return
-	 */
-	private int get_dupno(int i) {
-		IndexedFile p = this.filei;
-		p.key = DBT_SET(this.keys[i].getField());
-		p.temp_key.memcpy(p.key.getData());
-		p.cursor[i] = p.db[i].openCursor(null, null);
-		OperationResult ret = p.cursor[i].get(p.key, p.data, Get.SEARCH, null);
-
-		int dupno = 0;
-		while (ret != null && p.temp_key.memcmp(p.key.getData(), p.key.getSize()) == 0) {
-			int tempdupno = ByteBuffer.wrap(p.data.getData(), this.keys[0].getField().getSize(), 4).getInt();
-			if(dupno < tempdupno) {
-				dupno = tempdupno;
-			}
-			ret = p.cursor[i].get(p.key, p.data, Get.NEXT_DUP, null);
-		}
-
-		p.cursor[i].close();
-		p.cursor[i] = null;
-
-		return ++dupno;
 	}	
 
 	@Override
 	/**
-	 * libcob/fileio.cのindexed_rewriteの実装
+	 * Equivalent to indexed_rewrite in libcob/fileio.c
 	 */
 	public int rewrite_(int opt) {
 		IndexedFile p = this.filei;
-
-		p.write_cursor_open = true;
-		if (env != null) {
-			this.unlock_record();
-		}
-
-		if (this.check_alt_keys(true)) {
-			p.write_cursor_open = false;
-			return COB_STATUS_22_KEY_EXISTS;
-		}
 		
+		p.write_cursor_open = true;
+		
+		if(this.access_mode == COB_ACCESS_SEQUENTIAL && !IndexedCursor.matchKeyHead(p.key, DBT_SET(this.keys[0].getField()))) {
+			return COB_STATUS_21_KEY_INVALID;
+		}
+
+		p.key = DBT_SET(this.keys[0].getField());
+
 		int ret = this.indexed_delete_internal(true);
 
 		if (ret != COB_STATUS_00_SUCCESS) {
@@ -848,115 +545,63 @@ public class CobolIndexedFile extends CobolFile {
 			return ret;
 		}
 
-		p.key = DBT_SET(this.keys[0].getField());
-		ret = this.indexed_write_internal(true, opt);
-
-		return ret;
+		return this.indexed_write_internal(true, opt);
 	}
 
 	/**
-	 * libcob/fileio.cのindexed_delete_internalの実装
-	 * @param rewrite
-	 * @return
+	 * Equivalent to indexed_delete_internal in libcob/fileio.c
 	 */
 	private int indexed_delete_internal(boolean rewrite) {
 		IndexedFile p = this.filei;
 		boolean close_cursor;
 
-		this.txn = this.env.beginTransaction(null, null);
-		p.cursor[0] = p.db[0].openCursor(this.txn, null);
 		p.write_cursor_open = true;
 		close_cursor = true;
-
-		if (env != null) {
-			this.unlock_record();
-		}
-
+		
 		if (this.access_mode != COB_ACCESS_SEQUENTIAL) {
 			p.key = DBT_SET(this.keys[0].getField());
 		}
-
-		OperationResult result = p.cursor[0].get(p.key, p.data, Get.SEARCH, null);
-		int ret = result != null ? 0 : 1;
-		if (ret != 0 && this.access_mode != COB_ACCESS_SEQUENTIAL) {
-			if (close_cursor) {
-				p.cursor[0].close();
-				p.cursor[0] = null;
-				p.write_cursor_open = false;
-			}
-			this.txn.abort();
-			return COB_STATUS_23_KEY_NOT_EXISTS;
+		
+		if(this.access_mode != COB_ACCESS_SEQUENTIAL && !keyExistsInTable(p, 0, p.key)) {
+			return returnWith(p, close_cursor, 0, COB_STATUS_23_KEY_NOT_EXISTS);
 		}
 
-		DatabaseEntry prim_key = p.key;
-
-		for (int i = 1; i < this.nkeys; ++i) {
-			p.key = DBT_SET(this.keys[i].getField());
-			try {				
-				DatabaseEntry subKey = DBT_SET(this.keys[0].getField());
-				DatabaseEntry subData = new DatabaseEntry();
-				Cursor subCursor = p.sub_db[i-1].openCursor(this.txn, null);
-				if(subCursor.get(subKey, subData, Get.SEARCH, null) != null) {
-					do {
-						p.cursor[i] = p.db[i].openCursor(this.txn, null);
-						byte[] alternateKey = subData.getData();
-						if(p.cursor[i].get(subData, p.data, Get.SEARCH, null) != null) {
-							do {
-								if(this.keys[0].getField().getDataStorage().memcmp(p.data.getData(), prim_key.getSize()) == 0) {
-									p.cursor[i].delete();
-								}
-							} while(p.cursor[i].get(subData, p.data, Get.NEXT, null) != null
-									&& Arrays.equals(subData.getData(), alternateKey));
-						}
-						p.cursor[i].close();
-						p.cursor[i] = null;
-						subCursor.delete();
-					} while(subCursor.get(subKey, subData, Get.NEXT, null) != null &&
-							this.keys[0].getField().getDataStorage().memcmp(subKey.getData(), this.keys[0].getField().getSize()) == 0);
-				}
-				subCursor.close();
-			} catch (LockConflictException e) {
-				if(p.cursor[i] != null) {
-					p.cursor[i].close();
-					p.cursor[i] = null;
-				}
-				this.txn.abort();
-				return COB_STATUS_51_RECORD_LOCKED;
-			}
-		}
-
+		// delete data from the primary table
 		try {
-			p.cursor[0].delete();
-		} catch(LockConflictException e) {
-			if(close_cursor) {
-				p.cursor[0].close();
-				p.cursor[0] = null;
-				p.write_cursor_open = false;
+			String query = String.format("delete from %s where key = ?", getTableName(0));
+			PreparedStatement statement = p.connection.prepareStatement(query);
+			statement.setBytes(1, p.key);
+			statement.execute();
+		} catch(SQLException e) {
+			return returnWith(p, close_cursor, 0, COB_STATUS_30_PERMANENT_ERROR);
+		}
+
+		// delete data from sub tables
+		for(int i=1; i<this.nkeys; ++i) {
+			try {
+				PreparedStatement statement = p.connection.prepareStatement(
+				String.format("delete from %s where value = ?", getTableName(i)));
+				statement.setBytes(1, p.key);
+				statement.execute();			
+			} catch(SQLException e) {
+				return returnWith(p, close_cursor, 0, COB_STATUS_30_PERMANENT_ERROR);
 			}
-			this.txn.abort();
-			return COB_STATUS_51_RECORD_LOCKED;
 		}
-		if(close_cursor) {
-			p.cursor[0].close();
-			p.cursor[0] = null;
-			p.write_cursor_open = false;
+		
+		try {
+			p.connection.commit();
+		} catch(SQLException e) {
+				return returnWith(p, close_cursor, 0, COB_STATUS_30_PERMANENT_ERROR);
 		}
-		this.txn.commit();
+		
+		this.updateWhileReading = true;
+
 		return COB_STATUS_00_SUCCESS;
-	}
-	
-	private static boolean arrayEquals(byte[] a, byte[] b, int size) {
-		for(int i=0; i<size; ++i) {
-			if(a[i] != b[i]) {
-				return false;
-			}
-		}
-		return true;
 	}
 
 	@Override
 	/**
-	 * libcob/fileio.cのindexed_deleteの実装
+	 * Equivalent to libcob/fileio.c in indexed_delete
 	 */
 	public int delete_() {
 		return this.indexed_delete_internal(false);
@@ -965,12 +610,5 @@ public class CobolIndexedFile extends CobolFile {
 	@Override
 	public void unlock_() {
 		IndexedFile p = this.filei;
-		if (this.open_mode != COB_OPEN_CLOSED && this.open_mode != COB_OPEN_LOCKED) {
-			return;
-		}
-
-		if (env != null) {
-			this.unlock_record();
-		}
 	}
 }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -1,0 +1,600 @@
+/**
+ * Emulate a cursor in SQLite tables
+ */
+package jp.osscons.opensourcecobol.libcobj.file;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import jp.osscons.opensourcecobol.libcobj.file.CobolIndexedFile;
+
+/**
+ * Represents a result of fetching a data from SQLite tables.
+ */
+class FetchResult {
+	public byte[] key;
+	public byte[] value;
+	public int dupNo;
+	
+	public FetchResult(byte[] key, byte[] value , int dupNo) {
+		this.key = key;
+		this.value = value;
+		this.dupNo = dupNo;
+	}
+	
+	public FetchResult(byte[] key, byte[] value) {
+		this.key = key;
+		this.value = value;
+		this.dupNo = 0;
+	}
+}
+
+enum CursorReadOption {
+	NEXT,
+	PREV,
+	FIRST,
+	LAST
+}
+
+/**
+ * Emulates a cursor in SQLite
+ */
+public class IndexedCursor {
+	/** a cursor to the top direction */
+	private Optional<ResultSet> backwardCursor;
+	/** a cursor to the bottom direction */
+	private Optional<ResultSet> forwardCursor;
+	/** a connection to the SQLite database */
+	private Connection conn;
+	/** firstFetch is true if and only if the cursor has not read any data yet */
+	private boolean firstFetch;
+	/** a position in buffers that stores the read data */
+	private int cursorIndex;
+	/** one of COB_EQ, COB_LT, COB_LE, COB_GT, COB_GE in CobolIndexedFile.java */
+	private int comparator;
+	/** isDuplicate is true if and only if the table key allows duplicates */
+	private boolean isDuplicate;
+	/** a key */
+	private byte[] key;
+	/** forwardBuffer stores data located to the bottom direction from the first read position */
+	ArrayList<FetchResult> forwardBuffer;
+	/** bakckwardBuffer stores data located to the first direction from the first read position */
+	ArrayList<FetchResult> backwardBuffer;
+	/** the index of the table*/
+	private int tableIndex;
+	private boolean nextCursorFetchKeyDiffrent;
+	private boolean prevCursorFetchKeyDiffrent;
+	
+	public void setComparator(int comparator) {
+		this.comparator = comparator;
+	}
+	
+	private IndexedCursor(Connection conn, byte[] key, int tableIndex, boolean isDuplicate, int comparator) {
+		this.conn = conn;
+		this.key = new byte[key.length];
+		System.arraycopy(key, 0, this.key, 0, key.length);
+		this.cursorIndex = 0;
+		this.comparator = comparator;
+		this.firstFetch = true;
+		this.isDuplicate = isDuplicate;
+		this.tableIndex = tableIndex;
+		this.nextCursorFetchKeyDiffrent = false;
+		this.prevCursorFetchKeyDiffrent = false;
+		this.forwardBuffer = new ArrayList<FetchResult>();
+		this.backwardBuffer = new ArrayList<FetchResult>();
+	}
+
+	/**
+	 * create a crusor
+	 * @param conn a connection to the SQLite database
+	 * @param key a key data
+	 * @param tableIndex the index of the table in the SQLite database
+	 * @param isDuplicate allows that the key data in the table is duplicate
+	 * @param comparator specifys the comparing type (one of COB_EQ, COB_LT, COB_LE, COB_GT, COB_GE in CobolIndexedFile.java)
+	 * @return return the cursor wrapped by Optional if the cursor is successfully created.
+	 * 		   Otherwise, Optional.empty().
+	 */
+	public static Optional<IndexedCursor> createCursor(Connection conn, byte[] key, int tableIndex, boolean isDuplicate, int comparator) {
+		IndexedCursor cursor = new IndexedCursor(conn, key, tableIndex, isDuplicate, comparator);
+		cursor.forwardCursor = getCursor(conn, key, tableIndex, isDuplicate, comparator, true);
+		cursor.backwardCursor = getCursor(conn, key, tableIndex, isDuplicate, comparator, false);
+		if(cursor.forwardCursor.isEmpty() || cursor.backwardCursor.isEmpty()) {
+			return Optional.empty();
+		} else {
+			return Optional.of(cursor);
+		}
+	}
+
+	/**
+	 * reload a cursor
+	 */
+	public Optional<IndexedCursor> reloadCursor() {
+		if(this.firstFetch) {
+			return createCursor(this.conn, this.key, this.tableIndex, this.isDuplicate, this.comparator);
+		}
+		
+		int newComparator;
+		if(this.comparator == CobolIndexedFile.COB_EQ) {
+			newComparator = CobolIndexedFile.COB_EQ;
+		} else {
+			newComparator = CobolIndexedFile.COB_GE;
+		}
+		
+		FetchResult result;
+		if(this.cursorIndex < 0) {
+			result = this.backwardBuffer.get(- this.cursorIndex - 1);
+		} else {
+			result = this.forwardBuffer.get(this.cursorIndex);
+		}
+
+		IndexedCursor newCursor = new IndexedCursor(this.conn, this.key, this.tableIndex, this.isDuplicate, this.comparator);
+		newCursor.forwardCursor = reloadedCursor(this.conn, this.tableIndex, this.isDuplicate, newComparator, result, this.comparator, true);
+		newCursor.backwardCursor = reloadedCursor(this.conn, this.tableIndex, this.isDuplicate, newComparator, result, this.comparator, false);
+		
+		Optional<FetchResult> reFetchResult = reFetch(this.conn, this.tableIndex, this.isDuplicate, result);
+		if(!reFetchResult.isEmpty()) {
+			FetchResult r = reFetchResult.get();
+			newCursor.forwardBuffer.add(r);
+			newCursor.cursorIndex = 0;
+			newCursor.firstFetch = false;
+		}
+		
+		if(newCursor.forwardCursor.isEmpty() || newCursor.backwardCursor.isEmpty()) {
+			return Optional.empty();
+		} else {
+			return Optional.of(newCursor);
+		}
+	}
+	
+	private static Optional<FetchResult> reFetch(Connection conn, int tableIndex, boolean isDuplicate, FetchResult result) {
+		final boolean isPrimaryTable = tableIndex == 0;
+		final String primaryTable = CobolIndexedFile.getTableName(0);
+		final String subTable = CobolIndexedFile.getTableName(tableIndex);
+		final String query;
+		if(isPrimaryTable) {
+			query = String.format(
+				"select key, value from %s where key == ?",
+				primaryTable);
+		} else if(isDuplicate){
+			query = String.format(
+				"select %s.key, %s.value, %s.dupNo from " +
+				"%s join %s on %s.value = %s.key " +
+				"where %s.key == ? and %s.dupNo == ?",
+				subTable, primaryTable, subTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, subTable);
+		} else {
+			query = String.format(
+				"select %s.key, %s.value from " +
+				"%s join %s on %s.value = %s.key " +
+				"where %s.key == ?",
+				subTable, primaryTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable);		
+		}
+		
+		try {
+			PreparedStatement statement = conn.prepareStatement(query);
+			if(isDuplicate) {
+				statement.setBytes(1, result.key);
+				statement.setInt(2, result.dupNo);
+			} else {
+				statement.setBytes(1, result.key);
+			}
+			statement.setFetchSize(0);
+			ResultSet rs = statement.executeQuery();
+			if(rs.next()) {
+				byte[] key = rs.getBytes(1);
+				byte[] value = rs.getBytes(2);
+				if(isDuplicate) {
+					int dupNo = rs.getInt(3);
+					return Optional.of(new FetchResult(key, value, dupNo));
+				} else {
+					return Optional.of(new FetchResult(key, value));
+				}
+			}
+			return Optional.empty();
+		} catch (SQLException  e) {
+			return Optional.empty();
+		}	
+	}
+	
+	private static Optional<ResultSet> reloadedCursor(
+		Connection conn, int tableIndex, boolean isDuplicate, int comparator, FetchResult result, int comparaotr, boolean forward) {
+
+		final String compOperator = forward ? ">" : "<";
+		
+		final String sortOrder = forward ? "" : "desc";	
+
+		final String queryPreffix = getReloadCursorQueryPrefix(tableIndex, isDuplicate, compOperator, sortOrder);
+
+		final String querySuffix = getQuerySuffix(tableIndex, isDuplicate, sortOrder);
+		
+		final String query = queryPreffix + querySuffix;
+
+		try {
+			PreparedStatement statement = conn.prepareStatement(query);
+			if(isDuplicate) {
+				statement.setBytes(1, result.key);
+				statement.setInt(2, result.dupNo);
+				statement.setBytes(3, result.key);
+			} else {
+				statement.setBytes(1, result.key);
+			}
+			statement.setFetchSize(0);
+			return Optional.ofNullable(statement.executeQuery());
+		} catch (SQLException  e) {
+			return Optional.empty();
+		}
+	}
+	
+	private static String getReloadCursorQueryPrefix(int index, boolean isDuplicate, String compOperator, String sortOrder) {		
+		final boolean isPrimaryTable = index == 0;
+		final String primaryTable = CobolIndexedFile.getTableName(0);
+		final String subTable = CobolIndexedFile.getTableName(index);
+		if(isPrimaryTable) {
+			return String.format(
+				"select key, value from %s where key %s ? order by key %s",
+				primaryTable,
+				compOperator,
+				sortOrder);
+		} else if(isDuplicate){
+			return String.format(
+				"select %s.key, %s.value, %s.dupNo from " +
+				"%s join %s on %s.value = %s.key " +
+				"where (%s.key == ? and %s.dupNo %s ?) or %s.key %s ? " +
+				"order by %s.key %s",
+				subTable, primaryTable, subTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, subTable, compOperator, subTable, compOperator,
+				subTable, sortOrder);
+		} else {
+			return String.format(
+				"select %s.key, %s.value from " +
+				"%s join %s on %s.value = %s.key " +
+				"where %s.key %s ? " +
+				"order by %s.key %s",
+				subTable, primaryTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, compOperator,
+				subTable, sortOrder);		
+		}
+	}
+	
+	public static boolean matchKeyHead(byte[] originalKey, byte[] fetchKey) {
+		if(originalKey.length > fetchKey.length) {
+			return false;
+		}
+		for(int i=0; i<originalKey.length; ++i) {
+			if(originalKey[i] != fetchKey[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	private Optional<FetchResult> fetchNext(ResultSet cursor) {
+		if(this.comparator == CobolIndexedFile.COB_EQ && this.nextCursorFetchKeyDiffrent) {
+			return Optional.empty();
+		}
+		try {
+			if(cursor.next()) {
+				byte[] fetchKey = cursor.getBytes(1);
+				byte[] fetchValue = cursor.getBytes(2);
+				if(this.comparator == CobolIndexedFile.COB_EQ && !matchKeyHead(this.key, fetchKey)) {
+					this.nextCursorFetchKeyDiffrent = true;
+					return Optional.empty();
+				}
+				FetchResult result;
+				if(this.isDuplicate) {
+					int dupNo = cursor.getInt(3);
+					result = new FetchResult(fetchKey, fetchValue, dupNo);
+				} else {
+					result = new FetchResult(fetchKey, fetchValue);
+				}
+				return Optional.of(result);
+			} else {
+				return Optional.empty();
+			}
+		} catch(SQLException e) {
+			return Optional.empty();
+		}
+	}
+	
+	private Optional<FetchResult> fetchPrev(ResultSet cursor) {
+		if(this.comparator == CobolIndexedFile.COB_EQ && this.prevCursorFetchKeyDiffrent) {
+			return Optional.empty();
+		}
+		try {
+			if(cursor.next()) {
+				byte[] fetchKey = cursor.getBytes(1);
+				byte[] fetchValue = cursor.getBytes(2);
+				if(this.comparator == CobolIndexedFile.COB_EQ && !matchKeyHead(this.key, fetchKey)) {
+					this.prevCursorFetchKeyDiffrent = true;
+					return Optional.empty();
+				}
+				FetchResult result;
+				if(this.isDuplicate) {
+					int dupNo = cursor.getInt(3);
+					result = new FetchResult(fetchKey, fetchValue, dupNo);
+				} else {
+					result = new FetchResult(fetchKey, fetchValue);
+				}
+				return Optional.of(result);
+			} else {
+				return Optional.empty();
+			}
+		} catch(SQLException e) {
+			return Optional.empty();
+		}
+	}
+	
+	/**
+	 * read a next data
+	 * @return return the read data wrapped by Optional when reading data successfully.
+	 *         Otherwise, return Optional.empty()
+	 */
+	public Optional<FetchResult> next() {
+		if(this.forwardCursor.isEmpty()) {
+			return Optional.empty();
+		}
+		ResultSet cursor = this.forwardCursor.get();
+		if(this.firstFetch) {
+			this.cursorIndex = 0;
+			Optional<FetchResult> fetchResult = this.fetchNext(cursor);
+			if(this.comparator == CobolIndexedFile.COB_GT) {
+				while(fetchResult.isPresent()) {
+					FetchResult result = fetchResult.get();
+					if(!matchKeyHead(this.key, result.key)) {
+						break;
+					}
+					fetchResult = this.fetchNext(cursor);
+				}
+			}
+			this.firstFetch = false;
+			if(fetchResult.isPresent()) {
+				this.forwardBuffer.add(fetchResult.get());
+			}
+			return fetchResult;
+		} else if(this.cursorIndex >= this.forwardBuffer.size()) {
+			return Optional.empty();
+		} else if(-this.cursorIndex > this.backwardBuffer.size()) {
+			++this.cursorIndex;
+			return Optional.empty();			
+		} else if(this.cursorIndex == this.forwardBuffer.size() - 1) {
+			Optional<FetchResult> fetchResult = this.fetchNext(cursor);
+			if(fetchResult.isPresent()) {
+				this.forwardBuffer.add(fetchResult.get());
+				++this.cursorIndex;
+			}
+			return fetchResult;
+		} else if (this.cursorIndex < -1){
+			++this.cursorIndex;
+			return Optional.of(backwardBuffer.get(- this.cursorIndex - 1));
+		} else {
+			++this.cursorIndex;
+			return Optional.of(forwardBuffer.get(this.cursorIndex));
+		}
+	}
+
+	/**
+	 * read a previous data
+	 * @return return the read data wrapped by Optional when reading data successfully.
+	 *         Otherwise, return Optional.empty()
+	 */
+	public Optional<FetchResult> prev() {
+		if(this.backwardCursor.isEmpty()) {
+			return Optional.empty();
+		}
+		ResultSet cursor = this.backwardCursor.get();
+		if(this.firstFetch) {
+			this.cursorIndex = -1;
+			Optional<FetchResult> fetchResult = this.fetchPrev(cursor);
+			if(fetchResult.isPresent()) {
+				this.firstFetch = false;
+				this.backwardBuffer.add(fetchResult.get());
+			}
+			return fetchResult;
+		} else if(this.cursorIndex > this.forwardBuffer.size()) {
+			--this.cursorIndex;
+			return Optional.empty();
+		} else if(-this.cursorIndex - 1 >= this.backwardBuffer.size()) {
+			return Optional.empty();			
+		} else if(-this.cursorIndex == this.backwardBuffer.size()) {
+			Optional<FetchResult> fetchResult = this.fetchPrev(cursor);
+			if(fetchResult.isPresent()) {
+				this.backwardBuffer.add(fetchResult.get());
+				--this.cursorIndex;
+			}
+			return fetchResult;
+		} else if (this.cursorIndex > 0){
+			--this.cursorIndex;
+			return Optional.of(forwardBuffer.get(this.cursorIndex));
+		} else {
+			--this.cursorIndex;
+			return Optional.of(backwardBuffer.get(- this.cursorIndex - 1));
+		}
+	}
+
+	/**
+	 * close a cursor
+	 */
+	public void close() {
+		try {
+			if(backwardCursor.isPresent()) {
+				backwardCursor.get().close();
+			}
+			if(forwardCursor.isPresent()) {
+				forwardCursor.get().close();
+			}
+		} catch (SQLException e) {
+		}
+	}
+
+	public Optional<FetchResult> read(CursorReadOption opt) {
+		if(opt == CursorReadOption.NEXT) {
+			return this.next();
+		} else if (opt == CursorReadOption.PREV){
+			return this.prev();
+		} else {
+			return Optional.empty();
+		}
+	}
+	
+	private static Optional<ResultSet> getCursor(Connection conn, byte[] key, int index, boolean isDuplicate, int comparator, boolean forward) {
+		final Optional<String> optionalCompOperator = getCompOperator(comparator, forward);
+
+		if(optionalCompOperator.isEmpty()) {
+			return Optional.empty();
+		}
+
+		final String compOperator = optionalCompOperator.get();
+		
+		final String sortOrder = forward ? "" : "desc";	
+
+		final String queryPreffix = getQueryPrefix(index, compOperator, sortOrder, isDuplicate);
+
+		final String querySuffix = getQuerySuffix(index, isDuplicate, sortOrder);
+		
+		final String query = queryPreffix + querySuffix;
+
+		try {
+			PreparedStatement statement = conn.prepareStatement(query);
+			statement.setBytes(1, key);
+			statement.setFetchSize(0);
+			return Optional.ofNullable(statement.executeQuery());
+		} catch (SQLException  e) {
+			return Optional.empty();
+		}
+	}
+	
+	private static Optional<String> getCompOperator(int comparator, boolean forward) {
+		if (comparator == CobolIndexedFile.COB_EQ ||
+			comparator == CobolIndexedFile.COB_GE ||
+			comparator == CobolIndexedFile.COB_LT) {
+			return Optional.of(forward ? ">=" : "<");
+		} else if (comparator == CobolIndexedFile.COB_GT ||
+				comparator == CobolIndexedFile.COB_LE){
+			return Optional.of(forward ? ">" : "<=");
+		} else {
+			return Optional.empty();
+		}
+	}
+	
+	private static String getQueryPrefix(int index, String compOperator, String sortOrder, boolean isDuplicate) {
+		final boolean isPrimaryTable = index == 0;
+		final String primaryTable = CobolIndexedFile.getTableName(0);
+		final String subTable = CobolIndexedFile.getTableName(index);
+		if(isPrimaryTable) {
+			return String.format(
+				"select key, value from %s where key %s ? order by key %s",
+				primaryTable,
+				compOperator,
+				sortOrder);
+		} else if(isDuplicate) {
+			return String.format(
+				"select %s.key, %s.value, %s.dupNo from " +
+				"%s join %s on %s.value = %s.key " +
+				"where %s.key %s ? order by %s.key %s",
+				subTable, primaryTable, subTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, compOperator, subTable, sortOrder);
+		} else {
+			return String.format(
+				"select %s.key, %s.value from " +
+				"%s join %s on %s.value = %s.key " +
+				"where %s.key %s ? order by %s.key %s",
+				subTable, primaryTable,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, compOperator, subTable, sortOrder);		
+		}
+	}
+	
+	private Optional<ResultSet> getCursorForFirstLast(int index, boolean isDuplicate, CursorReadOption option) {
+		final String query = getQueryForFirstLast(index, isDuplicate, option);
+		try {
+			Statement statement = this.conn.createStatement();
+			return Optional.ofNullable(statement.executeQuery(query));
+		} catch (SQLException e) {
+			return Optional.empty();
+		}
+	}
+	
+	public boolean moveToFirst() {
+		Optional<ResultSet> cursor = getCursorForFirstLast(this.tableIndex, this.isDuplicate, CursorReadOption.FIRST);
+		if(cursor.isEmpty()) {
+			return false;
+		}
+		this.forwardCursor = cursor;
+		this.backwardCursor = Optional.empty();
+		this.firstFetch = true;
+		this.cursorIndex = 0;
+		return true;
+	}
+	
+	public boolean moveToLast() {
+		Optional<ResultSet> cursor = getCursorForFirstLast(this.tableIndex, this.isDuplicate, CursorReadOption.LAST);
+		if(cursor.isEmpty()) {
+			return false;
+		}
+		this.backwardCursor = cursor;
+		this.forwardCursor = Optional.empty();
+		this.firstFetch = true;
+		this.cursorIndex = 0;
+		return true;	
+	}
+	
+	private static String getQueryForFirstLast(int index, boolean isDuplicate, CursorReadOption option) {
+		final String sortOrder;
+		if(option == CursorReadOption.FIRST) {
+			sortOrder = "";
+		} else {
+			sortOrder = "desc";
+		}
+
+		boolean isPrimaryTable = index == 0;
+		final String primaryTable = CobolIndexedFile.getTableName(0);
+		final String subTable = CobolIndexedFile.getTableName(index);
+
+		if(isPrimaryTable) {
+			return String.format(
+				"select key, value from %s order by key %s",
+				primaryTable,
+				sortOrder);
+		} else {
+			String optionColumn;
+			if(isDuplicate) {
+				optionColumn = String.format(", %s.dupNo", subTable);
+			} else {
+				optionColumn = "";
+			}
+			String query = String.format(
+				"select %s.key, %s.value %s from " +
+				"%s join %s on %s.value = %s.key " +
+				"order by %s.key %s",
+				subTable, primaryTable, optionColumn,
+				subTable, primaryTable, subTable, primaryTable,
+				subTable, sortOrder);
+			if(isDuplicate) {
+				return query + String.format(", dupNo %s", sortOrder);
+			} else {
+				return query;
+			}
+		}
+	}
+	
+	private static String getQuerySuffix(int index, boolean isDuplicate, String sortOrder) {
+		if(isDuplicate) {
+			final String tableName = CobolIndexedFile.getTableName(index);
+			return String.format(", %s.dupNo %s", tableName, sortOrder);
+		} else {
+			return "";
+		}
+	}
+}

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
@@ -1,9 +1,9 @@
 package jp.osscons.opensourcecobol.libcobj.file;
 
-import com.sleepycat.je.Cursor;
-import com.sleepycat.je.Database;
-import com.sleepycat.je.DatabaseEntry;
-import com.sleepycat.je.Transaction;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Optional;
 
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
@@ -11,16 +11,13 @@ public class IndexedFile {
 	public int key_index;
 	public CobolDataStorage last_key;
 	public CobolDataStorage temp_key;
-	public Database[] db;
-	public Database[] sub_db;
-	public DatabaseEntry key;
-	public DatabaseEntry data;
-	public CobolDataStorage[] last_readkey;
+	public Connection connection;
+	public byte[] key;
+	public byte[] data;
+	public byte[][] last_readkey;
 	public int[] last_dupno;
 	public int[] rewrite_sec_key;
 
-	public Cursor[] cursor;
-	public Transaction file_lock;
 	public String filename;
 	public Object record_lock;
 	public boolean write_cursor_open;


### PR DESCRIPTION
Up to v1.0.2, opensource COBOL 4j uses Berkeley DB Java Edition as a storage library to implement INDEXED files and some NIST COBOL 85 test cases fail.
I replace Berkeley DB Java Edition with SQLite and all NIST COBOL 85 test cases related to INDEXED files pass. (except for test cases using Relative files)