### PR TITLE
Implement the environemt variable COB_NIBBLE_C_UNSIGNED

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -198,6 +198,11 @@ public class CobolUtil {
     if (s != null && s.length() > 0 && (s.charAt(0) == 'y' || s.charAt(0) == 'Y')) {
       CobolUtil.cob_io_assume_rewrite = true;
     }
+
+    s = CobolUtil.getEnv("COB_NIBBLE_C_UNSIGNED");
+    if (s != null && s.length() > 0 && (s.charAt(0) == 'y' || s.charAt(0) == 'Y')) {
+      CobolUtil.nibbleCForUnsigned = true;
+    }
   }
 
   /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -1113,12 +1113,16 @@ public abstract class AbstractCobolField {
         if (sign == 0x0f) {
           return true;
         }
-        if (CobolUtil.nibbleCForUnsigned) {
+        if (this.getAttribute().isFlagHaveSign()) {
+          if (sign == 0x0c || sign == 0x0d) {
+            return true;
+          }
+        } else if (CobolUtil.nibbleCForUnsigned) {
           if (sign == 0x0c) {
             return true;
           }
         }
-        return sign == 0x0c || sign == 0x0d;
+        return false;
       case CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY:
         int size = this.getFieldSize();
         int firstIndex = this.getFirstDataIndex();

--- a/tests/jp-compat.src/file-control.at
+++ b/tests/jp-compat.src/file-control.at
@@ -354,8 +354,6 @@ AT_CLEANUP
 
 AT_SETUP([Allow file delete (INDEXED)])
 
-AT_CHECK([test $COB_SPLITKEY_FLAGS = "yes" || exit 77])
-
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      prog.

--- a/tests/jp-compat.src/nibble-c-for-unsigned.at
+++ b/tests/jp-compat.src/nibble-c-for-unsigned.at
@@ -1,5 +1,4 @@
 AT_SETUP([Decimal nibble C as unsigned])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This PR implements the environemt variable COB_NIBBLE_C_UNSIGNED.
This option affects the process that determines if a given COMP-3 data is numeric.
Additionally, this PR lets a test case for indexed files not to be skipped.