### PR TITLE
Fix the process that checks moving x to numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+### Added
+* Implement runtime numeric checkings (#253)
+* Implement sorting a table based on ebcdic (#254)
+* Implement KEY IS option of SORT statements (#259)
+* Add documents that describes installations and requirements (#256)
+* Implement the environemt variable COB_NIBBLE_C_UNSIGNED (#258)
+* Add intrinsic functions
+  * `C$CALLEDBY` (#262)
+  * `C$LIST-DIRECTORY` (#264)
+### Fixed
+* Fix the message of COB_VERBOSE file sort (#260)
+* Fix the process that checks moving x to numeric (#266)
+### Optimized
+* Optimize the file reading process (#257)
+
 ## [1.0.17] - 2023-11-28
 ### Added
 * Implement sorting a table (#251)

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -928,7 +928,7 @@ public abstract class AbstractCobolField {
    *
    * @param field
    */
-  public void checkMoveStrNum(AbstractCobolField field) {
+  public void checkMoveStrNum(AbstractCobolField field) throws CobolStopRunException {
     switch (this.getAttribute().getType()) {
       case CobolFieldAttribute.COB_TYPE_ALPHANUMERIC:
       case CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL:
@@ -946,8 +946,8 @@ public abstract class AbstractCobolField {
             for (int i = 0; i < this.getSize(); i++) {
               byte val = data.getByte(firstIndex + i);
               if (val < 0x30 || 0x39 < val) {
-                System.out.println("Numeric value is expected");
-                // TODO STOP RUNを呼ぶ
+                CobolUtil.runtimeError("Numeric value is expected");
+                CobolStopRunException.stopRunAndThrow(1);
               }
             }
             break;

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -2058,7 +2058,6 @@ AT_CLEANUP
 
 
 AT_SETUP([MOVE x TO numeric])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This PR fixes the process that checks moving x to numeric so that a test in `tests/run.src/miscellaneous.at` is passed.
Additionally, this PR adds unreleased changes to CHANGELOG.md.