### PR TITLE
Optimize comparison of PIC S9(n)V9(m), fix a bug of `COMPUTE` statement and improve testing system

### DIFF
--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -592,45 +592,25 @@ public class CobolDecimal {
     int size = numBuffPtr.length;
 
     CobolDataStorage data = f.getDataStorage();
-    int firstDataIndex = f.getFirstDataIndex();
     int diff = f.getFieldSize() - size;
+
     if (diff < 0) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_SIZE_OVERFLOW);
       if ((opt & CobolDecimal.COB_STORE_KEEP_ON_OVERFLOW) > 0) {
         return CobolRuntimeException.code;
       }
+    }
 
-      BigDecimal val = this.value;
-      for (int i = 0; i < Math.abs(this.scale); ++i) {
-        if (this.scale < 0) {
-          val = val.multiply(BigDecimal.TEN);
-        } else {
-          val = val.divide(BigDecimal.TEN);
-        }
-      }
-      numString = val.toPlainString();
-      int pointIndex = numString.indexOf('.');
-      byte[] numBuff = numString.replace(".", "").getBytes();
-      int d = f.getFieldSize() - f.getAttribute().getScale() - pointIndex;
-      for (int i = 0; i < f.getFieldSize(); ++i) {
-        if (0 <= i - d && i - d < numBuff.length) {
-          data.setByte(i + firstDataIndex, numBuff[i - d]);
-        } else {
-          data.setByte(i + firstDataIndex, (byte) '0');
-        }
-      }
-    } else {
-      int fFirstIndex = f.getFirstDataIndex();
-      int fFieldSize = f.getFieldSize();
-      int fPointIndex = fFieldSize - f.getAttribute().getScale();
-      for (int i = 0; i < fFieldSize; i++) {
-        int fIndex = fFirstIndex + i;
-        int dIndex = i + dPointIndex - fPointIndex;
-        if (0 <= dIndex && dIndex < numBuffPtr.length) {
-          data.setByte(fIndex, numBuffPtr[dIndex]);
-        } else {
-          data.setByte(fIndex, (byte) '0');
-        }
+    int fFirstIndex = f.getFirstDataIndex();
+    int fFieldSize = f.getFieldSize();
+    int fPointIndex = fFieldSize - f.getAttribute().getScale();
+    for (int i = 0; i < fFieldSize; i++) {
+      int fIndex = fFirstIndex + i;
+      int dIndex = i + dPointIndex - fPointIndex;
+      if (0 <= dIndex && dIndex < numBuffPtr.length) {
+        data.setByte(fIndex, numBuffPtr[dIndex]);
+      } else {
+        data.setByte(fIndex, (byte) '0');
       }
     }
     f.putSign(sign);

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -966,13 +966,25 @@ public class CobolNumericField extends AbstractCobolField {
       final int r2 = fieldSize2 - pointIndex2;
       final int left = Math.min(l1, l2);
       final int right = Math.max(r1, r2);
+      final int lastIndex1;
+      if(attr1.isFlagHaveSign() && !attr1.isFlagSignLeading() && attr1.isFlagSignSeparate()) {
+        lastIndex1 = size1 - 2;
+      } else {
+        lastIndex1 = size1 - 1;
+      }
+      final int lastIndex2;
+      if(attr2.isFlagHaveSign() && !attr2.isFlagSignLeading() && attr2.isFlagSignSeparate()) {
+        lastIndex2 = size2 - 2;
+      } else {
+        lastIndex2 = size2 - 1;
+      }
       CobolDataStorage d1 = this.getDataStorage();
       CobolDataStorage d2 = field.getDataStorage();
       for (int i = left; i < right; ++i) {
         final int i1 = firstIndex1 + i + pointIndex1;
         final int i2 = firstIndex2 + i + pointIndex2;
         byte b1;
-        if (i1 < 0 || i1 >= size1) {
+        if (i1 < 0 || i1 > lastIndex1) {
           b1 = (byte) '0';
         } else {
           b1 = d1.getByte(i1);
@@ -981,7 +993,7 @@ public class CobolNumericField extends AbstractCobolField {
           }
         }
         byte b2;
-        if (i2 < 0 || i2 >= size2) {
+        if (i2 < 0 || i2 > lastIndex2) {
           b2 = (byte) '0';
         } else {
           b2 = d2.getByte(i2);

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -984,7 +984,7 @@ public class CobolNumericField extends AbstractCobolField {
         if (i2 < 0 || i2 >= size2) {
           b2 = (byte) '0';
         } else {
-          b2 = d2.getByte(i1);
+          b2 = d2.getByte(i2);
           if (i2 == signIndex2 && b2 >= 0x70) {
             b2 -= 0x40;
           }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -967,13 +967,13 @@ public class CobolNumericField extends AbstractCobolField {
       final int left = Math.min(l1, l2);
       final int right = Math.max(r1, r2);
       final int lastIndex1;
-      if(attr1.isFlagHaveSign() && !attr1.isFlagSignLeading() && attr1.isFlagSignSeparate()) {
+      if (attr1.isFlagHaveSign() && !attr1.isFlagSignLeading() && attr1.isFlagSignSeparate()) {
         lastIndex1 = size1 - 2;
       } else {
         lastIndex1 = size1 - 1;
       }
       final int lastIndex2;
-      if(attr2.isFlagHaveSign() && !attr2.isFlagSignLeading() && attr2.isFlagSignSeparate()) {
+      if (attr2.isFlagHaveSign() && !attr2.isFlagSignLeading() && attr2.isFlagSignSeparate()) {
         lastIndex2 = size2 - 2;
       } else {
         lastIndex2 = size2 - 1;

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -940,32 +940,67 @@ public class CobolNumericField extends AbstractCobolField {
   public int numericCompareTo(AbstractCobolField field) {
     CobolFieldAttribute attr1 = this.getAttribute();
     CobolFieldAttribute attr2 = field.getAttribute();
-    if (!attr1.isFlagHaveSign() && !attr2.isFlagHaveSign() && attr2.isTypeNumericDisplay()) {
+    if (attr2.isTypeNumericDisplay()) {
       final int scale1 = attr1.getScale();
       final int scale2 = attr2.getScale();
-      final int size1 = this.getSize();
-      final int size2 = field.getSize();
-      final int pointIndex1 = size1 - scale1;
-      final int pointIndex2 = size2 - scale2;
+      final int firstIndex1 = this.getFirstDataIndex();
+      final int firstIndex2 = field.getFirstDataIndex();
+      final int fieldSize1 = this.getFieldSize();
+      final int fieldSize2 = field.getFieldSize();
+      final int size1 = this.getFieldSize();
+      final int size2 = field.getFieldSize();
+      final int pointIndex1 = fieldSize1 - scale1;
+      final int pointIndex2 = fieldSize2 - scale2;
+      int sign1 = this.getSign();
+      int sign2 = field.getSign();
+      sign1 = sign1 > 0 ? 1 : sign1 < 0 ? -1 : 1;
+      sign2 = sign2 > 0 ? 1 : sign2 < 0 ? -1 : 1;
 
+      final int signIndex1 =
+          attr1.isFlagHaveSign() && !attr1.isFlagSignLeading() ? size1 - 1 : firstIndex1;
+      final int signIndex2 =
+          attr2.isFlagHaveSign() && !attr2.isFlagSignLeading() ? size2 - 1 : firstIndex2;
       final int l1 = -pointIndex1;
       final int l2 = -pointIndex2;
-      final int r1 = size1 - pointIndex1;
-      final int r2 = size2 - pointIndex2;
+      final int r1 = fieldSize1 - pointIndex1;
+      final int r2 = fieldSize2 - pointIndex2;
       final int left = Math.min(l1, l2);
       final int right = Math.max(r1, r2);
       CobolDataStorage d1 = this.getDataStorage();
       CobolDataStorage d2 = field.getDataStorage();
       for (int i = left; i < right; ++i) {
-        final int i1 = i + pointIndex1;
-        final int i2 = i + pointIndex2;
-        byte b1 = i1 < 0 || i1 >= size1 ? (byte) '0' : d1.getByte(i1);
-        byte b2 = i2 < 0 || i2 >= size2 ? (byte) '0' : d2.getByte(i2);
+        final int i1 = firstIndex1 + i + pointIndex1;
+        final int i2 = firstIndex2 + i + pointIndex2;
+        byte b1;
+        if (i1 < 0 || i1 >= size1) {
+          b1 = (byte) '0';
+        } else {
+          b1 = d1.getByte(i1);
+          if (i1 == signIndex1 && b1 >= 0x70) {
+            b1 -= 0x40;
+          }
+        }
+        byte b2;
+        if (i2 < 0 || i2 >= size2) {
+          b2 = (byte) '0';
+        } else {
+          b2 = d2.getByte(i1);
+          if (i2 == signIndex2 && b2 >= 0x70) {
+            b2 -= 0x40;
+          }
+        }
         if (b1 != b2) {
-          return ((int) b1) - ((int) b2);
+          return (sign1 * (int) b1) - (sign2 * (int) b2);
         }
       }
-      return 0;
+
+      if (sign1 * sign2 >= 0) {
+        return 0;
+      } else if (sign1 > 0) {
+        return 1;
+      } else {
+        return -1;
+      }
     } else {
       return super.numericCompareTo(field);
     }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -947,8 +947,8 @@ public class CobolNumericField extends AbstractCobolField {
       final int firstIndex2 = field.getFirstDataIndex();
       final int fieldSize1 = this.getFieldSize();
       final int fieldSize2 = field.getFieldSize();
-      final int size1 = this.getFieldSize();
-      final int size2 = field.getFieldSize();
+      final int size1 = this.getSize();
+      final int size2 = field.getSize();
       final int pointIndex1 = fieldSize1 - scale1;
       final int pointIndex2 = fieldSize2 - scale2;
       int sign1 = this.getSign();

--- a/tests/cobol85/Makefile.am
+++ b/tests/cobol85/Makefile.am
@@ -62,7 +62,9 @@ clean-all:
 $(MODULES_MAKEFILES):
 	@echo "test:"               > $@
 	@echo "	. ../../atconfig; . ../../atlocal; export PATH; perl $(COB85DIR)/report.pl" >> $@
+	@echo "	@cat report.txt" >> $@
 
 $(EXTRA_MODULES_MAKEFILES):
 	@echo "test:"               > $@
 	@echo "	. ../../atconfig; . ../../atlocal; export PATH; perl $(COB85DIR)/report.pl" >> $@
+	@echo "	@cat report.txt" >> $@

--- a/tests/cobol85/Makefile.in
+++ b/tests/cobol85/Makefile.in
@@ -530,10 +530,12 @@ clean-all:
 $(MODULES_MAKEFILES):
 	@echo "test:"               > $@
 	@echo "	. ../../atconfig; . ../../atlocal; export PATH; perl $(COB85DIR)/report.pl" >> $@
+	@echo "	@cat report.txt" >> $@
 
 $(EXTRA_MODULES_MAKEFILES):
 	@echo "test:"               > $@
 	@echo "	. ../../atconfig; . ../../atlocal; export PATH; perl $(COB85DIR)/report.pl" >> $@
+	@echo "	@cat report.txt" >> $@
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
* Optimize comparisions between any pairs of the following data
  * `PIC 9(m)`
  * `PIC S9(m)`
  * `PIC S9(m)V9(n)` SIGN LEADING
  * `PIC S9(m)V9(n)` SIGN TRAILING SEPARATE and so on
* Fix a buf of `COMPUTE` statement. With the former version, the following program displays `+00250.000.00`
```cobol
       IDENTIFICATION   DIVISION.
       PROGRAM-ID.      p.
       DATA             DIVISION.
       WORKING-STORAGE SECTION.
       01  WS-NUM              PIC S9(5)V9(6).
       PROCEDURE        DIVISION.
           COMPUTE WS-NUM = FUNCTION ANNUITY(0, 4).
           DISPLAY WS-NUM.
```
* Fix `tests/cobol85/Makefile.am` so that `make tests` displays results whenever all tests of each modules are done.