### PR TITLE
Fix the message of COB_VERBOSE file sort

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -798,7 +798,7 @@ public class CobolFileSort {
       for (int i = 0; i < varcnt; i++) {
         fbase[i].close(CobolFile.COB_CLOSE_NORMAL, null);
       }
-      CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD %d.", cntRec));
+      CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD=%d.", cntRec));
 
     } else {
 
@@ -835,7 +835,7 @@ public class CobolFileSort {
       for (int i = 0; i < varcnt; i++) {
         fbase[i].close(CobolFile.COB_CLOSE_NORMAL, null);
       }
-      CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD %d.", cntRec));
+      CobolUtil.verboseOutput(String.format("END OF SORT/MERGE, RECORD=%d.", cntRec));
     }
   }
 

--- a/tests/jp-compat.src/verbose-runtime.at
+++ b/tests/jp-compat.src/verbose-runtime.at
@@ -1,5 +1,4 @@
 AT_SETUP([COB_VERBOSE file sort])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION       DIVISION.
@@ -35,7 +34,7 @@ AT_DATA([prog.cob], [
 AT_CHECK([echo -n 11CC33AA22BB >input.txt])
 AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([COB_VERBOSE=Y java prog], [0],
-[libcobj: END OF SORT/MERGE, RECORD= 3.
+[libcobj: END OF SORT/MERGE, RECORD=3.
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This PR fixes the message of COB_VERBOSE file sort so that a test in tests/jp-comat.src/verbose-runtime.at is passed