### PR TITLE
Improve the performance of converting Strings to byte arrays

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -496,7 +496,7 @@ static void joutput_string_write(const unsigned char *s, int size, int printable
     if (param_wrap_string_flag) {
       joutput("makeCobolDataStorage(");
     } else {
-      joutput("CobolUtil.stringToBytes(");
+      joutput("CobolUtil.toBytes(");
     }
 
     for (i = 0; i < size; i++) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -493,7 +493,11 @@ static void joutput_string_write(const unsigned char *s, int size, int printable
 
     joutput("\")");
   } else {
-    joutput("makeCobolDataStorage(");
+    if (param_wrap_string_flag) {
+      joutput("makeCobolDataStorage(");
+    } else {
+      joutput("CobolUtil.stringToBytes(");
+    }
 
     for (i = 0; i < size; i++) {
       joutput("(byte)0x%02x", s[i]);
@@ -550,15 +554,11 @@ static void joutput_all_string_literals() {
 	int tmp_param_wrap_string_flag = param_wrap_string_flag;
 
 	while(l != NULL) {
-	  if(l->printable) {
-        if(l->param_wrap_string_flag) {
-          data_type = data_type_storage;
-        } else {
-          data_type = data_type_bytes;
-        }
-	  } else {
-        data_type = data_type_storage;
-	  }
+    if(l->param_wrap_string_flag) {
+      data_type = data_type_storage;
+    } else {
+      data_type = data_type_bytes;
+    }
 		joutput_prefix();
 		joutput("public static final %s %s = ", data_type, l->var_name);
 		param_wrap_string_flag = l->param_wrap_string_flag;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -476,6 +476,8 @@ static void joutput_string_write(const unsigned char *s, int size, int printable
   if (printable) {
     if (param_wrap_string_flag) {
       joutput("new CobolDataStorage(");
+    } else {
+      joutput("CobolUtil.stringToBytes(");
     }
 
     joutput("\"");
@@ -493,13 +495,7 @@ static void joutput_string_write(const unsigned char *s, int size, int printable
                          ((0x81 <= c && c <= 0x9f) || (0xe0 <= c && c <= 0xef));
     }
 
-    joutput("\"");
-
-    if (param_wrap_string_flag) {
-      joutput(")");
-    } else if(flag_convert_to_byte == CONVERT_STRING_TO_BYTES) {
-      joutput(".getBytes()");
-    }
+    joutput("\")");
   } else {
     joutput("makeCobolDataStorage(");
 
@@ -554,22 +550,19 @@ joutput_string(const unsigned char *s, int size, int flag_convert_to_byte) {
 static void joutput_all_string_literals() {
   const char* data_type_storage = "CobolDataStorage";
   const char* data_type_bytes = "byte[]";
-  const char* data_type_string = "String";
 	const char* data_type;
 	struct string_literal_cache* l = string_literal_list;
 	int tmp_param_wrap_string_flag = param_wrap_string_flag;
 
 	while(l != NULL) {
 	  if(l->printable) {
-      if(l->param_wrap_string_flag) {
-        data_type = data_type_storage;
-      } else if(l->flag_convert_to_byte == CONVERT_STRING_TO_BYTES) {
-        data_type = data_type_bytes;
-      } else {
-        data_type = data_type_string;
-      }
+        if(l->param_wrap_string_flag) {
+          data_type = data_type_storage;
+        } else {
+          data_type = data_type_bytes;
+        }
 	  } else {
-      data_type = data_type_storage;
+        data_type = data_type_storage;
 	  }
 		joutput_prefix();
 		joutput("public static final %s %s = ", data_type, l->var_name);
@@ -2245,7 +2238,7 @@ static void joutput_initialize_one(struct cb_initialize *p, cb_tree x) {
           }
           joutput_data(x);
           joutput(".setBytes (");
-          joutput_string((ucharptr)buff, f->size, DO_NOT_CONVERT_STRING_TO_BYTES);
+          joutput_string((ucharptr)buff, f->size, CONVERT_STRING_TO_BYTES);
           joutput(", %d);\n", f->size);
         }
       }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -25,11 +25,11 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** TODO 暫定的に作ったクラス ここに実装されたメソッドは別の適切なクラスに実装する、または適切なクラス名に変更する */
 public class CobolCheck {
-  public static void checkSubscript(int i, int min, int max, String name) {
+  public static void checkSubscript(int i, int min, int max, byte[] name) {
     // TODO 実装 (libcob/common.c)
   }
 
-  public static void checkSubscript(long i, int min, int max, String name) {
+  public static void checkSubscript(long i, int min, int max, byte[] name) {
     CobolCheck.checkSubscript((int) i, min, max, name);
   }
 
@@ -37,7 +37,7 @@ public class CobolCheck {
     // TODO 実装
   }
 
-  public static void checkSubscript(CobolDataStorage i, int min, int max, String name) {
+  public static void checkSubscript(CobolDataStorage i, int min, int max, byte[] name) {
     // TODO 実装 (libcob/common.c)
   }
 

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -18,6 +18,7 @@
  */
 package jp.osscons.opensourcecobol.libcobj.common;
 
+import java.io.UnsupportedEncodingException;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.Calendar;
@@ -687,5 +688,13 @@ public class CobolUtil {
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {
     CobolUtil.envVarTable.setProperty(envVarName.getString().trim(), envVarValue.getString());
+  }
+
+  public static byte[] stringToBytes(String s) {
+    try {
+      return s.getBytes("Shift_JIS");
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
   }
 }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -698,7 +698,7 @@ public class CobolUtil {
     }
   }
 
-  public static byte[] stringToBytes(byte... bytes) {
+  public static byte[] toBytes(byte... bytes) {
     return bytes;
   }
 }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -125,8 +125,7 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block:
-        if (m.groupCount() != 3) {
+        date_time_block: if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -162,11 +161,10 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm =
-          CobolUtil.cobLocalTm
-              .withHour(rt.getHour())
-              .withMinute(rt.getMinute())
-              .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
+          .withHour(rt.getHour())
+          .withMinute(rt.getMinute())
+          .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -548,8 +546,7 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP:
-    while (i < size && ret != 0) {
+    OUTER_LOOP: while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -682,8 +679,9 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName the name of an environment variable. The leading and trailing spaces are
-   *     ignored.
+   * @param envVarName  the name of an environment variable. The leading and
+   *                    trailing spaces are
+   *                    ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {
@@ -696,5 +694,9 @@ public class CobolUtil {
     } catch (UnsupportedEncodingException e) {
       return null;
     }
+  }
+
+  public static byte[] stringToBytes(byte... bytes) {
+    return bytes;
   }
 }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -125,7 +125,8 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block: if (m.groupCount() != 3) {
+        date_time_block:
+        if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -161,10 +162,11 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
-          .withHour(rt.getHour())
-          .withMinute(rt.getMinute())
-          .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm =
+          CobolUtil.cobLocalTm
+              .withHour(rt.getHour())
+              .withMinute(rt.getMinute())
+              .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -546,7 +548,8 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP: while (i < size && ret != 0) {
+    OUTER_LOOP:
+    while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -679,9 +682,8 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName  the name of an environment variable. The leading and
-   *                    trailing spaces are
-   *                    ignored.
+   * @param envVarName the name of an environment variable. The leading and trailing spaces are
+   *     ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -694,9 +694,7 @@ public abstract class AbstractCobolField {
    *
    * @param s
    */
-  public void checkNumeric(String s) {
-    System.err.println("checkNumeric is not implemented");
-  }
+  public void checkNumeric(byte[] s) {}
 
   // TODO abstract指定
   /**

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
@@ -37,6 +37,11 @@ public class CobolFieldFactory {
     return CobolFieldFactory.makeCobolField(size, new CobolDataStorage(str), attr);
   }
 
+  public static AbstractCobolField makeCobolField(
+      int size, byte[] bytes, CobolFieldAttribute attr) {
+    return CobolFieldFactory.makeCobolField(size, new CobolDataStorage(bytes), attr);
+  }
+
   /**
    * attrに設定された値に応じて適切なAbstractCobolFieldクラスのサブクラスの コンストラクタを呼びだす。
    *

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -39,8 +39,8 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr trueなら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
-   * @param fields 出力する変数(可変長)
+   * @param newline  trueなら出力後に改行しない,それ以外の場合は改行する
+   * @param fields   出力する変数(可変長)
    */
   public static void display(boolean dispStdout, boolean newline, AbstractCobolField... fields) {
     PrintStream stream = dispStdout ? System.out : System.err;
@@ -68,9 +68,9 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr 0なら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline 0なら出力後に改行しない,それ以外の場合は改行する
-   * @param varcnt 出力する変数の数
-   * @param fields 出力する変数(可変長)
+   * @param newline  0なら出力後に改行しない,それ以外の場合は改行する
+   * @param varcnt   出力する変数の数
+   * @param fields   出力する変数(可変長)
    */
   public static void display(int outorerr, int newline, int varcnt, AbstractCobolField... fields) {
     PrintStream stream = outorerr == 0 ? System.out : System.err;
@@ -275,11 +275,9 @@ public class CobolTerminal {
    * @param f
    */
   public static void displayArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     temp.moveFrom(f);
     int n = ByteBuffer.wrap(data).getInt();
     if (n < 0 || n > CobolUtil.commandLineArgs.length) {
@@ -295,12 +293,10 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
     ByteBuffer.wrap(data).putInt(CobolUtil.commandLineArgs.length);
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     f.moveFrom(temp);
   }
 
@@ -310,8 +306,6 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgValue(AbstractCobolField f) {
-    // System.out.println("[dbg]CobolUtil.currentArgIndex=" +
-    // CobolUtil.currentArgIndex);
     if (CobolUtil.currentArgIndex > CobolUtil.commandLineArgs.length) {
       CobolException.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
       return;

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -39,8 +39,8 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr trueなら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline  trueなら出力後に改行しない,それ以外の場合は改行する
-   * @param fields   出力する変数(可変長)
+   * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
+   * @param fields 出力する変数(可変長)
    */
   public static void display(boolean dispStdout, boolean newline, AbstractCobolField... fields) {
     PrintStream stream = dispStdout ? System.out : System.err;
@@ -68,9 +68,9 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr 0なら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline  0なら出力後に改行しない,それ以外の場合は改行する
-   * @param varcnt   出力する変数の数
-   * @param fields   出力する変数(可変長)
+   * @param newline 0なら出力後に改行しない,それ以外の場合は改行する
+   * @param varcnt 出力する変数の数
+   * @param fields 出力する変数(可変長)
    */
   public static void display(int outorerr, int newline, int varcnt, AbstractCobolField... fields) {
     PrintStream stream = outorerr == 0 ? System.out : System.err;
@@ -275,9 +275,11 @@ public class CobolTerminal {
    * @param f
    */
   public static void displayArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr =
+        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
-    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp =
+        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     temp.moveFrom(f);
     int n = ByteBuffer.wrap(data).getInt();
     if (n < 0 || n > CobolUtil.commandLineArgs.length) {
@@ -293,10 +295,12 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr =
+        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
     ByteBuffer.wrap(data).putInt(CobolUtil.commandLineArgs.length);
-    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp =
+        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     f.moveFrom(temp);
   }
 

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -39,8 +39,8 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr trueなら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
-   * @param fields 出力する変数(可変長)
+   * @param newline  trueなら出力後に改行しない,それ以外の場合は改行する
+   * @param fields   出力する変数(可変長)
    */
   public static void display(boolean dispStdout, boolean newline, AbstractCobolField... fields) {
     PrintStream stream = dispStdout ? System.out : System.err;
@@ -68,9 +68,9 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr 0なら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline 0なら出力後に改行しない,それ以外の場合は改行する
-   * @param varcnt 出力する変数の数
-   * @param fields 出力する変数(可変長)
+   * @param newline  0なら出力後に改行しない,それ以外の場合は改行する
+   * @param varcnt   出力する変数の数
+   * @param fields   出力する変数(可変長)
    */
   public static void display(int outorerr, int newline, int varcnt, AbstractCobolField... fields) {
     PrintStream stream = outorerr == 0 ? System.out : System.err;
@@ -275,14 +275,12 @@ public class CobolTerminal {
    * @param f
    */
   public static void displayArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     temp.moveFrom(f);
     int n = ByteBuffer.wrap(data).getInt();
-    if (n < 0 || n >= CobolUtil.commandLineArgs.length) {
+    if (n < 0 || n > CobolUtil.commandLineArgs.length) {
       CobolException.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
       return;
     }
@@ -295,12 +293,10 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
     ByteBuffer.wrap(data).putInt(CobolUtil.commandLineArgs.length);
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     f.moveFrom(temp);
   }
 
@@ -310,6 +306,8 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgValue(AbstractCobolField f) {
+    // System.out.println("[dbg]CobolUtil.currentArgIndex=" +
+    // CobolUtil.currentArgIndex);
     if (CobolUtil.currentArgIndex > CobolUtil.commandLineArgs.length) {
       CobolException.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
       return;


### PR DESCRIPTION
This modification has approximately quadrupled the execution speed of the following programs on my machine.
This fix solve the performance problem partially (Issue #106)

```cobol
       IDENTIFICATION   DIVISION.
       PROGRAM-ID.      prog.
       DATA             DIVISION.
       WORKING-STORAGE  SECTION.
       01  STR   PIC X(5).
       01 IDX PIC 9(12).
       PROCEDURE        DIVISION.
           PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX >= 400000000
                  MOVE "HELLO" TO STR
           END-PERFORM
           STOP RUN.
```

The older version of opensource COBOL generates the following code for the above MOVE statement.

```java
b_STR.setBytes ("HELLO", 5);
```

Since `setBytes` internally converts String to a byte array, the COBOL program converts String to a byte array for each loop iteration. On the other hand, the newer version generates the following code and the generated program converts "HELLO" to a byte array only once during the program execution.

```java
b_STR.setBytes (str_literal_1_HELLO, 5);

// variables declaration
public static final byte[] str_literal_1_HELLO = CobolUtil.stringToBytes("HELLO");
```