### PR TITLE
Run SpotBugs in GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -111,13 +111,19 @@ jobs:
           sudo apt-get install -y clang-format cppcheck
           curl -L -o google-java-format.jar https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar
           curl -L -o pmd-bin-6.52.0.zip https://github.com/pmd/pmd/releases/download/pmd_releases%2F6.52.0/pmd-bin-6.52.0.zip
+          curl -L -o spotbugs-4.7.3.zip https://github.com/spotbugs/spotbugs/releases/download/4.7.3/spotbugs-4.7.3.zip
           unzip pmd-bin-6.52.0.zip
+          unzip spotbugs-4.7.3.zip
 
       - name: Check format with google-java-format and clang-format
         run: |
           export PATH_GOOGLE_JAVA_FORMAT=${PWD}/google-java-format.jar
           ./check-format
           echo $?
+
+      - name: Run SpotBugs
+        run: |
+          java -jar spotbugs-4.7.3/lib/spotbugs.jar -textui libcobj/
 
       - name: Run PMD
         run: |


### PR DESCRIPTION
This modification make cicd.yml to run [SpotBugs](https://spotbugs.github.io/) in GitHub Actions.
Currently the result is ignored and all warnings should be fixed in the future.