### PR TITLE
Refactor generated Java files

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -494,7 +494,7 @@ static void joutput_string_write(const unsigned char *s, int size, int printable
     joutput("\")");
   } else {
     if (param_wrap_string_flag) {
-      joutput("makeCobolDataStorage(");
+      joutput("CobolDataStorage.makeCobolDataStorage(");
     } else {
       joutput("CobolUtil.toBytes(");
     }
@@ -5876,11 +5876,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
     }
   }
   joutput("\n");
-
-  joutput_line(
-      "private static CobolDataStorage makeCobolDataStorage(byte ...bytes) {");
-  joutput_line("  return new CobolDataStorage(bytes);");
-  joutput_line("}");
 
   /* CALL cache */
   if (call_cache) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5877,29 +5877,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   }
   joutput("\n");
 
-  //未実装のメソッド群の出力
-  joutput_line("private void cobolPushCallStackList(String programId)");
-  joutput_line("{");
-  joutput_line("}\n");
-
-  joutput_line("private void cobolFatalError(int errorCode)");
-  joutput_line("{");
-  joutput_line("}\n");
-
-  joutput_line("private void cobolCheckVersion(String sourceFile, int "
-               "packageVersion, int patchVersion)");
-  joutput_line("{");
-  joutput_line("}\n");
-
-  joutput_line(
-      "private void cobolSetCancel(String programId, Object a, Object b)");
-  joutput_line("{");
-  joutput_line("}\n");
-
-  joutput_line("private void cobolPopCallStackList()");
-  joutput_line("{");
-  joutput_line("}\n");
-
   joutput_line(
       "private static CobolDataStorage makeCobolDataStorage(byte ...bytes) {");
   joutput_line("  return new CobolDataStorage(bytes);");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5737,10 +5737,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput_line("private boolean initialized = false;");
   joutput_line("private CobolModule cobolCurrentModule;");
   joutput_line("private CobolModule module;");
-  joutput_line("private CobolFrame frame;");
-  joutput_line("private static boolean cobolInitialized = false;");
-  joutput_line("private CobolCallParams cobolSaveCallParams = null;");
-  joutput_line("private CobolCallParams cobolCallParams = null;");
   joutput_line("private boolean cobolErrorOnExitFlag;");
   joutput_line("private int entry;");
   joutput("\n");
@@ -5832,7 +5828,7 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput_indent_level += 2;
 
   // if (prog->flag_main) {
-  joutput_line("CobolUtil.cob_init(args, cobolInitialized);");
+  joutput_line("CobolUtil.cob_init(args, false);");
   //}
 
   joutput_line("CobolDecimal.cobInitNumeric();");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -553,6 +553,10 @@ static void joutput_all_string_literals() {
 	struct string_literal_cache* l = string_literal_list;
 	int tmp_param_wrap_string_flag = param_wrap_string_flag;
 
+  if(l != NULL) {
+	  joutput_line("/* String literals */");
+  }
+
 	while(l != NULL) {
     if(l->param_wrap_string_flag) {
       data_type = data_type_storage;
@@ -5861,7 +5865,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput("\n");
 
 	//Output the declarations of string literals
-	joutput_line("/* String literals */");
 	joutput_all_string_literals();
 	free_string_literal_list();
 

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -61,6 +61,10 @@ public class CobolDataStorage {
     this(data, 0);
   }
 
+  public static CobolDataStorage makeCobolDataStorage(byte... bytes) {
+    return new CobolDataStorage(bytes);
+  }
+
   public CobolDataStorage() {
     this.index = 0;
     this.data = null;


### PR DESCRIPTION
* Remove unused variables and method in generated Java files
* Move the definition of the method `makeCobolDataStorage` in generated Java file into `CobolDataStorage.java`
* Suppress unused comments in some cases