### PR TITLE
Implement runtime numeric checkings

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -40,17 +40,18 @@ public abstract class AbstractCobolField {
 
   static int lastsize = 0;
   static CobolDataStorage lastdata = null;
+  static Charset CharSetSJIS = Charset.forName("SHIFT-JIS");
 
   static final int[] cobExp10 = {
-    1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
+      1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
   };
 
   /**
    * コンストラクタ
    *
-   * @param size データを格納するバイト配列の長さ
+   * @param size        データを格納するバイト配列の長さ
    * @param dataStorage データを格納するバイト配列を扱うオブジェクト
-   * @param attribute 変数に関する様々な情報を保持するオブジェクト(符号付か,COMP-3指定かなど)
+   * @param attribute   変数に関する様々な情報を保持するオブジェクト(符号付か,COMP-3指定かなど)
    */
   public AbstractCobolField(int size, CobolDataStorage dataStorage, CobolFieldAttribute attribute) {
     this.size = size;
@@ -122,7 +123,8 @@ public abstract class AbstractCobolField {
   }
 
   /**
-   * opensource COBOLのCOB_FIELD_DATAに相当するメソッド バイト配列の中で(符号データではなく)数値データの格納されている最小の添え字を返す opensource
+   * opensource COBOLのCOB_FIELD_DATAに相当するメソッド
+   * バイト配列の中で(符号データではなく)数値データの格納されている最小の添え字を返す opensource
    * COBOLではポインタを返しているが,このメソッドは添え字を返す
    *
    * @return SIGN_LEADINGかつSIGN_SEPARATEなら1,それ以外は0
@@ -132,13 +134,12 @@ public abstract class AbstractCobolField {
   }
 
   public byte[] getBytes() {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage n = new CobolDataStorage(new byte[4], 0);
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, n, attr);
     temp.moveFrom(this);
@@ -154,13 +155,12 @@ public abstract class AbstractCobolField {
 
   /** @return */
   public int getInt() {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage n = new CobolDataStorage(new byte[4], 0);
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, n, attr);
     temp.moveFrom(this);
@@ -269,7 +269,7 @@ public abstract class AbstractCobolField {
    * libcob/numeric.cのcob_addの実装 thisの保持する数値データに,引数で与えられたフィールドの保持する数値データを加算する
    *
    * @param field 加算する数値を保持するフィールド
-   * @param opt 加算に関するオプション.詳しくはopensourceCOBOLを参照
+   * @param opt   加算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 加算後のthisの保持する数値データ
    */
   public int add(AbstractCobolField field, int opt) throws CobolStopRunException {
@@ -283,7 +283,7 @@ public abstract class AbstractCobolField {
    * libcob/numeric.cのcob_subの実装 thisの保持する数値データに,引数で与えられたフィールドの保持する数値データを減算する
    *
    * @param field 減算する数値を保持するフィールド
-   * @param opt 減算に関するオプション.詳しくはopensourceCOBOLを参照
+   * @param opt   減算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 減算後のthisの保持する数値データ
    */
   public int sub(AbstractCobolField field, int opt) throws CobolStopRunException {
@@ -599,18 +599,17 @@ public abstract class AbstractCobolField {
   public void moveFrom(String s) {
     // The maximum number of digits of int type in decimal is 10
 
-    byte[] bytes = s.getBytes(Charset.forName("SJIS"));
+    byte[] bytes = s.getBytes(CharSetSJIS);
 
     CobolDataStorage storage = new CobolDataStorage(bytes.length);
     storage.memcpy(bytes);
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_ALPHANUMERIC,
-            bytes.length,
-            0,
-            0,
-            String.format("X(%d)", bytes.length));
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_ALPHANUMERIC,
+        bytes.length,
+        0,
+        0,
+        String.format("X(%d)", bytes.length));
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(bytes.length, storage, attr);
     this.moveFrom(tmp);
@@ -632,13 +631,12 @@ public abstract class AbstractCobolField {
       storage.setByte(length - 1, (byte) (storage.getByte(length - 1) + 0x40));
     }
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-            length,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            "S9(10)");
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+        length,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        "S9(10)");
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(length, storage, attr);
     this.moveFrom(tmp);
@@ -665,13 +663,12 @@ public abstract class AbstractCobolField {
     CobolDataStorage storage = new CobolDataStorage(ss.length());
     storage.memcpy(ss, ss.length());
 
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-            ss.length(),
-            scale,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            "");
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+        ss.length(),
+        scale,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        "");
 
     AbstractCobolField tmp = CobolFieldFactory.makeCobolField(ss.length(), storage, attr);
     if (number < 0) {
@@ -692,7 +689,15 @@ public abstract class AbstractCobolField {
    *
    * @param s
    */
-  public void checkNumeric(byte[] s) {}
+  public void checkNumeric(byte[] s) throws CobolStopRunException {
+    if (!this.isNumeric()) {
+      byte[] buff = this.getDataStorage().getByteArrayRef(0, this.getSize());
+      String name = new String(s, CharSetSJIS);
+      String content = new String(buff, CharSetSJIS);
+      CobolUtil.runtimeError("'" + name + "' not numeric: '" + content + "'");
+      CobolStopRunException.stopRunAndThrow(1);
+    }
+  }
 
   // TODO abstract指定
   /**
@@ -847,8 +852,7 @@ public abstract class AbstractCobolField {
     int sign = this.getSign();
     int ret = 0;
     int p = 0;
-    outer:
-    {
+    outer: {
       while (size >= field.getSize()) {
         // TODO moduleを参照するコードにする
         ret = alnumCmps(data, p, field.getDataStorage(), 0, this.getSize(), null);
@@ -975,7 +979,8 @@ public abstract class AbstractCobolField {
   }
 
   /**
-   * libcob/common.cのcob_field_to_stringの実装 TODO CobolNationalFieldでオーバーライドしなくても済むように修正する.
+   * libcob/common.cのcob_field_to_stringの実装 TODO
+   * CobolNationalFieldでオーバーライドしなくても済むように修正する.
    *
    * @return this.dataの保持するデータを文字列にして返す.
    */
@@ -992,13 +997,12 @@ public abstract class AbstractCobolField {
 
   /** libcob/move.cのcob_set_intの実装 */
   public void setInt(int n) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage data = new CobolDataStorage(ByteBuffer.allocate(4).putInt(n).array());
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(4, data, attr);
     this.moveFrom(temp);
@@ -1010,13 +1014,12 @@ public abstract class AbstractCobolField {
   }
 
   public void setLong(Long n) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            9,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        9,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     CobolDataStorage data = new CobolDataStorage(ByteBuffer.allocate(8).putLong(n).array());
     AbstractCobolField temp = CobolFieldFactory.makeCobolField(8, data, attr);
     this.moveFrom(temp);
@@ -1029,10 +1032,8 @@ public abstract class AbstractCobolField {
    * @param size
    */
   public void memcpy(byte[] src, int size) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null);
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(size, new CobolDataStorage(src), attr);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(size, new CobolDataStorage(src), attr);
     this.moveFrom(temp);
   }
 
@@ -1229,14 +1230,13 @@ public abstract class AbstractCobolField {
     int sign = 0;
 
     if ((this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL
-            || this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_NATIONAL_ALL)
+        || this.getAttribute().getType() == CobolFieldAttribute.COB_TYPE_NATIONAL_ALL)
         && this.getSize() < other.getSize()) {
       int size = other.getSize();
       CobolDataStorage data = other.getDataStorage();
       sign = other.getSign();
       CobolDataStorage s = CobolModule.getCurrentModule().collating_sequence;
-      OUTSIDE:
-      do {
+      OUTSIDE: do {
         while (size >= this.getSize()) {
           ret = comparator.compare(this.getDataStorage(), data, this.getSize(), s);
           if (ret != 0) {
@@ -1254,8 +1254,7 @@ public abstract class AbstractCobolField {
       CobolDataStorage data = this.getDataStorage();
       sign = this.getSign();
       CobolDataStorage s = CobolModule.getCurrentModule().collating_sequence;
-      OUTSIDE:
-      do {
+      OUTSIDE: do {
         while (size >= other.getSize()) {
           ret = comparator.compare(data, other.getDataStorage(), other.getSize(), s);
           if (ret != 0) {
@@ -1297,15 +1296,13 @@ public abstract class AbstractCobolField {
     if (ret == 0) {
       if (lf.getSize() > sf.getSize()) {
         if ((lf.getAttribute().getType() & CobolFieldAttribute.COB_TYPE_NATIONAL) != 0) {
-          ret =
-              CobolUtil.isNationalPadding(
-                  lf.getDataStorage().getSubDataStorage(sf.getSize()), lf.getSize() - sf.getSize());
+          ret = CobolUtil.isNationalPadding(
+              lf.getDataStorage().getSubDataStorage(sf.getSize()), lf.getSize() - sf.getSize());
         } else {
-          ret =
-              CobolUtil.commonCmpc(
-                  lf.getDataStorage().getSubDataStorage(sf.getSize()),
-                  (byte) ' ',
-                  lf.getSize() - sf.getSize());
+          ret = CobolUtil.commonCmpc(
+              lf.getDataStorage().getSubDataStorage(sf.getSize()),
+              (byte) ' ',
+              lf.getSize() - sf.getSize());
         }
         if (this.getSize() < other.getSize()) {
           ret = -ret;
@@ -1441,13 +1438,12 @@ public abstract class AbstractCobolField {
    * @return
    */
   public long getLong() {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
-            18,
-            0,
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(
+        CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY,
+        18,
+        0,
+        CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+        null);
     byte[] data = new byte[8];
     CobolDataStorage storage = new CobolDataStorage(data);
     AbstractCobolField field = CobolFieldFactory.makeCobolField(8, storage, attr);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -45,7 +45,7 @@ public class CobolDataStorage {
   /**
    * コンストラクタ.データを保存するバイト配列と保存する領域の相対位置を引数で指定する.
    *
-   * @param data データを保存するバイト配列
+   * @param data  データを保存するバイト配列
    * @param index このクラスの扱うデータが保存する領域のバイト配列中での相対位置
    */
   public CobolDataStorage(byte[] data, int index) {
@@ -157,7 +157,7 @@ public class CobolDataStorage {
   /**
    * バイト配列の引数で指定した相対位置から指定した長さをコピーした配列を返す。
    *
-   * @param index コピーの開始位置(this.indexバイト目を基準とする)
+   * @param index  コピーの開始位置(this.indexバイト目を基準とする)
    * @param length コピーする長さ(バイト数)
    * @return 開始位置からlengthバイト分の配列
    */
@@ -165,6 +165,16 @@ public class CobolDataStorage {
     byte[] result = new byte[length];
     System.arraycopy(this.data, this.index + index, result, 0, length);
     return result;
+  }
+
+  /*
+   * Returns a reference to the byte array holded by this object.
+   * Modification of the returned array will affect the data holded by this
+   * object.
+   */
+  public byte[] getByteArrayRef(int index, int length) {
+    ByteBuffer buffer = ByteBuffer.wrap(this.data, this.index + index, length);
+    return buffer.array();
   }
 
   /**
@@ -331,14 +341,13 @@ public class CobolDataStorage {
   /**
    * 引数で指定されたバイト配列をthis.dataの引数で指定された位置からコピーする
    *
-   * @param data コピー元のバイト配列
+   * @param data  コピー元のバイト配列
    * @param index this.byteのコピー開始位置(this.indexバイト目を基準とする)
    */
   public void setData(byte[] data, int index) {
-    int length =
-        (data.length <= this.data.length - this.index - index)
-            ? data.length
-            : this.data.length - this.index - index;
+    int length = (data.length <= this.data.length - this.index - index)
+        ? data.length
+        : this.data.length - this.index - index;
 
     System.arraycopy(data, 0, this.data, this.index + index, length);
   }
@@ -409,7 +418,7 @@ public class CobolDataStorage {
    * バイト配列のthis.indexバイト目からsizeバイトの範囲にvalueを代入する
    *
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(byte value, int size) {
     fillBytes(0, value, size);
@@ -419,7 +428,7 @@ public class CobolDataStorage {
    * バイト配列のthis.indexバイト目からsizeバイトの範囲にvalueを代入する
    *
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(int value, int size) {
     fillBytes(0, value, size);
@@ -429,7 +438,7 @@ public class CobolDataStorage {
    * バイト配列のthis.indexバイト目からsizeバイトの範囲にvalueを代入する
    *
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(char value, int size) {
     fillBytes(0, value, size);
@@ -440,7 +449,7 @@ public class CobolDataStorage {
    *
    * @param index コピーの開始位置(this.indexが基準)
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(int index, byte value, int size) {
     for (int i = 0; i < size; ++i) {
@@ -453,7 +462,7 @@ public class CobolDataStorage {
    *
    * @param index コピーの開始位置(this.indexが基準)
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(int index, int value, int size) {
     this.fillBytes(index, (byte) value, size);
@@ -464,7 +473,7 @@ public class CobolDataStorage {
    *
    * @param index コピーの開始位置(this.indexが基準)
    * @param value 代入する値
-   * @param size 代入先のバイト数
+   * @param size  代入先のバイト数
    */
   public void fillBytes(int index, char value, int size) {
     this.fillBytes(index, (byte) value, size);
@@ -484,7 +493,7 @@ public class CobolDataStorage {
   /**
    * 指定のバイト配列に格納された値を this.dataのthis.indexバイト目以降へlengthバイトだけコピーする.
    *
-   * @param bytes コピー元の配列
+   * @param bytes  コピー元の配列
    * @param length コピーするバイト数
    */
   public void setBytes(byte[] bytes, int length) {
@@ -496,8 +505,8 @@ public class CobolDataStorage {
   /**
    * 指定のバイト配列に格納された値を this.dataのthis.index+indexバイト目以降へlengthバイトだけコピーする.
    *
-   * @param index コピー先のthis.indexからの相対位置
-   * @param bytes コピー元の配列
+   * @param index  コピー先のthis.indexからの相対位置
+   * @param bytes  コピー元の配列
    * @param length コピーするバイト数
    */
   public void setBytes(int index, byte[] bytes, int length) {
@@ -509,7 +518,7 @@ public class CobolDataStorage {
   /**
    * 指定した文字列をバイト配列にコピーする
    *
-   * @param str コピー元の文字列
+   * @param str    コピー元の文字列
    * @param length コピーするバイト数
    */
   public void setBytes(String str, int length) {
@@ -523,7 +532,7 @@ public class CobolDataStorage {
   /**
    * 指定されたCobolDataStorageのインスタンスから,lengthバイトだけデータをコピーする
    *
-   * @param data コピー元のCobolDataStorage
+   * @param data   コピー元のCobolDataStorage
    * @param length コピーするバイト数
    */
   public void setBytes(CobolDataStorage data, int length) {
@@ -533,8 +542,8 @@ public class CobolDataStorage {
   /**
    * 指定されたCobolDataStorageのインスタンスから,lengthバイトだけデータをコピーする
    *
-   * @param data コピー元のCobolDataStorage
-   * @param length コピーするバイト数
+   * @param data     コピー元のCobolDataStorage
+   * @param length   コピーするバイト数
    * @param dstIndex コピー先(this.data)のthis.indexからの相対位置
    */
   public void setBytes(CobolDataStorage data, int length, int dstIndex) {
@@ -544,8 +553,8 @@ public class CobolDataStorage {
   /**
    * 指定されたCobolDataStorageのインスタンスから,lengthバイトだけデータをコピーする
    *
-   * @param data コピー元のCobolDataStorage
-   * @param length コピーするバイト数
+   * @param data     コピー元のCobolDataStorage
+   * @param length   コピーするバイト数
    * @param dstIndex コピー先(this.data)のthis.indexからの相対位置
    * @param srcIndex コピー元バイト配列中の相対位置
    */
@@ -712,25 +721,23 @@ public class CobolDataStorage {
     int run(long a, long b);
   }
 
-  private static final Cmpr compareS =
-      new Cmpr() {
-        public int run(long a, long b) {
-          if (a < b) {
-            return -1;
-          } else if (a > b) {
-            return 1;
-          } else {
-            return 0;
-          }
-        }
-      };
+  private static final Cmpr compareS = new Cmpr() {
+    public int run(long a, long b) {
+      if (a < b) {
+        return -1;
+      } else if (a > b) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  };
 
-  private static final Cmpr compareU =
-      new Cmpr() {
-        public int run(long a, long b) {
-          return Long.compareUnsigned(a, b);
-        }
-      };
+  private static final Cmpr compareU = new Cmpr() {
+    public int run(long a, long b) {
+      return Long.compareUnsigned(a, b);
+    }
+  };
 
   public int compareToBinary(long n, int numOfBytes, boolean signed, boolean isBigEndian) {
     long val = this.toLong(numOfBytes, signed, isBigEndian);

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -182,7 +182,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       numcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  TEST-REC.
@@ -206,7 +206,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       basedcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  XçÄñ⁄    PIC  X(4) VALUE 'ABCD'.
@@ -228,7 +228,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       odocheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  IçÄñ⁄         PIC 9 VALUE 4.
@@ -251,7 +251,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       odocheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  IçÄñ⁄         PIC 9 VALUE 2.
@@ -274,7 +274,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       refcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  I             PIC 9    VALUE 2.
@@ -297,7 +297,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       refcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  I             PIC 9    VALUE 6.
@@ -320,7 +320,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       refcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  I             PIC 9    VALUE 2.
@@ -343,7 +343,7 @@ AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
-       PROGRAM-ID.       refcheck.
+       PROGRAM-ID.       prog.
        DATA              DIVISION.
        WORKING-STORAGE   SECTION.
        01  I             PIC 99   VALUE 18.

--- a/tests/package.m4
+++ b/tests/package.m4
@@ -1,6 +1,6 @@
 # Signature of the current package.
 m4_define([AT_PACKAGE_NAME],	  [opensource COBOL 4J])
-m4_define([AT_PACKAGE_TARNAME],	  [opensource-cobol-4j-1.0.16])
-m4_define([AT_PACKAGE_VERSION],	  [1.0.16])
-m4_define([AT_PACKAGE_STRING],	  [opensource COBOL 4J 1.0.16])
+m4_define([AT_PACKAGE_TARNAME],	  [opensource-cobol-4j-1.0.17])
+m4_define([AT_PACKAGE_VERSION],	  [1.0.17])
+m4_define([AT_PACKAGE_STRING],	  [opensource COBOL 4J 1.0.17])
 m4_define([AT_PACKAGE_BUGREPORT], [ws-opensource-cobol-contact@osscons.jp])

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -2085,7 +2085,6 @@ AT_CLEANUP
 
 
 AT_SETUP([COMPUTE include string])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This PR enables runtime numeric checkings.
```cobol
       IDENTIFICATION   DIVISION.
       PROGRAM-ID.      prog.
       DATA             DIVISION.
       WORKING-STORAGE  SECTION.
       01 X.
          03 X-ABC      PIC 999.
       01 Y             PIC 999 VALUE 100.
       PROCEDURE        DIVISION.
           MOVE "abc" TO X.
           COMPUTE Y = X-ABC + Y.
           STOP RUN.
```
For example, if the above program is executed, it displays `libcobj: 'X-ABC' not numeric: 'abc'` because the contents of `X-ABC` does not represent a integer.

In addtion, this PR changes the program ids in tests/i18n_sjis.src/user-defined-word.at