### PR TITLE
Fix `syntax` test

### DIFF
--- a/tests/syntax.src/assign-external.at
+++ b/tests/syntax.src/assign-external.at
@@ -1,5 +1,4 @@
 AT_SETUP([ASSIGN TO DYNAMIC create file (assign_external)])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -26,7 +25,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_MODULE} --assign_external prog.cob])
-AT_CHECK([export TEST_FILE=TEST-ext && ${COBCRUN} prog])
+AT_CHECK([export TEST_FILE=TEST-ext && java prog])
 AT_CHECK([if test -f TEST-dyn ; then echo -n OK ; else echo -n NG ; fi], [0], [OK])
 
 AT_CLEANUP

--- a/tests/syntax.src/free-1col-aster.at
+++ b/tests/syntax.src/free-1col-aster.at
@@ -1,6 +1,4 @@
 AT_SETUP([free_1col_aster OPTION])
-AT_CHECK([${SKIP_TEST}])
-
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      prog.
@@ -9,7 +7,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -x -free_1col_aster prog.cob], [0], [])
+AT_CHECK([${COMPILE} -free_1col_aster prog.cob], [0], [])
 
 AT_CLEANUP
 
@@ -24,7 +22,7 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE} -x -free_1col_aster prog.cob], [1], [],
+AT_CHECK([${COMPILE} -free_1col_aster prog.cob], [1], [],
 [prog.cob:6: Error: 'A' undefined
 ])
 


### PR DESCRIPTION
Fix minor errors of `syntax` test in order to pass all testsuite in `syntax` test