### PR TITLE
Add an experimental command line option to enable embedding COBOL variable names into Java variable names

### DIFF
--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -314,6 +314,7 @@ static const struct option long_options[] = {
 	{"assign_external", no_argument, NULL, 'A'},
 	{"reference_check", no_argument, NULL, 'K'},
 	{"constant", optional_argument, NULL, '3'},
+	{"embed-var-name", no_argument, &cb_flag_embed_var_name, 1},
 #undef	CB_FLAG
 #define	CB_FLAG(var,name,doc)			\
 	{"f"name, no_argument, &var, 1},	\

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -181,12 +181,12 @@ static char* get_java_identifier_field(struct cb_field* f);
 static char* get_java_identifier_base(struct cb_field* f);
 static void get_java_identifier_helper(struct cb_field* f, char* buf);
 static void strcpy_identifier_cobol_to_java(char* buf, char* identifier);
-#define ENABLE_EMBED_ORIGINAL_VARIABLE_NAME 1
+//#define ENABLE_EMBED_ORIGINAL_VARIABLE_NAME 1
 
 static char*
 get_java_identifier_field(struct cb_field* f) {
 	char *buf = malloc(COB_SMALL_BUFF);
-	if(ENABLE_EMBED_ORIGINAL_VARIABLE_NAME) {
+	if(cb_flag_embed_var_name) {
 		strcpy(buf, CB_PREFIX_FIELD);
 		get_java_identifier_helper(f, buf + strlen(CB_PREFIX_FIELD));
 	} else {
@@ -198,7 +198,7 @@ get_java_identifier_field(struct cb_field* f) {
 static char*
 get_java_identifier_base(struct cb_field* f) {
 	char *buf = malloc(COB_SMALL_BUFF);
-	if(ENABLE_EMBED_ORIGINAL_VARIABLE_NAME) {
+	if(cb_flag_embed_var_name) {
 		strcpy(buf, CB_PREFIX_BASE);
 		get_java_identifier_helper(f, buf + strlen(CB_PREFIX_BASE));
 	} else {

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -70,3 +70,6 @@ CB_FLAG (cb_flag_mfcomment, "mfcomment",
 
 CB_FLAG (cb_flag_null_param, "null-param",
 	 N_("Pass extra NULL terminating pointers on CALL statements"))
+
+CB_FLAG (cb_flag_embed_var_name, "embed-var-name",
+	 N_("Embed COBOL variable names into Java variable names. This option is experimental."))


### PR DESCRIPTION
I partially solve the problem described in #38.
With -fembed-var-name option, the compiler replaces variable names f_{number} and b_{number} in Java source code with f_{COBOL variable name} and b_{COBOL variable name} respectively.