### PR TITLE
Implement `COB_IO_ASSUME_REWRITE`

### DIFF
--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -34,7 +34,7 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
 public class CobolUtil {
-  private static int cob_io_assume_rewrite = 0;
+  private static boolean cob_io_assume_rewrite = false;
   private static boolean cob_verbose = false;
   private static HandlerList hdlrs = null;
   private static String runtime_err_str = null;
@@ -96,7 +96,7 @@ public class CobolUtil {
     return 0;
   }
 
-  public static int cob_io_rewwrite_assumed() {
+  public static boolean cob_io_rewwrite_assumed() {
     return cob_io_assume_rewrite;
   }
 
@@ -190,6 +190,11 @@ public class CobolUtil {
     s = CobolUtil.getEnv("COB_VERBOSE");
     if (s != null && s.length() > 0 && (s.charAt(0) == 'y' || s.charAt(0) == 'Y')) {
       CobolUtil.cob_verbose = true;
+    }
+
+    s = CobolUtil.getEnv("COB_IO_ASSUME_REWRITE");
+    if (s != null && s.length() > 0 && (s.charAt(0) == 'y' || s.charAt(0) == 'Y')) {
+      CobolUtil.cob_io_assume_rewrite = true;
     }
   }
 

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -1064,7 +1064,7 @@ public class CobolFile {
       throws CobolStopRunException {
     if (this.access_mode == COB_ACCESS_SEQUENTIAL
         && this.last_open_mode == COB_OPEN_I_O
-        && CobolUtil.cob_io_rewwrite_assumed() != 0) {
+        && CobolUtil.cob_io_rewwrite_assumed()) {
       this.rewrite(rec, opt, fnstatus);
       return;
     }

--- a/tests/jp-compat.src/file-control.at
+++ b/tests/jp-compat.src/file-control.at
@@ -425,7 +425,6 @@ AT_CHECK([${RUN_MODULE} prog], [0], [91
 AT_CLEANUP
 
 AT_SETUP([Assume REWRITE for WRITE on OPEN I-O])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
Due to this modification, rewriting sequential file is enabled if environment value `COB_IO_ASSUME_REWRITE` is equal to `Y` or `y`.