### PR TITLE
Fix moveFrom of CobolNumericPackedField

### DIFF
--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -344,13 +344,13 @@ public class CobolNumericPackedField extends AbstractCobolField {
     int sign = 0;
     CobolDataStorage data = this.getDataStorage();
 
-    if(val == Integer.MIN_VALUE) {
-      //Integer.MIN_VALUE == -2147483647
+    if (val == Integer.MIN_VALUE) {
+      // Integer.MIN_VALUE == -2147483647
       int[] bytes = {2, 1, 4, 7, 4, 8, 3, 6, 4, 8};
       int digits = this.getAttribute().getDigits();
       int iter = Math.min(bytes.length, digits);
-      for(int i=0; i<digits; ++i) {
-        if(i < bytes.length) {
+      for (int i = 0; i < digits; ++i) {
+        if (i < bytes.length) {
           this.setDigit(digits - 1 - i, bytes[bytes.length - 1 - i]);
         } else {
           this.setDigit(digits - 1 - i, 0);

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -343,7 +343,22 @@ public class CobolNumericPackedField extends AbstractCobolField {
     int n;
     int sign = 0;
     CobolDataStorage data = this.getDataStorage();
-    if (val < 0) {
+
+    if(val == Integer.MIN_VALUE) {
+      //Integer.MIN_VALUE == -2147483647
+      int[] bytes = {2, 1, 4, 7, 4, 8, 3, 6, 4, 8};
+      int digits = this.getAttribute().getDigits();
+      int iter = Math.min(bytes.length, digits);
+      for(int i=0; i<digits; ++i) {
+        if(i < bytes.length) {
+          this.setDigit(digits - 1 - i, bytes[bytes.length - 1 - i]);
+        } else {
+          this.setDigit(digits - 1 - i, 0);
+        }
+      }
+      this.putSign(-1);
+      return;
+    } else if (val < 0) {
       n = -val;
       sign = 1;
     } else {

--- a/tests/misc.src/java-interface.at
+++ b/tests/misc.src/java-interface.at
@@ -517,3 +517,71 @@ ret1: 101
 ret2: ‚©‚«‚­‚¯‚±
 ])
 AT_CLEANUP
+
+
+AT_SETUP([COMP-3 Integer.MIN_VALUE])
+
+AT_DATA([b.cbl], [
+       identification division.
+       program-id. b.
+       data division.
+       linkage section.
+       01 k1 pic S9(1) usage comp-3 value zero.
+       01 k2 pic S9(2) usage comp-3 value zero.
+       01 k3 pic S9(3) usage comp-3 value zero.
+       01 k4 pic S9(4) usage comp-3 value zero.
+       01 k5 pic S9(5) usage comp-3 value zero.
+       01 k6 pic S9(6) usage comp-3 value zero.
+       01 k7 pic S9(7) usage comp-3 value zero.
+       01 k8 pic S9(8) usage comp-3 value zero.
+       01 k9 pic S9(9) usage comp-3 value zero.
+       01 k10 pic S9(10) usage comp-3 value zero.
+       01 k11 pic S9(11) usage comp-3 value zero.
+       01 k12 pic S9(12) usage comp-3 value zero.
+       01 k13 pic S9(13) usage comp-3 value zero.
+       procedure division
+           using k1 k2 k3 k4 k5 k6 k7 k8 k9 k10 k11 k12 k13.
+
+       display k1.
+       display k2.
+       display k3.
+       display k4.
+       display k5.
+       display k6.
+       display k7.
+       display k8.
+       display k9.
+       display k10.
+       display k11.
+       display k12.
+       display k13.
+])
+
+AT_DATA([a.java], [
+public class a {
+        public static void main(String@<:@@:>@ args) {
+                int v = Integer.MIN_VALUE;
+                b prog = new b();
+                prog.execute(v, v, v, v, v, v, v, v, v, v, v, v, v);
+        }
+}
+])
+
+AT_CHECK([cobj b.cbl])
+AT_CHECK([javac a.java])
+AT_CHECK([java a], [0],
+[-8
+-48
+-648
+-3648
+-83648
+-483648
+-7483648
+-47483648
+-147483648
+-2147483648
+-02147483648
+-002147483648
+-0002147483648
+])
+AT_CLEANUP


### PR DESCRIPTION
CobolNumericPackedのmoveFromにInteger.MIN_VALUE(-2147483648)を渡すと、実行時エラーになった問題を修正した。
