### PR TITLE
Implement `-debug` option

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -771,6 +771,7 @@ static void cobc_print_usage(void) {
   puts(_("  -free_1col_aster                  Use free(1col_aster) source "
          "format"));
   puts(_("  -g                                Enable Java compiler debug"));
+  puts(_("  -debug                            Enable all run-time error checking"));
   puts(_("  -o <dir>, -class-file-dir=<dir>   Place class files into <dir>"));
   puts(_("  -j <dir>, -java-source-dir=<dir>  Place Java files into <dir>"));
   puts(_("  -E                                Preprocess only; do not compile "

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -841,7 +841,7 @@ cb_tree cb_build_identifier(cb_tree x) {
     if (CB_EXCEPTION_ENABLE(COB_EC_BOUND_REF_MOD)) {
       if (!CB_LITERAL_P(r->offset) || (r->length && !CB_LITERAL_P(r->length))) {
         e1 = cb_build_funcall_4(
-            "cob_check_ref_mod", cb_build_cast_integer(r->offset),
+            "CobolUtil.cobCheckRefMod", cb_build_cast_integer(r->offset),
             r->length ? cb_build_cast_integer(r->length) : cb_int1,
             cb_int(f->size), cb_build_string0((ucharptr)f->name));
         r->check = cb_list_add(r->check, e1);
@@ -853,12 +853,12 @@ cb_tree cb_build_identifier(cb_tree x) {
         if (cb_tree_category(CB_TREE(r)) == CB_CATEGORY_NATIONAL ||
             cb_tree_category(CB_TREE(r)) == CB_CATEGORY_NATIONAL_EDITED) {
           e1 = cb_build_funcall_4(
-              "cob_check_ref_mod_national", cb_build_cast_integer(r->offset),
+              "CobolUtil.cobCheckRefModNational", cb_build_cast_integer(r->offset),
               r->length ? cb_build_cast_integer(r->length) : cb_int2,
               cb_int(f->size), cb_build_string0((ucharptr)f->name));
         } else {
           e1 = cb_build_funcall_4(
-              "cob_check_ref_mod", cb_build_cast_integer(r->offset),
+              "CobolUtil.cobCheckRefMod", cb_build_cast_integer(r->offset),
               r->length ? cb_build_cast_integer(r->length) : cb_int1,
               cb_int(f->size), cb_build_string0((ucharptr)f->name));
         }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -30,6 +30,7 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
 public class CobolUtil {
@@ -99,6 +100,40 @@ public class CobolUtil {
     return cob_io_assume_rewrite;
   }
 
+  public static void cobCheckRefModNational(int offset, int length, int size, byte[] name)
+      throws CobolStopRunException {
+    CobolUtil.cobCheckRefMod(offset, length, size, name);
+  }
+
+  public static void cobCheckRefModNational(int offset, int length, int size, String name)
+      throws CobolStopRunException {
+    CobolUtil.cobCheckRefMod(offset, length, size, name);
+  }
+
+  public static void cobCheckRefMod(int offset, int length, int size, byte[] name) throws CobolStopRunException {
+    try {
+      CobolUtil.cobCheckRefMod(offset, length, size, new String(name, "Shift_JIS"));
+    } catch (UnsupportedEncodingException e) {
+      CobolUtil.cobCheckRefMod(offset, length, size, "");
+    }
+  }
+
+  public static void cobCheckRefMod(int offset, int length, int size, String name) throws CobolStopRunException {
+    /* check the offset */
+    if (offset < 1 || offset > size) {
+      CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
+      CobolRuntimeException.displayRuntimeError(String.format("Offset of '%s' out of bounds: %d", name, offset));
+      CobolStopRunException.stopRunAndThrow(1);
+    }
+
+    /* check the length */
+    if (length < 1 || offset + length - 1 > size) {
+      CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
+      CobolRuntimeException.displayRuntimeError(String.format("Length of '%s' out of bounds: %d", name, length));
+      CobolStopRunException.stopRunAndThrow(1);
+    }
+  }
+
   /** libcob/common.cのcob_initの実装 TODO 未完成 */
   public static void cob_init(String[] argv, boolean cobInitialized) {
     if (!cobInitialized) {
@@ -125,8 +160,7 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block:
-        if (m.groupCount() != 3) {
+        date_time_block: if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -162,11 +196,10 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm =
-          CobolUtil.cobLocalTm
-              .withHour(rt.getHour())
-              .withMinute(rt.getMinute())
-              .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
+          .withHour(rt.getHour())
+          .withMinute(rt.getMinute())
+          .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -548,8 +581,7 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP:
-    while (i < size && ret != 0) {
+    OUTER_LOOP: while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -682,8 +714,9 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName the name of an environment variable. The leading and trailing spaces are
-   *     ignored.
+   * @param envVarName  the name of an environment variable. The leading and
+   *                    trailing spaces are
+   *                    ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -100,17 +100,17 @@ public class CobolUtil {
     return cob_io_assume_rewrite;
   }
 
-  public static void cobCheckRefModNational(int offset, int length, int size, byte[] name)
+  public static void cobCheckRefModNational(int offset, long length, int size, byte[] name)
       throws CobolStopRunException {
     CobolUtil.cobCheckRefMod(offset, length, size, name);
   }
 
-  public static void cobCheckRefModNational(int offset, int length, int size, String name)
+  public static void cobCheckRefModNational(int offset, long length, int size, String name)
       throws CobolStopRunException {
     CobolUtil.cobCheckRefMod(offset, length, size, name);
   }
 
-  public static void cobCheckRefMod(int offset, int length, int size, byte[] name)
+  public static void cobCheckRefMod(int offset, long length, int size, byte[] name)
       throws CobolStopRunException {
     try {
       CobolUtil.cobCheckRefMod(offset, length, size, new String(name, "Shift_JIS"));
@@ -119,7 +119,7 @@ public class CobolUtil {
     }
   }
 
-  public static void cobCheckRefMod(int offset, int length, int size, String name)
+  public static void cobCheckRefMod(int offset, long length, int size, String name)
       throws CobolStopRunException {
     /* check the offset */
     if (offset < 1 || offset > size) {

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -29,8 +29,8 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
 public class CobolUtil {
@@ -110,7 +110,8 @@ public class CobolUtil {
     CobolUtil.cobCheckRefMod(offset, length, size, name);
   }
 
-  public static void cobCheckRefMod(int offset, int length, int size, byte[] name) throws CobolStopRunException {
+  public static void cobCheckRefMod(int offset, int length, int size, byte[] name)
+      throws CobolStopRunException {
     try {
       CobolUtil.cobCheckRefMod(offset, length, size, new String(name, "Shift_JIS"));
     } catch (UnsupportedEncodingException e) {
@@ -118,18 +119,21 @@ public class CobolUtil {
     }
   }
 
-  public static void cobCheckRefMod(int offset, int length, int size, String name) throws CobolStopRunException {
+  public static void cobCheckRefMod(int offset, int length, int size, String name)
+      throws CobolStopRunException {
     /* check the offset */
     if (offset < 1 || offset > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolRuntimeException.displayRuntimeError(String.format("Offset of '%s' out of bounds: %d", name, offset));
+      CobolRuntimeException.displayRuntimeError(
+          String.format("Offset of '%s' out of bounds: %d", name, offset));
       CobolStopRunException.stopRunAndThrow(1);
     }
 
     /* check the length */
     if (length < 1 || offset + length - 1 > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolRuntimeException.displayRuntimeError(String.format("Length of '%s' out of bounds: %d", name, length));
+      CobolRuntimeException.displayRuntimeError(
+          String.format("Length of '%s' out of bounds: %d", name, length));
       CobolStopRunException.stopRunAndThrow(1);
     }
   }
@@ -160,7 +164,8 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block: if (m.groupCount() != 3) {
+        date_time_block:
+        if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -196,10 +201,11 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
-          .withHour(rt.getHour())
-          .withMinute(rt.getMinute())
-          .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm =
+          CobolUtil.cobLocalTm
+              .withHour(rt.getHour())
+              .withMinute(rt.getMinute())
+              .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -581,7 +587,8 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP: while (i < size && ret != 0) {
+    OUTER_LOOP:
+    while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -714,9 +721,8 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName  the name of an environment variable. The leading and
-   *                    trailing spaces are
-   *                    ignored.
+   * @param envVarName the name of an environment variable. The leading and trailing spaces are
+   *     ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -155,7 +155,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/java-package.at \
 	command-line-options.src/edit-code-command.at \
 	command-line-options.src/file-path.at \
-	command-line-options.src/fdefaultbyte.at
+	command-line-options.src/fdefaultbyte.at \
+	command-line-options.src/debug.at
 
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -696,7 +696,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/java-package.at \
 	command-line-options.src/edit-code-command.at \
 	command-line-options.src/file-path.at \
-	command-line-options.src/fdefaultbyte.at
+	command-line-options.src/fdefaultbyte.at \
+	command-line-options.src/debug.at
 
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \

--- a/tests/command-line-options.at
+++ b/tests/command-line-options.at
@@ -16,5 +16,6 @@ m4_include([fserial-variable.at])
 m4_include([fshort-variable.at])
 m4_include([file-path.at])
 m4_include([fdefaultbyte.at])
+m4_include([debug.at])
 
 # m4_include([edit-code-command.at])

--- a/tests/command-line-options.src/debug.at
+++ b/tests/command-line-options.src/debug.at
@@ -1,0 +1,28 @@
+AT_SETUP([-debug])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+       PROGRAM-ID.                 prog.
+       DATA                        DIVISION.
+       WORKING-STORAGE             SECTION.
+       01   IDX  PIC 9(04) COMP VALUE 5.
+       01   SRC  PIC X(10) VALUE "0123456789".
+       01   DST  PIC X(10) VALUE "          ".
+       PROCEDURE                   DIVISION.
+       MAIN.
+           MOVE  SRC(1:IDX)  TO  DST.
+           DISPLAY "<" DST ">".
+           MOVE 15 TO IDX.
+           MOVE  SRC(1:IDX)  TO  DST.
+           DISPLAY "<" DST ">".
+           STOP RUN.
+])
+
+AT_CHECK([${COBJ} -debug prog.cbl])
+AT_CHECK([java prog], [1],
+[<01234     >
+],
+[libcobj: Length of 'SRC' out of bounds: 15
+])
+
+AT_CLEANUP

--- a/tests/run.src/ref-mod.at
+++ b/tests/run.src/ref-mod.at
@@ -88,7 +88,6 @@ d:d
 AT_CLEANUP
 
 AT_SETUP([Dynamic reference modification])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
* Implement `-debug` option
  * Implement `CobolUtil.cobCheckRefMod` which corresponds to `cob_check_ref_mod` of opensource COBOL
  * This change solve #41 and a testsuite in run.src/ref-mod.at