### PR TITLE
update: rename prefixes of Java variables

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -220,12 +220,12 @@ static char *get_java_identifier_base(struct cb_field *f) {
 }
 
 static void get_java_identifier_helper(struct cb_field *f, char *buf) {
-  static const char *of = "_of_";
+  static const char *delimitor = "__";
   strcpy_identifier_cobol_to_java(buf, f->name);
   buf += strlen(f->name);
   if (f->parent != NULL) {
-    strcpy(buf, of);
-    buf += strlen(of);
+    strcpy(buf, delimitor);
+    buf += strlen(delimitor);
     get_java_identifier_helper(f->parent, buf);
   }
 }

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -29,15 +29,16 @@
 
 #define COB_MAX_SUBSCRIPTS 16
 
-#define CB_PREFIX_ATTR "attr$"     /* field attribute (cob_field_attr) */
-#define CB_PREFIX_BASE "storage$"     /* base address (unsigned char *) */
-#define CB_PREFIX_CONST "const$"    /* constant or literal (cob_field) */
-#define CB_PREFIX_DECIMAL "decimal$"  /* decimal number (cob_decimal) */
-#define CB_PREFIX_FIELD "field$"    /* field (cob_field) */
-#define CB_PREFIX_FILE "file$"     /* file (cob_file) */
-#define CB_PREFIX_KEYS "file_key$"     /* file keys (struct cob_file_key []) */
-#define CB_PREFIX_LABEL "label$"    /* label */
-#define CB_PREFIX_SEQUENCE "coll_seq$" /* collating sequence */
+#define CB_PREFIX_ATTR "a_"     /* field attribute (cob_field_attr) */
+#define CB_PREFIX_BASE "b_"     /* base address (unsigned char *) */
+#define CB_PREFIX_CONST "c_"    /* constant or literal (cob_field) */
+#define CB_PREFIX_DECIMAL "d_"  /* decimal number (cob_decimal) */
+#define CB_PREFIX_FIELD "f_"    /* field (cob_field) */
+#define CB_PREFIX_FILE "h_"     /* file (cob_file) */
+#define CB_PREFIX_KEYS "k_"     /* file keys (struct cob_file_key []) */
+#define CB_PREFIX_LABEL "l_"    /* label */
+#define CB_PREFIX_SEQUENCE "s_" /* collating sequence */
+#define CB_PREFIX_STRING_LITERAL "str_" /* string literal */
 
 #define CB_PROGRAM_TYPE 0
 #define CB_FUNCTION_TYPE 1

--- a/tests/command-line-options.src/fserial-variable.at
+++ b/tests/command-line-options.src/fserial-variable.at
@@ -30,16 +30,16 @@ A
 3
 B
 ])
-AT_CHECK([grep 'field\$AAA' prog.java], [1])
-AT_CHECK([grep 'storage\$AAA' prog.java], [1])
-AT_CHECK([grep 'field\$BBB' prog.java], [1])
-AT_CHECK([grep 'storage\$BBB' prog.java], [1])
-AT_CHECK([grep 'field\$CCC' prog.java], [1])
-AT_CHECK([grep 'storage\$CCC' prog.java], [1])
-AT_CHECK([grep 'field\$DDD' prog.java], [1])
-AT_CHECK([grep 'field\$EEE' prog.java], [1])
-AT_CHECK([grep 'field\$FFF' prog.java], [1])
-AT_CHECK([grep 'storage\$GRP' prog.java], [1])
+AT_CHECK([grep 'f_AAA' prog.java], [1])
+AT_CHECK([grep 'b_AAA' prog.java], [1])
+AT_CHECK([grep 'f_BBB' prog.java], [1])
+AT_CHECK([grep 'b_BBB' prog.java], [1])
+AT_CHECK([grep 'f_CCC' prog.java], [1])
+AT_CHECK([grep 'b_CCC' prog.java], [1])
+AT_CHECK([grep 'f_DDD' prog.java], [1])
+AT_CHECK([grep 'f_EEE' prog.java], [1])
+AT_CHECK([grep 'f_FFF' prog.java], [1])
+AT_CHECK([grep 'b_GRP' prog.java], [1])
 
 AT_CHECK([${COMPILE} prog.cbl])
 AT_CHECK([${RUN_MODULE} prog], [0],
@@ -50,15 +50,15 @@ A
 3
 B
 ])
-AT_CHECK([grep 'field\$AAA' prog.java > /dev/null], [0])
-AT_CHECK([grep 'storage\$AAA' prog.java > /dev/null], [0])
-AT_CHECK([grep 'field\$BBB' prog.java > /dev/null], [0])
-AT_CHECK([grep 'storage\$BBB' prog.java > /dev/null], [0])
-AT_CHECK([grep 'field\$CCC' prog.java > /dev/null], [0])
-AT_CHECK([grep 'storage\$CCC' prog.java > /dev/null], [0])
-AT_CHECK([grep 'field\$DDD' prog.java > /dev/null], [0])
-AT_CHECK([grep 'field\$EEE' prog.java > /dev/null], [0])
-AT_CHECK([grep 'field\$FFF' prog.java > /dev/null], [0])
-AT_CHECK([grep 'storage\$GRP' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_AAA' prog.java > /dev/null], [0])
+AT_CHECK([grep 'b_AAA' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_BBB' prog.java > /dev/null], [0])
+AT_CHECK([grep 'b_BBB' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_CCC' prog.java > /dev/null], [0])
+AT_CHECK([grep 'b_CCC' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_DDD' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_EEE' prog.java > /dev/null], [0])
+AT_CHECK([grep 'f_FFF' prog.java > /dev/null], [0])
+AT_CHECK([grep 'b_GRP' prog.java > /dev/null], [0])
 
 AT_CLEANUP

--- a/tests/command-line-options.src/fshort-variable.at
+++ b/tests/command-line-options.src/fshort-variable.at
@@ -33,16 +33,16 @@ cc
 ee
 00005
 ])
-AT_CHECK([cat prog.java | grep 'field\$bb' > /dev/null], [0])
-AT_CHECK([cat prog.java | grep 'field\$cc' > /dev/null], [0])
-AT_CHECK([cat prog.java | grep 'field\$ee' > /dev/null], [0])
-AT_CHECK([cat prog.java | grep 'field\$ff' > /dev/null], [0])
-AT_CHECK([cat prog.java | grep 'field\$gg' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_bb' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_cc' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_ee' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_ff' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_gg' > /dev/null], [0])
 
-AT_CHECK([cat prog.java | grep 'field\$bb_of' > /dev/null], [1])
-AT_CHECK([cat prog.java | grep 'field\$cc_of' > /dev/null], [1])
-AT_CHECK([cat prog.java | grep 'field\$ee_of' > /dev/null], [1])
-AT_CHECK([cat prog.java | grep 'field\$ff_of' > /dev/null], [1])
-AT_CHECK([cat prog.java | grep 'field\$gg_of' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_bb__' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_cc__' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_ee__' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_ff__' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_gg__' > /dev/null], [1])
 
 AT_CLEANUP


### PR DESCRIPTION
* Revert the change of #165
  * attr$
 -> a_
  * storage$ -> b_
  * const$ -> c_
  * decimal$
 -> d_
  * file$ -> h_
  * file_key$ -> k_
  * label$ -> l_
  * coll_seq$ -> s_
* Change the delimitor from `_of_` to `__`