### PR TITLE
Fix two tests in `tests/jp-compat.src/special-names.at`

### DIFF
--- a/tests/jp-compat.src/special-names.at
+++ b/tests/jp-compat.src/special-names.at
@@ -22,7 +22,6 @@ AT_CHECK([java prog this is arg], [0], [03])
 AT_CLEANUP
 
 AT_SETUP([ACCEPT ARGUMENT-VALUE])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -71,7 +70,6 @@ AT_CHECK([export TESTENV=envvalue && java prog], [0], [envvalue])
 AT_CLEANUP
 
 AT_SETUP([DISPLAY ARGUMENT-NUMBER])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This PR ensures that two tests of command line arguments are not skipped.