### PR TITLE
fix: some tests in run.src/ref-mod.at

### DIFF
--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -26,7 +26,6 @@ import jp.osscons.opensourcecobol.libcobj.common.CobolModule;
 import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 public class CobolSystemRoutine {
@@ -66,8 +65,7 @@ public class CobolSystemRoutine {
       AbstractCobolField paramater = paramaters.get(0);
       int size = paramater.getSize();
       if (size <= 0) {
-        CobolUtil.runtimeError(
-            "The size of the paramater to SYSTEM call is less than 1");
+        CobolUtil.runtimeError("The size of the paramater to SYSTEM call is less than 1");
         CobolStopRunException.stopRunAndThrow(1);
       }
       return size;
@@ -508,7 +506,7 @@ public class CobolSystemRoutine {
 
     for (int n = 0; n < length; ++n) {
       byte b = data.getByte(n);
-      byte[] bytes = { b };
+      byte[] bytes = {b};
       byte result = new String(bytes).toLowerCase().getBytes()[0];
       data.setByte(n, result);
     }
@@ -535,7 +533,7 @@ public class CobolSystemRoutine {
 
     for (int n = 0; n < length; ++n) {
       byte b = data.getByte(n);
-      byte[] bytes = { b };
+      byte[] bytes = {b};
       byte result = new String(bytes).toUpperCase().getBytes()[0];
       data.setByte(n, result);
     }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -66,13 +66,13 @@ public class CobolSystemRoutine {
       AbstractCobolField paramater = paramaters.get(0);
       int size = paramater.getSize();
       if (size <= 0) {
-        CobolRuntimeException.displayRuntimeError(
+        CobolUtil.runtimeError(
             "The size of the paramater to SYSTEM call is less than 1");
         CobolStopRunException.stopRunAndThrow(1);
       }
       return size;
     } else {
-      CobolRuntimeException.displayRuntimeError("The size of the paramater is not specified");
+      CobolUtil.runtimeError("The size of the paramater is not specified");
       CobolStopRunException.stopRunAndThrow(1);
       // not reached
       return -1;
@@ -508,7 +508,7 @@ public class CobolSystemRoutine {
 
     for (int n = 0; n < length; ++n) {
       byte b = data.getByte(n);
-      byte[] bytes = {b};
+      byte[] bytes = { b };
       byte result = new String(bytes).toLowerCase().getBytes()[0];
       data.setByte(n, result);
     }
@@ -535,7 +535,7 @@ public class CobolSystemRoutine {
 
     for (int n = 0; n < length; ++n) {
       byte b = data.getByte(n);
-      byte[] bytes = {b};
+      byte[] bytes = { b };
       byte result = new String(bytes).toUpperCase().getBytes()[0];
       data.setByte(n, result);
     }

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -59,8 +59,8 @@ public class CobolUtil {
 
   private static boolean lineTrace = false;
 
-  private static String sourceFile;
-  private static int sourceLine;
+  public static String sourceFile;
+  public static int sourceLine;
 
   abstract class HandlerList {
     public HandlerList next = null;
@@ -124,7 +124,7 @@ public class CobolUtil {
     /* check the offset */
     if (offset < 1 || offset > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolRuntimeException.displayRuntimeError(
+      CobolUtil.runtimeError(
           String.format("Offset of '%s' out of bounds: %d", name, offset));
       CobolStopRunException.stopRunAndThrow(1);
     }
@@ -132,7 +132,7 @@ public class CobolUtil {
     /* check the length */
     if (length < 1 || offset + length - 1 > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolRuntimeException.displayRuntimeError(
+      CobolUtil.runtimeError(
           String.format("Length of '%s' out of bounds: %d", name, length));
       CobolStopRunException.stopRunAndThrow(1);
     }
@@ -164,8 +164,7 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block:
-        if (m.groupCount() != 3) {
+        date_time_block: if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -206,11 +205,10 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm =
-          CobolUtil.cobLocalTm
-              .withHour(rt.getHour())
-              .withMinute(rt.getMinute())
-              .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
+          .withHour(rt.getHour())
+          .withMinute(rt.getMinute())
+          .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -282,7 +280,8 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
+  }
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -590,8 +589,7 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP:
-    while (i < size && ret != 0) {
+    OUTER_LOOP: while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -724,8 +722,9 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName the name of an environment variable. The leading and trailing spaces are
-   *     ignored.
+   * @param envVarName  the name of an environment variable. The leading and
+   *                    trailing spaces are
+   *                    ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -124,16 +124,14 @@ public class CobolUtil {
     /* check the offset */
     if (offset < 1 || offset > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolUtil.runtimeError(
-          String.format("Offset of '%s' out of bounds: %d", name, offset));
+      CobolUtil.runtimeError(String.format("Offset of '%s' out of bounds: %d", name, offset));
       CobolStopRunException.stopRunAndThrow(1);
     }
 
     /* check the length */
     if (length < 1 || offset + length - 1 > size) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_REF_MOD);
-      CobolUtil.runtimeError(
-          String.format("Length of '%s' out of bounds: %d", name, length));
+      CobolUtil.runtimeError(String.format("Length of '%s' out of bounds: %d", name, length));
       CobolStopRunException.stopRunAndThrow(1);
     }
   }
@@ -164,7 +162,8 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block: if (m.groupCount() != 3) {
+        date_time_block:
+        if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -205,10 +204,11 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
-          .withHour(rt.getHour())
-          .withMinute(rt.getMinute())
-          .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm =
+          CobolUtil.cobLocalTm
+              .withHour(rt.getHour())
+              .withMinute(rt.getMinute())
+              .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -280,8 +280,7 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
-  }
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -589,7 +588,8 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP: while (i < size && ret != 0) {
+    OUTER_LOOP:
+    while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -722,9 +722,8 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName  the name of an environment variable. The leading and
-   *                    trailing spaces are
-   *                    ignored.
+   * @param envVarName the name of an environment variable. The leading and trailing spaces are
+   *     ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -19,7 +19,6 @@
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 import java.util.List;
-import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 
 /** 実行時エラーを示す例外 */
 public class CobolRuntimeException extends RuntimeException {
@@ -38,7 +37,7 @@ public class CobolRuntimeException extends RuntimeException {
    * コンストラクタ
    *
    * @param errorCode this.errorCodeに設定する値
-   * @param message   this.messageに設定する値
+   * @param message this.messageに設定する値
    */
   public CobolRuntimeException(int errorCode, String message) {
     super();

--- a/libcobj/src/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/src/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -19,15 +19,13 @@
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 import java.util.List;
+import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 
 /** 実行時エラーを示す例外 */
 public class CobolRuntimeException extends RuntimeException {
   public static int code;
 
   public static final int COBOL_FITAL_ERROR = 9000;
-
-  public static String source_file = null;
-  public static int source_line = 0;
 
   public static List<RuntimeErrorHandler> hdlrs = null;
 
@@ -40,7 +38,7 @@ public class CobolRuntimeException extends RuntimeException {
    * コンストラクタ
    *
    * @param errorCode this.errorCodeに設定する値
-   * @param message this.messageに設定する値
+   * @param message   this.messageに設定する値
    */
   public CobolRuntimeException(int errorCode, String message) {
     super();
@@ -74,27 +72,5 @@ public class CobolRuntimeException extends RuntimeException {
   public static void setException(int id) {
     code = CobolExceptionTabCode.code[id];
     // TODO common.c実装に残りをやる
-  }
-
-  /** libcob/common.cのcob_runtime_errorの実装 */
-  public static void displayRuntimeError(String message) {
-    if (hdlrs != null && !hdlrs.isEmpty()) {
-      String runtimeErrStr;
-      if (source_file != null) {
-        runtimeErrStr = String.format("%s:%d: %s", source_file, source_line, message);
-      } else {
-        runtimeErrStr = message;
-      }
-      for (RuntimeErrorHandler h : hdlrs) {
-        h.proc(runtimeErrStr);
-      }
-      hdlrs = null;
-    }
-
-    if (source_file != null) {
-      System.err.print(String.format("%s:%d", source_file, source_line));
-    }
-    System.err.println("libcobj: " + message);
-    System.err.flush();
   }
 }

--- a/tests/command-line-options.src/debug.at
+++ b/tests/command-line-options.src/debug.at
@@ -22,7 +22,7 @@ AT_CHECK([${COBJ} -debug prog.cbl])
 AT_CHECK([java prog], [1],
 [<01234     >
 ],
-[libcobj: Length of 'SRC' out of bounds: 15
+[prog.cbl:14: libcobj: Length of 'SRC' out of bounds: 15
 ])
 
 AT_CLEANUP

--- a/tests/run.src/ref-mod.at
+++ b/tests/run.src/ref-mod.at
@@ -148,7 +148,6 @@ prog.cob:14: Error: Length of 'X' out of bounds: 5
 AT_CLEANUP
 
 AT_SETUP([Offset underflow])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -171,7 +170,6 @@ AT_CHECK([java prog], [1], ,
 AT_CLEANUP
 
 AT_SETUP([Offset overflow])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -194,7 +192,6 @@ AT_CHECK([java prog], [1], ,
 AT_CLEANUP
 
 AT_SETUP([Length underflow])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -217,7 +214,6 @@ AT_CHECK([java prog], [1], ,
 AT_CLEANUP
 
 AT_SETUP([Length overflow])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -243,7 +239,6 @@ AT_CLEANUP
 # 6) TODO
 
 AT_SETUP([Offset out of bounds in MOVE (1)])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
* With `-debug` option, generated programs print the souce file name and the line number where an error occurs
* Remove duplicate methods