### PR TITLE
Fix a test case in tests/jp-compat.src/file-desc.at

### DIFF
--- a/tests/jp-compat.src/file-desc.at
+++ b/tests/jp-compat.src/file-desc.at
@@ -30,7 +30,6 @@ AT_CHECK([od -An -tx1 TEST-FILE | sed -e 's/  */ /g' -e 's/ *$//'], [0], [ 41 41
 AT_CLEANUP
 
 AT_SETUP([ignore invalid (too large) RECORD CONTAINS ])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -53,7 +52,7 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0])
-AT_CHECK([od -An -tx1 TEST-FILE | sed -e 's/  */ /g' -e 's/ *$//'], [0], [ 00 04 00 00 41 41 41 41
+AT_CHECK([od -An -tx1 TEST-FILE | sed -e 's/  */ /g' -e 's/ *$//'], [0], [ 00 00 00 04 41 41 41 41
 ])
 AT_CHECK([${COMPILE_JP_COMPAT} prog.cob])
 AT_CHECK([java prog], [0])


### PR DESCRIPTION
This PR fixes a test case `ignore invalid (too large) RECORD CONTAINS` in tests/jp-compat.src/file-desc.at