### PR TITLE
Implement new options `-o`, `-j`, `-class-file-path`, `-java-file-path`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,23 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v2
+
+    - name: Install dependencies on Ubuntu 22.04
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y default-jdk build-essential bison flex gettext texinfo automake autoconf
+      
+    - name: Install opensource COBOL 4J
+      run: |
+        mkdir ~/.java_lib
+        curl -L -o ~/.java_lib/sqlite.jar https://github.com/xerial/sqlite-jdbc/releases/download/3.36.0.3/sqlite-jdbc-3.36.0.3.jar
+        export CLASSPATH=":$HOME/.java_lib/sqlite.jar"
+        ./configure --prefix=/usr/
+        make
+        sudo make install
+        export CLASSPATH=":/usr/lib/opensourcecobol4j/libcobj.jar:$HOME/.java_lib/sqlite.jar"
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "develop" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -249,7 +249,7 @@ static cob_sighandler_t intsig = NULL;
 static cob_sighandler_t qutsig = NULL;
 #endif
 
-static const char short_options[] = "hVvECbmxgwoj:t:I:L:l:D:";
+static const char short_options[] = "hVvECbmxgwo:j:t:I:L:l:D:";
 
 static const struct option long_options[] = {
     {"help", no_argument, NULL, 'h'},
@@ -767,6 +767,8 @@ static void cobc_print_usage(void) {
   puts(_("  -g                                Enable Java compiler debug"));
   puts(_("  -o <dir>                          Place class files into <dir>"));
   puts(_("  -class-file-dir=<dir>             Place class files into <dir>"));
+  puts(_("  -j <dir>                          Place java files into <dir>"));
+  puts(_("  -java-source-dir=<dir>            Place java files into <dir>"));
   puts(_("  -E                                Preprocess only; do not compile "
          "or link"));
   puts(_("  -C                                Translation only; convert COBOL "
@@ -831,6 +833,18 @@ static int process_command_line(const int argc, char *argv[]) {
       argv[argnum - 1][0] = '-';
     }
   }
+
+  /*while(c = getopt(argc, argv, short_options)) {
+    switch(c) {
+    case 'o':
+      output_name = strdup(optarg);
+      break;
+
+    case 'j':
+      java_source_dir = strdup(optarg);
+      break;
+    }
+  }*/
 
   while ((c = getopt_long_only(argc, argv, short_options, long_options,
                                &idx)) >= 0) {
@@ -921,12 +935,14 @@ static int process_command_line(const int argc, char *argv[]) {
       break;
 
     case 'o':
-      /* -o : Output file */
-      /* -class-path : Output file*/
+      /* -o : the directory where class files are stored */
+      /* -class-file-dir : the directory where class files are stored */
       output_name = strdup(optarg);
       break;
 
     case 'j':
+      /* -j : the directory where java files are stored */
+      /* -java-file-dir : the directory where java files are stored */
       java_source_dir = strdup(optarg);
       break;
 

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -229,7 +229,7 @@ static pid_t cob_process_id = 0;
 static int strip_output = 0;
 static int gflag_set = 0;
 
-static char *output_name;
+static char *output_name = NULL;
 
 static const char *cob_tmpdir; /* /tmp */
 
@@ -264,6 +264,7 @@ static const struct option long_options[] = {
     {"std", required_argument, NULL, '$'},
     {"conf", required_argument, NULL, '&'},
     {"debug", no_argument, NULL, 'd'},
+    {"class-file-dir", optional_argument, NULL, 'o'},
     {"ext", required_argument, NULL, 'e'},
     {"free", no_argument, &cb_source_format, CB_FORMAT_FREE},
     {"free_1col_aster", no_argument, &cb_source_format,
@@ -762,6 +763,8 @@ static void cobc_print_usage(void) {
   puts(_("  -free_1col_aster                  Use free(1col_aster) source "
          "format"));
   puts(_("  -g                                Enable Java compiler debug"));
+  puts(_("  -o <dir>                          Place class files into <dir>"));
+  puts(_("  -class-file-dir=<dir>             Place class files into <dir>"));
   puts(_("  -E                                Preprocess only; do not compile "
          "or link"));
   puts(_("  -C                                Translation only; convert COBOL "
@@ -917,6 +920,7 @@ static int process_command_line(const int argc, char *argv[]) {
 
     case 'o':
       /* -o : Output file */
+      /* -class-path : Output file*/
       output_name = strdup(optarg);
       break;
 
@@ -1616,8 +1620,8 @@ static int process_compile(struct filename *fn) {
   }
 
   for (char **program_id = program_id_list; *program_id; ++program_id) {
-    sprintf(buff, "javac %s -encoding SJIS -d . %s.java", cob_java_flags,
-            *program_id);
+    sprintf(buff, "javac %s -encoding SJIS -d %s %s.java", cob_java_flags,
+            output_name == NULL ? "." : output_name, *program_id);
     ret = process(buff);
   }
   return ret;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5512,8 +5512,8 @@ void joutput_execution_entry_func() {
   joutput_line("}");
 }
 
-void codegen(struct cb_program *prog, const int nested,
-             char **program_id_list) {
+void codegen(struct cb_program *prog, const int nested, char **program_id_list,
+             char *java_source_dir) {
   int i;
   cb_tree l;
   struct field_list *k;
@@ -5545,8 +5545,8 @@ void codegen(struct cb_program *prog, const int nested,
 
   // modify 8/29 11:00
   joutput_target = yyout;
-  char java_file_name[64];
-  sprintf(java_file_name, "%s.java", prog->program_id);
+  char java_file_name[1024];
+  sprintf(java_file_name, "%s/%s.java", java_source_dir, prog->program_id);
   *program_id_list = (char *)prog->program_id;
   joutput_target = fopen(java_file_name, "w");
 
@@ -5834,7 +5834,7 @@ void codegen(struct cb_program *prog, const int nested,
     joutput_line("}");
     fclose(joutput_target);
     ++program_id_list;
-    codegen(prog->next_program, 1, program_id_list);
+    codegen(prog->next_program, 1, program_id_list, java_source_dir);
     return;
   }
 

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -1568,7 +1568,7 @@ extern void cobc_tree_cast_error(cb_tree x, const char *filen,
 
 /* codegen.c */
 extern void codegen(struct cb_program *prog, const int nested,
-                    char **program_id_list);
+                    char **program_id_list, char *java_source_dir);
 
 /* scanner.l */
 extern void cb_set_in_procedure(void);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -153,7 +153,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/fserial-variable.at \
 	command-line-options.src/fshort-variable.at \
 	command-line-options.src/java-package.at \
-	command-line-options.src/edit-code-command.at
+	command-line-options.src/edit-code-command.at \
+	command-line-options.src/file-path.at
 
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -694,7 +694,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/fserial-variable.at \
 	command-line-options.src/fshort-variable.at \
 	command-line-options.src/java-package.at \
-	command-line-options.src/edit-code-command.at
+	command-line-options.src/edit-code-command.at \
+	command-line-options.src/file-path.at
 
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \

--- a/tests/command-line-options.at
+++ b/tests/command-line-options.at
@@ -14,5 +14,6 @@ m4_include([ftrace-ftraceall.at])
 m4_include([fsyntax-only.at])
 m4_include([fserial-variable.at])
 m4_include([fshort-variable.at])
+m4_include([file-path.at])
 
 # m4_include([edit-code-command.at])

--- a/tests/command-line-options.src/file-path.at
+++ b/tests/command-line-options.src/file-path.at
@@ -1,0 +1,125 @@
+AT_SETUP([file-path options])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+       PROGRAM-ID.                 prog.
+       DATA                        DIVISION.
+       WORKING-STORAGE             SECTION.
+       PROCEDURE                   DIVISION.
+           DISPLAY "HELLO".
+])
+
+AT_CHECK([mkdir class_dir java_dir sub])
+
+AT_CHECK([${COBJ} -j java_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test -e prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -java-source-dir=java_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test -e prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -o class_dir prog.cbl])
+AT_CHECK([test -e prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -class-file-dir=class_dir prog.cbl])
+AT_CHECK([test -e prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK(${COBJ} -j java_dir -o class_dir prog.cbl)
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+# compile in sub/
+AT_CHECK([cd sub && ${COBJ} -j ../java_dir ../prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test -e sub/prog.class])
+AT_CHECK([test ! -e sub/prog.java])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/* sub/*])
+
+AT_CHECK([cd sub && ${COBJ} -java-source-dir=../java_dir ../prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test -e sub/prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([test ! -e sub/prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/* sub/*])
+
+AT_CHECK([cd sub && ${COBJ} -o ../class_dir ../prog.cbl])
+AT_CHECK([test -e sub/prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e sub/prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/* sub/*])
+
+AT_CHECK([cd sub && ${COBJ} -class-file-dir=../class_dir ../prog.cbl])
+AT_CHECK([test -e sub/prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e sub/prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/* sub/*])
+
+AT_CHECK([cd sub && ${COBJ} -j ../java_dir -o ../class_dir ../prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([test ! -e sub/prog.java])
+AT_CHECK([test -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e sub/prog.class])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/* sub/*])
+
+# with -C option
+
+AT_CHECK([${COBJ} -C -j java_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -C -java-source-dir=java_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -C -j java_dir -o class_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -C -java-source-dir=java_dir -o class_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -C -j java_dir -class-file-dir=class_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CHECK([${COBJ} -C -java-source-dir=java_dir -class-file-dir=class_dir prog.cbl])
+AT_CHECK([test -e java_dir/prog.java])
+AT_CHECK([test ! -e prog.class])
+AT_CHECK([test ! -e class_dir/prog.class])
+AT_CHECK([test ! -e prog.java])
+AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
+
+AT_CLEANUP

--- a/tests/data-rep.src/display.at
+++ b/tests/data-rep.src/display.at
@@ -60,7 +60,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ascii -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ascii prog.cob])
 AT_CHECK([java prog], [0],
 [12340
 12340
@@ -116,7 +116,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ascii  -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ascii prog.cob])
 AT_CHECK([java prog], [0], [0123456789pqrstuvwxy])
 
 AT_CLEANUP
@@ -162,7 +162,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ebcdic -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ebcdic prog.cob])
 AT_CHECK([java prog], [0], [{ABCDEFGHI}JKLMNOPQR])
 
 AT_CLEANUP
@@ -197,7 +197,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ascii -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ascii prog.cob])
 AT_CHECK([java prog], [0],
 [+0000 0000+
 +0000 0000+
@@ -230,7 +230,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ascii -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ascii prog.cob])
 AT_CHECK([java prog], [0],
 [0000
 0000
@@ -263,7 +263,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -fsign-ebcdic -o prog prog.cob])
+AT_CHECK([${COMPILE} -fsign-ebcdic prog.cob])
 AT_CHECK([java prog], [0],
 [000{
 000{

--- a/tests/jp-compat.src/copy-joining.at
+++ b/tests/jp-compat.src/copy-joining.at
@@ -17,7 +17,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -41,7 +41,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -69,7 +69,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -94,7 +94,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -119,7 +119,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -146,7 +146,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -176,7 +176,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT}  prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP

--- a/tests/jp-compat.src/copy-leading-trailing.at
+++ b/tests/jp-compat.src/copy-leading-trailing.at
@@ -18,7 +18,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -43,7 +43,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -72,7 +72,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([java prog], [0], [OKOK])
 
 AT_CLEANUP

--- a/tests/jp-compat.src/file-control.at
+++ b/tests/jp-compat.src/file-control.at
@@ -23,7 +23,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_IO_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -54,7 +54,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_IO_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -88,7 +88,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_IO_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -121,7 +121,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_IO_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -152,7 +152,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_EXTEND_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -183,7 +183,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_EXTEND_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -217,7 +217,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_EXTEND_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -250,7 +250,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([export OC_EXTEND_CREATES=yes && ${RUN_MODULE} prog], [0], [00
 ])
 
@@ -282,7 +282,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0], [00
 ])
 
@@ -314,7 +314,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0], [00
 ])
 
@@ -349,7 +349,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0], [00
 ])
 
@@ -386,7 +386,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0], [00
 ])
 
@@ -422,7 +422,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([${RUN_MODULE} prog], [0], [91
 ])
 
@@ -453,7 +453,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([echo 000011112222 >TEST-FILE])
-AT_CHECK([${COMPILE_MODULE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} prog.cob])
 AT_CHECK([COB_IO_ASSUME_REWRITE=Y ${RUN_MODULE} prog])
 AT_CHECK([test `cat TEST-FILE` = '0000AAAA2222'])
 

--- a/tests/jp-compat.src/job-date.at
+++ b/tests/jp-compat.src/job-date.at
@@ -15,7 +15,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/01/02 java prog], [0], [700102
 ])
 
@@ -39,7 +39,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/01/02 java prog], [0], [19700102
 ])
 
@@ -61,7 +61,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/02/01 java prog], [0], [70032
 ])
 
@@ -83,7 +83,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/02/01 java prog], [0], [1970032
 ])
 
@@ -107,7 +107,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/01/02 java prog], [0], [19700102
 ])
 
@@ -131,7 +131,7 @@ AT_DATA([prog.cob],[
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970 java prog > out1.txt], [0], [],
 [Warning: COB_DATE format invalid, ignored.
 ])
@@ -158,7 +158,7 @@ AT_DATA([prog.cob],[
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=1970/1/1 java prog > out1.txt], [0], [],
 [Warning: COB_DATE format invalid, ignored.
 ])
@@ -185,7 +185,7 @@ AT_DATA([prog.cob],[
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=10000/01/01 java prog > out1.txt], [0], [],
 [Warning: COB_DATE format invalid, ignored.
 ])
@@ -242,7 +242,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([COB_DATE=`date +%Y/%m/%d` java prog], [0], [0
 ])
 

--- a/tests/run.src/accept.at
+++ b/tests/run.src/accept.at
@@ -52,7 +52,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [(999999  )
 (99999999)

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -58,7 +58,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00001234
 00004660
@@ -86,7 +86,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00074565
 16777215
@@ -110,7 +110,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -167,7 +167,7 @@ AT_DATA([prog.cob], [
          END-IF.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], 
 [X-1
 X-2
@@ -204,7 +204,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [0002
 0002
@@ -231,7 +231,7 @@ AT_DATA([prog.cob], [
            END-DISPLAY.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [99/99/9999.99.99    ])
 
 AT_CLEANUP
@@ -262,7 +262,7 @@ AT_DATA([prog.cob], [
            END-DISPLAY.
 ])
 
-AT_CHECK([${COMPILE} -std=mvs -o prog prog.cob])
+AT_CHECK([${COMPILE} -std=mvs prog.cob])
 AT_CHECK([java prog], [0], [123456:34:56])
 
 AT_CLEANUP
@@ -338,7 +338,7 @@ AT_DATA([prog.cob], [
           STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -std=mf -o prog prog.cob], [0], ,
+AT_CHECK([${COMPILE} -std=mf prog.cob], [0], ,
 [prog.cob: In paragraph 'S-03':
 prog.cob:37: Warning: Move non-integer to alphanumeric
 prog.cob: In paragraph 'S-10':
@@ -398,7 +398,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} setfilename.c])
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0])
 AT_CHECK([test -e TESTFILE], [0])
 
@@ -444,7 +444,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} setfilename.c])
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0])
 AT_CHECK([test -e TESTFILE], [0])
 
@@ -532,7 +532,7 @@ AT_DATA([prog.cob], [
        END PROGRAM PROG.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -555,7 +555,7 @@ AT_DATA([prog.cob], [
        END PROGRAM caller.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -579,7 +579,7 @@ AT_DATA([prog.cob], [
        END PROGRAM caller.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -611,7 +611,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob], [0], ,
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob], [0], ,
 [prog.cob:12: Warning: 'FILENAME' will be implicitly defined
 ])
 AT_CHECK([java prog], [0])
@@ -642,7 +642,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([java prog], [0])
 AT_CHECK([test -f FILENAME], [0])
 
@@ -672,7 +672,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([DD_FILENAME="x" java prog], [0])
 AT_CHECK([test -f "x"], [0])
 AT_CHECK([dd_FILENAME="y" java prog], [0])
@@ -708,7 +708,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([DIR="." java prog], [0])
 AT_CHECK([test -f "./FILENAME" && rm -f "./FILENAME"], [0])
 
@@ -738,7 +738,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([COB_FILE_PATH=".." java prog], [0])
 AT_CHECK([test -f "../FILENAMEX" && rm -f "../FILENAMEX"], [0])
 
@@ -892,7 +892,7 @@ AT_DATA([prog.cob], [
            STOP RUN RETURNING 1.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1])
 
 AT_CLEANUP
@@ -975,7 +975,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog])
 AT_CHECK([cat TEST-FILE], [0], 
 [a
@@ -1035,7 +1035,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [(a   )
 (ab  )
@@ -1093,7 +1093,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([cat TEST-FILE | java prog], [0],
 [a
 ab
@@ -1141,7 +1141,7 @@ AT_DATA([prog.cob], [
 ])
 
 export TEST_ENV=OK
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog CHECKPAR], [0],
 [(OK  )
 (RXW )

--- a/tests/run.src/functions.at
+++ b/tests/run.src/functions.at
@@ -33,7 +33,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+0001.2345
 ])
@@ -62,7 +62,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -93,7 +93,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -122,7 +122,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -151,7 +151,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -172,7 +172,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [k
 ])
@@ -193,7 +193,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [0000987.00345
 ])
@@ -216,7 +216,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [defxabczz55666
 ])
@@ -240,7 +240,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [efxabczz5
 ])
@@ -269,7 +269,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -289,7 +289,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [20000925
 ])
@@ -310,7 +310,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [18981002
 ])
@@ -330,7 +330,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [2000269
 ])
@@ -351,7 +351,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [01995005
 ])
@@ -371,7 +371,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [2.7182818284590452353602874713526625
 ])
@@ -402,7 +402,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [35TEST-FILE
 ])
@@ -438,7 +438,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -debug -o prog prog.cob])
+AT_CHECK([${COMPILE} -debug prog.cob])
 AT_CHECK([java prog], [0],
 [prog; A00 OF A00-MAIN; 18])
 
@@ -469,7 +469,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -debug -o prog prog.cob])
+AT_CHECK([${COMPILE} -debug prog.cob])
 AT_CHECK([java prog], [0],
 [OPEN                           ])
 
@@ -500,7 +500,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [EC-I-O-PERMANENT-ERROR         ])
 
@@ -527,7 +527,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -547,7 +547,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [000000000000000720
 ])
@@ -570,7 +570,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+.123450000000000000
 -.123450000000000000
@@ -592,7 +592,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-000000000000000002
 ])
@@ -612,7 +612,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00146000
 ])
@@ -632,7 +632,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00146000
 ])
@@ -653,7 +653,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-000000000000000001
 ])
@@ -674,7 +674,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [8
 ])
@@ -699,7 +699,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -724,7 +724,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -749,7 +749,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -778,7 +778,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -807,7 +807,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -828,7 +828,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a#b.c%d+e$
 ])
@@ -849,7 +849,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a#b
 ])
@@ -869,7 +869,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [8
 ])
@@ -889,7 +889,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-1.20000000000000000
 ])
@@ -909,7 +909,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [0
 ])
@@ -930,7 +930,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-3.000000000000000000
 ])
@@ -950,7 +950,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-14
 ])
@@ -970,7 +970,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+000000000000000004
 ])
@@ -991,7 +991,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-00000000009876.1234
 ])
@@ -1012,7 +1012,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-00000000009876.1234
 ])
@@ -1032,7 +1032,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000108
 ])
@@ -1053,7 +1053,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000004
 ])
@@ -1074,7 +1074,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000002
 ])
@@ -1094,7 +1094,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [3.1415926535897932384626433832795029
 ])
@@ -1115,7 +1115,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [0.562500000000000000
 ])
@@ -1135,7 +1135,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+000000000000000022
 ])
@@ -1155,7 +1155,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [-000000000000000001
 ])
@@ -1176,7 +1176,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [$E+D%C.B#A
 ])
@@ -1197,7 +1197,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [$E+D
 ])
@@ -1227,7 +1227,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1255,7 +1255,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1282,7 +1282,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+00000001
 +00000000
@@ -1314,7 +1314,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1344,7 +1344,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1372,7 +1372,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1395,7 +1395,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000012
 ])
@@ -1418,7 +1418,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [zz1114446665defxxzz
 ])
@@ -1442,7 +1442,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [z11144466
 ])
@@ -1465,7 +1465,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [zz1114446665defxxzz
 ])
@@ -1489,7 +1489,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [z11144466
 ])
@@ -1518,7 +1518,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1542,7 +1542,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a#b.c%d+e$
  a#b.c%d+e$
@@ -1567,7 +1567,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [#b.
 a#b
@@ -1589,7 +1589,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [A#B.C%D+E$
 ])
@@ -1610,7 +1610,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [A#B
 ])
@@ -1631,7 +1631,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [+54.1600000000000000
 ])
@@ -1660,7 +1660,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])

--- a/tests/run.src/initialize.at
+++ b/tests/run.src/initialize.at
@@ -43,7 +43,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [   0])
 
 AT_CLEANUP
@@ -66,7 +66,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [ 0 0 0 0 0])
 
 AT_CLEANUP
@@ -91,7 +91,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [ 000])
 
 AT_CLEANUP
@@ -115,7 +115,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0   0   ])
 
 AT_CLEANUP
@@ -138,7 +138,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [ 0])
 
 AT_CLEANUP

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -38,7 +38,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [111])
 
 AT_CLEANUP
@@ -76,7 +76,7 @@ AT_DATA([caller.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} callee.cob])
-AT_CHECK([${COMPILE} -o prog caller.cob])
+AT_CHECK([${COMPILE} caller.cob])
 AT_CHECK([java prog], [0],
 [WRK-X = abc
 LCL-X = abc
@@ -121,7 +121,7 @@ AT_DATA([caller.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} callee.cob])
-AT_CHECK([${COMPILE} -o prog caller.cob])
+AT_CHECK([${COMPILE} caller.cob])
 AT_CHECK([java prog], [0],
 [Hello
 World
@@ -167,7 +167,7 @@ AT_DATA([caller.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} callee.cob])
-AT_CHECK([${COMPILE} -o prog caller.cob])
+AT_CHECK([${COMPILE} caller.cob])
 AT_CHECK([java prog], [0],
 [Extrn
 Hello
@@ -237,7 +237,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [12])
 
 AT_CLEANUP
@@ -257,7 +257,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [1000])
 
 AT_CLEANUP
@@ -280,7 +280,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [1   ])
 
 AT_CLEANUP
@@ -301,7 +301,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [1299])
 
 AT_CLEANUP
@@ -323,7 +323,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0])
 
 AT_CLEANUP
@@ -356,7 +356,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [000102])
 
 AT_CLEANUP
@@ -401,7 +401,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -422,7 +422,7 @@ AT_DATA([prog.cob], [
          END-IF.
 ])
 
-AT_CHECK([${COMPILE_ONLY} -o prog prog.cob])
+AT_CHECK([${COMPILE_ONLY} prog.cob])
 
 AT_CLEANUP
 
@@ -455,7 +455,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ                       abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789                       ])
 
 AT_CLEANUP
@@ -476,7 +476,7 @@ AT_DATA([prog.cob], [
          END-IF.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -505,7 +505,7 @@ AT_DATA([caller.cob], [
 
 AT_CHECK([${COMPILE_MODULE} -c callee.cob])
 AT_CHECK([${COMPILE} -c caller.cob])
-AT_CHECK([${COMPILE} -o prog caller.${OBJEXT} callee.${OBJEXT}])
+AT_CHECK([${COMPILE} caller.${OBJEXT} callee.${OBJEXT}])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -604,7 +604,7 @@ AT_DATA([call02.cob], [
            GOBACK.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([${COMPILE_MODULE} call01.cob])
 AT_CHECK([${COMPILE_MODULE} call02.cob])
 AT_CHECK([java prog], [0],
@@ -654,13 +654,13 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} dump.c])
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000001
 00000009
 00000004
 ])
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([java prog], [0],
 [00000001
 00000009
@@ -710,13 +710,13 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} dump.c])
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [00000001
 00000009
 00000004
 ])
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([java prog], [0],
 [00000001
 00000009
@@ -1010,7 +1010,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [XXXX])
 
 AT_CLEANUP
@@ -1035,7 +1035,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -1059,7 +1059,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OKOK])
 
 AT_CLEANUP
@@ -1090,7 +1090,7 @@ AT_DATA([prog.cob], [
            .
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0003])
 
 AT_CLEANUP
@@ -1126,7 +1126,7 @@ AT_DATA([prog.cob], [
            .
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0003])
 
 AT_CLEANUP
@@ -1154,7 +1154,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -1178,7 +1178,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [99])
 
 AT_CLEANUP
@@ -1219,7 +1219,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [abc])
 
 AT_CLEANUP
@@ -1249,7 +1249,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [ABC
 DEF
@@ -1286,7 +1286,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [0000000000])
 
 AT_CLEANUP
@@ -1323,7 +1323,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -1375,7 +1375,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [A
 C
@@ -1412,7 +1412,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a3b2c5d4e1
 c5d4a3b2e1
@@ -1457,7 +1457,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [12345abcde
 edcba54321
@@ -1494,7 +1494,7 @@ AT_DATA([prog.cob], [
              STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog])
 AT_CHECK([cat SORT-OUT], [0], [])
 
@@ -1526,7 +1526,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], 
 [(  1-)
 (    )
@@ -1566,7 +1566,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -std=mf -o prog prog.cob], [0], ,
+AT_CHECK([${COMPILE} -std=mf prog.cob], [0], ,
 [prog.cob:11: Warning: Size of 'XMAIN0502' larger than size of 'XMAIN0501'
 ])
 AT_CHECK([java prog], [0], 
@@ -1612,7 +1612,7 @@ AT_DATA([prog.cob], [
            EXIT.
 ])
 
-AT_CHECK([${COMPILE} -conf=test.conf -o prog prog.cob])
+AT_CHECK([${COMPILE} -conf=test.conf prog.cob])
 AT_CHECK([java prog], [0],
 [OK
 ])
@@ -1901,7 +1901,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob], [0], [],
+AT_CHECK([${COMPILE} prog.cob], [0], [],
 [prog.cob:20: Warning: KEY ignored with sequential READ
 ])
 
@@ -1990,7 +1990,7 @@ AT_DATA([prog.cob], [
            END-PERFORM.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [027021013])
 
 AT_CLEANUP
@@ -2045,7 +2045,7 @@ AT_DATA([prog.cob], [
            CLOSE SIN-F.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [021027013])
 
 AT_CLEANUP

--- a/tests/run.src/ref-mod.at
+++ b/tests/run.src/ref-mod.at
@@ -49,7 +49,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [-11-])
 
 AT_CLEANUP
@@ -77,7 +77,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a:ab:abc:abcd:abcd
 b:bc:bcd:bcd
@@ -109,7 +109,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0],
 [a
 d
@@ -164,7 +164,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:9: libcob: Offset of 'X' out of bounds: 0
 ])
@@ -187,7 +187,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:9: libcob: Offset of 'X' out of bounds: 5
 ])
@@ -210,7 +210,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:9: libcob: Length of 'X' out of bounds: 0
 ])
@@ -233,7 +233,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:9: libcob: Length of 'X' out of bounds: 5
 ])
@@ -259,7 +259,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Offset of 'X' out of bounds: 0
 ])
@@ -283,7 +283,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Offset of 'X' out of bounds: 0
 ])

--- a/tests/run.src/return-code.at
+++ b/tests/run.src/return-code.at
@@ -38,7 +38,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE}  prog.cob])
 AT_CHECK([java prog], [1], [01])
 
 AT_CLEANUP
@@ -81,7 +81,7 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([${COMPILE_MODULE} mod1.cob])
 AT_CHECK([${COMPILE_MODULE} mod2.cob])
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE}  prog.cob])
 AT_CHECK([java prog], [0], [+000000000+000000001+000000001+000000000])
 
 AT_CLEANUP
@@ -112,7 +112,7 @@ AT_DATA([prog.cob], [
        END PROGRAM prog.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE}  prog.cob])
 AT_CHECK([java prog], [0], [+000000001+000000001+000000002])
 
 AT_CLEANUP

--- a/tests/run.src/subscripts.at
+++ b/tests/run.src/subscripts.at
@@ -112,7 +112,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 0
 ])
@@ -137,7 +137,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
 ])
@@ -161,7 +161,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
 ])
@@ -185,7 +185,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
 ])
@@ -209,7 +209,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
 ])
@@ -233,7 +233,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
 ])
@@ -257,7 +257,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: OCCURS DEPENDING ON 'N' out of bounds: 3
 ])
@@ -282,7 +282,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: OCCURS DEPENDING ON 'N' out of bounds: 7
 ])
@@ -306,7 +306,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob], [1], ,
+AT_CHECK([${COMPILE} prog.cob], [1], ,
 [prog.cob:10: Error: Subscript of 'X' out of bounds: 0
 ])
 
@@ -329,7 +329,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob], [1], ,
+AT_CHECK([${COMPILE} prog.cob], [1], ,
 [prog.cob:10: Error: Subscript of 'X' out of bounds: 7
 ])
 
@@ -353,7 +353,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:10: libcob: Subscript of 'X' out of bounds: 5
 ])
@@ -381,7 +381,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [24])
 
 AT_CLEANUP
@@ -404,7 +404,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
 ])
@@ -429,7 +429,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [1], ,
 [prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
 ])
@@ -454,7 +454,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_DEFAULT} -o prog prog.cob])
+AT_CHECK([${COMPILE_DEFAULT} prog.cob])
 AT_CHECK([java prog], [0])
 
 AT_CLEANUP
@@ -477,7 +477,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_JP_COMPAT_DEFAULT} -o prog prog.cob])
+AT_CHECK([${COMPILE_JP_COMPAT_DEFAULT} prog.cob])
 AT_CHECK([java prog], [1], ,
 [libcob: Subscript of 'X' out of bounds: 0
 ])

--- a/tests/syntax.src/assign-external.at
+++ b/tests/syntax.src/assign-external.at
@@ -25,7 +25,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} --assign_external -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} --assign_external prog.cob])
 AT_CHECK([export TEST_FILE=TEST-ext && ${COBCRUN} prog])
 AT_CHECK([if test -f TEST-dyn ; then echo -n OK ; else echo -n NG ; fi], [0], [OK])
 

--- a/tests/syntax.src/copy.at
+++ b/tests/syntax.src/copy.at
@@ -60,7 +60,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -89,7 +89,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -119,7 +119,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OKOK])
 
 AT_CLEANUP
@@ -149,7 +149,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
@@ -176,7 +176,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [ZZ  ZZ])
 
 AT_CLEANUP

--- a/tests/syntax.src/error-recovery.at
+++ b/tests/syntax.src/error-recovery.at
@@ -11,7 +11,7 @@ AT_DATA([prog.cob], [
        PROCEDURE        DIVISION.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob], [1], ,
+AT_CHECK([${COMPILE} prog.cob], [1], ,
 [prog.cob:6: Error: syntax error, unexpected '.'
 prog.cob:7: Error: PICTURE clause required for 'X'
 ])
@@ -34,7 +34,7 @@ AT_DATA([prog.cob], [
            END-IF.
 ])
 
-AT_CHECK([${COMPILE} -o prog prog.cob], [1], ,
+AT_CHECK([${COMPILE} prog.cob], [1], ,
 [prog.cob:8: Error: syntax error, unexpected SECTION, expecting '.'
 prog.cob:10: Error: 'NOWHERE' undefined in SPECIAL-NAMES
 prog.cob:11: Error: 'ZZ' undefined

--- a/tests/syntax.src/unmatured-copy.at
+++ b/tests/syntax.src/unmatured-copy.at
@@ -15,7 +15,7 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([echo -n '       01 TEST-VAR PIC X(2) VALUE "OK".' > copy.inc
 ])
-AT_CHECK([${COMPILE} -o prog prog.cob], [0], ,
+AT_CHECK([${COMPILE} prog.cob], [0], ,
 [copy.inc:1: Warning: Line not terminated by a newline
 ])
 AT_CHECK([java prog], [0], [OK])


### PR DESCRIPTION
# -j option
In order to specify the directory where generated java files are stored, use `-j <dir>` command line option.
`-java-file-path=<dir>` has the same effect as `-j <dir>`.

# -o option
We can specify the directory where generated class files are stored, use `-o <dir>` command line option.
`-class-file-path=<dir>` has the same effect as `-o <dir>`.