### PR TITLE
codegen.c error with version 1.0.13

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -1408,6 +1408,7 @@ static void joutput_param(cb_tree x, int id) {
   struct cb_alphabet_name *abp;
   struct cb_alphabet_name *rbp;
   cb_tree l;
+  struct literal_list *ll;
   int n;
   int extrefs;
   int sav_stack_id;
@@ -1490,8 +1491,8 @@ static void joutput_param(cb_tree x, int id) {
     joutput("%s%s", CB_PREFIX_FILE, CB_FILE(x)->cname);
     break;
   case CB_TAG_LITERAL:
-    struct literal_list *l = lookup_literal(x);
-    joutput_const_identifier(l);
+    ll = lookup_literal(x);
+    joutput_const_identifier(ll);
     break;
   case CB_TAG_FIELD:
     /* TODO: remove me */


### PR DESCRIPTION
* I encountered the following error when running 'make' command using the latest 1.0.13. This error didn't occur with the previous 1.0.12.

```
codegen.c: In function ‘joutput_param’:
codegen.c:1484:5: error: a label can only be part of a statement and a declaration is not a statement
 1484 |     struct literal_list* l = lookup_literal(x);
      |     ^~~~~~
```

* Variable declarations in CASE statements were causing errors, which have been corrected.