### PR TITLE
Fix the method `realPutSign` of `AbstractCobolField`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,23 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v2
+
+    - name: Install dependencies on Ubuntu 22.04
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y default-jdk build-essential bison flex gettext texinfo automake autoconf
+      
+    - name: Install opensource COBOL 4J
+      run: |
+        mkdir ~/.java_lib
+        curl -L -o ~/.java_lib/sqlite.jar https://github.com/xerial/sqlite-jdbc/releases/download/3.36.0.3/sqlite-jdbc-3.36.0.3.jar
+        export CLASSPATH=":$HOME/.java_lib/sqlite.jar"
+        ./configure --prefix=/usr/
+        make
+        sudo make install
+        export CLASSPATH=":/usr/lib/opensourcecobol4j/libcobj.jar:$HOME/.java_lib/sqlite.jar"
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "develop" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -40,7 +40,7 @@ public abstract class AbstractCobolField {
   static CobolDataStorage lastdata = null;
 
   static final int[] cobExp10 = {
-    1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
+      1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
   };
 
   /**
@@ -48,14 +48,15 @@ public abstract class AbstractCobolField {
    *
    * @author y-sakamoto
    */
-  protected class GotoException extends Exception {}
+  protected class GotoException extends Exception {
+  }
 
   /**
    * コンストラクタ
    *
-   * @param size データを格納するバイト配列の長さ
+   * @param size        データを格納するバイト配列の長さ
    * @param dataStorage データを格納するバイト配列を扱うオブジェクト
-   * @param attribute 変数に関する様々な情報を保持するオブジェクト(符号付か,COMP-3指定かなど)
+   * @param attribute   変数に関する様々な情報を保持するオブジェクト(符号付か,COMP-3指定かなど)
    */
   public AbstractCobolField(int size, CobolDataStorage dataStorage, CobolFieldAttribute attribute) {
     this.size = size;
@@ -63,7 +64,8 @@ public abstract class AbstractCobolField {
     this.attribute = attribute;
   }
 
-  public AbstractCobolField() {}
+  public AbstractCobolField() {
+  }
 
   /**
    * メンバ変数dataStorageのgetter
@@ -129,7 +131,8 @@ public abstract class AbstractCobolField {
   }
 
   /**
-   * opensource COBOLのCOB_FIELD_DATAに相当するメソッド バイト配列の中で(符号データではなく)数値データの格納されている最小の添え字を返す opensource
+   * opensource COBOLのCOB_FIELD_DATAに相当するメソッド
+   * バイト配列の中で(符号データではなく)数値データの格納されている最小の添え字を返す opensource
    * COBOLではポインタを返しているが,このメソッドは添え字を返す
    *
    * @return SIGN_LEADINGかつSIGN_SEPARATEなら1,それ以外は0
@@ -139,13 +142,12 @@ public abstract class AbstractCobolField {
   }
 
   public byte[] getBytes() {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage n = new CobolDataStorage(new byte[4], 0);
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, n, attr);
     temp.moveFrom(this);
@@ -163,13 +165,12 @@ public abstract class AbstractCobolField {
    * @return
    */
   public int getInt() {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage n = new CobolDataStorage(new byte[4], 0);
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, n, attr);
     temp.moveFrom(this);
@@ -280,7 +281,7 @@ public abstract class AbstractCobolField {
    * libcob/numeric.cのcob_addの実装 thisの保持する数値データに,引数で与えられたフィールドの保持する数値データを加算する
    *
    * @param field 加算する数値を保持するフィールド
-   * @param opt 加算に関するオプション.詳しくはopensourceCOBOLを参照
+   * @param opt   加算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 加算後のthisの保持する数値データ
    */
   public int add(AbstractCobolField field, int opt) throws CobolStopRunException {
@@ -294,7 +295,7 @@ public abstract class AbstractCobolField {
    * libcob/numeric.cのcob_subの実装 thisの保持する数値データに,引数で与えられたフィールドの保持する数値データを減算する
    *
    * @param field 減算する数値を保持するフィールド
-   * @param opt 減算に関するオプション.詳しくはopensourceCOBOLを参照
+   * @param opt   減算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 減算後のthisの保持する数値データ
    */
   public int sub(AbstractCobolField field, int opt) throws CobolStopRunException {
@@ -619,13 +620,12 @@ public abstract class AbstractCobolField {
     CobolDataStorage storage = new CobolDataStorage(bytes.length);
     storage.memcpy(bytes);
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_ALPHANUMERIC,
-            bytes.length,
-            0,
-            0,
-            String.format("X(%d)", bytes.length));
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_ALPHANUMERIC,
+        bytes.length,
+        0,
+        0,
+        String.format("X(%d)", bytes.length));
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(bytes.length, storage, attr);
     this.moveFrom(tmp);
@@ -647,13 +647,12 @@ public abstract class AbstractCobolField {
       storage.setByte(length - 1, (byte) (storage.getByte(length - 1) + 0x40));
     }
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-            length,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            "S9(10)");
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+        length,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        "S9(10)");
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(length, storage, attr);
     this.moveFrom(tmp);
@@ -680,13 +679,12 @@ public abstract class AbstractCobolField {
     CobolDataStorage storage = new CobolDataStorage(ss.length());
     storage.memcpy(ss, ss.length());
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-            ss.length(),
-            scale,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            "");
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+        ss.length(),
+        scale,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        "");
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(ss.length(), storage, attr);
     if (number < 0) {
@@ -707,7 +705,8 @@ public abstract class AbstractCobolField {
    *
    * @param s
    */
-  public void checkNumeric(String s) {}
+  public void checkNumeric(String s) {
+  }
 
   // TODO abstract指定
   /**
@@ -840,24 +839,22 @@ public abstract class AbstractCobolField {
     CobolDataStorage data = new CobolDataStorage(48);
     if (attr.isTypeNumeric()) {
       if (!attr.isTypeNumericDisplay()) {
-        CobolFieldAttribute newAttr =
-            new CobolFieldAttribute(
-                CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-                attr.getDigits(),
-                attr.getScale(),
-                attr.getFlags() & (~CobolFieldAttribute.COB_FLAG_HAVE_SIGN),
-                attr.getPic());
+        CobolFieldAttribute newAttr = new CobolFieldAttribute(
+            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+            attr.getDigits(),
+            attr.getScale(),
+            attr.getFlags() & (~CobolFieldAttribute.COB_FLAG_HAVE_SIGN),
+            attr.getPic());
         CobolNumericField temp = new CobolNumericField(attr.getDigits(), data, newAttr);
         temp.moveFrom(field);
         field = temp;
       } else if (attr.isFlagHaveSign()) {
-        CobolFieldAttribute newAttr =
-            new CobolFieldAttribute(
-                CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-                attr.getDigits(),
-                attr.getScale(),
-                CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-                attr.getPic());
+        CobolFieldAttribute newAttr = new CobolFieldAttribute(
+            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+            attr.getDigits(),
+            attr.getScale(),
+            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+            attr.getPic());
         CobolNumericField temp = new CobolNumericField(attr.getDigits(), data, newAttr);
         temp.moveFrom(field);
         field = temp;
@@ -1021,7 +1018,8 @@ public abstract class AbstractCobolField {
   }
 
   /**
-   * libcob/common.cのcob_field_to_stringの実装 TODO CobolNationalFieldでオーバーライドしなくても済むように修正する.
+   * libcob/common.cのcob_field_to_stringの実装 TODO
+   * CobolNationalFieldでオーバーライドしなくても済むように修正する.
    *
    * @return this.dataの保持するデータを文字列にして返す.
    */
@@ -1038,13 +1036,12 @@ public abstract class AbstractCobolField {
 
   /** libcob/move.cのcob_set_intの実装 */
   public void setInt(int n) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage data = new CobolDataStorage(ByteBuffer.allocate(4).putInt(n).array());
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, data, attr);
     this.moveFrom(temp);
@@ -1062,10 +1059,8 @@ public abstract class AbstractCobolField {
    * @param size
    */
   public void memcpy(byte[] src, int size) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null);
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(size, new CobolDataStorage(src), attr);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(size, new CobolDataStorage(src), attr);
     this.moveFrom(temp);
   }
 
@@ -1262,14 +1257,13 @@ public abstract class AbstractCobolField {
     int sign = 0;
 
     if ((this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL
-            || this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_NATIONAL_ALL)
+        || this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_NATIONAL_ALL)
         && this.getSize() < other.getSize()) {
       int size = other.getSize();
       CobolDataStorage data = other.getDataStorage();
       sign = other.getSign();
       CobolDataStorage s = CobolModule.getCurrentModule().collating_sequence;
-      OUTSIDE:
-      do {
+      OUTSIDE: do {
         while (size >= this.getSize()) {
           ret = comparator.compare(this.getDataStorage(), data, this.getSize(), s);
           if (ret != 0) {
@@ -1287,8 +1281,7 @@ public abstract class AbstractCobolField {
       CobolDataStorage data = this.getDataStorage();
       sign = this.getSign();
       CobolDataStorage s = CobolModule.getCurrentModule().collating_sequence;
-      OUTSIDE:
-      do {
+      OUTSIDE: do {
         while (size >= other.getSize()) {
           ret = comparator.compare(data, other.getDataStorage(), other.getSize(), s);
           if (ret != 0) {
@@ -1330,15 +1323,13 @@ public abstract class AbstractCobolField {
     if (ret == 0) {
       if (lf.getSize() > sf.getSize()) {
         if ((lf.getAttribute().getType() & CobolFieldAttribute.COB_TYPE_NATIONAL) != 0) {
-          ret =
-              CobolUtil.isNationalPadding(
-                  lf.getDataStorage().getSubDataStorage(sf.getSize()), lf.getSize() - sf.getSize());
+          ret = CobolUtil.isNationalPadding(
+              lf.getDataStorage().getSubDataStorage(sf.getSize()), lf.getSize() - sf.getSize());
         } else {
-          ret =
-              CobolUtil.commonCmpc(
-                  lf.getDataStorage().getSubDataStorage(sf.getSize()),
-                  (byte) ' ',
-                  lf.getSize() - sf.getSize());
+          ret = CobolUtil.commonCmpc(
+              lf.getDataStorage().getSubDataStorage(sf.getSize()),
+              (byte) ' ',
+              lf.getSize() - sf.getSize());
         }
         if (this.getSize() < other.getSize()) {
           ret = -ret;
@@ -1454,6 +1445,7 @@ public abstract class AbstractCobolField {
         } else if (sign < 0) {
           p.setByte(0, (byte) (b + 0x40));
         }
+        return;
       case CobolFieldAttribute.COB_TYPE_NUMERIC_PACKED:
         p = this.getDataStorage().getSubDataStorage(this.size - 1);
         if (sign < 0) {
@@ -1474,13 +1466,12 @@ public abstract class AbstractCobolField {
    */
   public long getLong() {
     long n;
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            18,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        18,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     byte[] data = new byte[8];
     CobolDataStorage storage = new CobolDataStorage(data);
     AbstractCobolField field = CobolFieldFactory.makeCobolField(8, storage, attr);
@@ -1492,7 +1483,8 @@ public abstract class AbstractCobolField {
     return 0;
   }
 
-  public void setLongValue(long n) {}
+  public void setLongValue(long n) {
+  }
 
   /**
    * libcob/move.cのcob_hankaku_moveの実装


### PR DESCRIPTION
The implementation of `realPutSign` was slightly different form `cob_real_put_sign` of libcob/common.c of opensource COBOL.
Although no test case detected the bug caused by `realPutSign`, I fixed the implementation of `realPutSign`.