### PR TITLE
Fix CobolUtil.checkRefMod method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * `C$LIST-DIRECTORY` (#264)
 ### Fixed
 * Fix the message of COB_VERBOSE file sort (#260)
-* Fix the process that checks moving x to numeric (#266)
+* Fix the process that checks MOVE statements (#266, #267)
 ### Optimized
 * Optimize the file reading process (#257)
 

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -861,7 +861,8 @@ cb_tree cb_build_identifier(cb_tree x) {
           e1 = cb_build_funcall_5(
               "CobolUtil.cobCheckRefMod", cb_build_cast_integer(r->offset),
               r->length ? cb_build_cast_integer(r->length) : cb_int1,
-              cb_int(f->size), cb_build_string0((ucharptr)f->name), cb_int(strlen((ucharptr)f->name)));
+              cb_int(f->size), cb_build_string0((ucharptr)f->name),
+              cb_int(strlen((ucharptr)f->name)));
         }
         r->check = cb_list_add(r->check, e1);
       }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -858,10 +858,10 @@ cb_tree cb_build_identifier(cb_tree x) {
               r->length ? cb_build_cast_integer(r->length) : cb_int2,
               cb_int(f->size), cb_build_string0((ucharptr)f->name));
         } else {
-          e1 = cb_build_funcall_4(
+          e1 = cb_build_funcall_5(
               "CobolUtil.cobCheckRefMod", cb_build_cast_integer(r->offset),
               r->length ? cb_build_cast_integer(r->length) : cb_int1,
-              cb_int(f->size), cb_build_string0((ucharptr)f->name));
+              cb_int(f->size), cb_build_string0((ucharptr)f->name), cb_int(strlen((ucharptr)f->name)));
         }
         r->check = cb_list_add(r->check, e1);
       }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -114,7 +114,8 @@ public class CobolUtil {
     CobolUtil.cobCheckRefMod(offset, length, size, name);
   }
 
-  public static void cobCheckRefMod(int offset, long length, int size, CobolDataStorage name, int nameLen)
+  public static void cobCheckRefMod(
+      int offset, long length, int size, CobolDataStorage name, int nameLen)
       throws CobolStopRunException {
     cobCheckRefMod(offset, length, size, name.getByteArrayRef(0, nameLen));
   }
@@ -181,7 +182,8 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block: if (m.groupCount() != 3) {
+        date_time_block:
+        if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -227,10 +229,11 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
-          .withHour(rt.getHour())
-          .withMinute(rt.getMinute())
-          .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm =
+          CobolUtil.cobLocalTm
+              .withHour(rt.getHour())
+              .withMinute(rt.getMinute())
+              .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -302,8 +305,7 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
-  }
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -611,7 +613,8 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP: while (i < size && ret != 0) {
+    OUTER_LOOP:
+    while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -642,8 +645,9 @@ public class CobolUtil {
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
     if (col != null) {
       for (int i = 0; i < size; ++i) {
-        int ret = col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
-            - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
+        int ret =
+            col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
+                - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
         if (ret != 0) {
           return ret;
         }
@@ -752,9 +756,8 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName  the name of an environment variable. The leading and
-   *                    trailing spaces are
-   *                    ignored.
+   * @param envVarName the name of an environment variable. The leading and trailing spaces are
+   *     ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -114,6 +114,16 @@ public class CobolUtil {
     CobolUtil.cobCheckRefMod(offset, length, size, name);
   }
 
+  public static void cobCheckRefMod(int offset, long length, int size, CobolDataStorage name, int nameLen)
+      throws CobolStopRunException {
+    cobCheckRefMod(offset, length, size, name.getByteArrayRef(0, nameLen));
+  }
+
+  public static void cobCheckRefMod(int offset, long length, int size, byte[] name, int nameLen)
+      throws CobolStopRunException {
+    cobCheckRefMod(offset, length, size, name);
+  }
+
   public static void cobCheckRefMod(int offset, long length, int size, byte[] name)
       throws CobolStopRunException {
     try {
@@ -121,6 +131,11 @@ public class CobolUtil {
     } catch (UnsupportedEncodingException e) {
       CobolUtil.cobCheckRefMod(offset, length, size, "");
     }
+  }
+
+  public static void cobCheckRefMod(int offset, long length, int size, String name, int nameLen)
+      throws CobolStopRunException {
+    cobCheckRefMod(offset, length, size, name);
   }
 
   public static void cobCheckRefMod(int offset, long length, int size, String name)
@@ -166,8 +181,7 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block:
-        if (m.groupCount() != 3) {
+        date_time_block: if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -213,11 +227,10 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm =
-          CobolUtil.cobLocalTm
-              .withHour(rt.getHour())
-              .withMinute(rt.getMinute())
-              .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
+          .withHour(rt.getHour())
+          .withMinute(rt.getMinute())
+          .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -289,7 +302,8 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
+  }
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -597,8 +611,7 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP:
-    while (i < size && ret != 0) {
+    OUTER_LOOP: while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -629,9 +642,8 @@ public class CobolUtil {
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
     if (col != null) {
       for (int i = 0; i < size; ++i) {
-        int ret =
-            col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
-                - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
+        int ret = col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
+            - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
         if (ret != 0) {
           return ret;
         }
@@ -740,8 +752,9 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName the name of an environment variable. The leading and trailing spaces are
-   *     ignored.
+   * @param envVarName  the name of an environment variable. The leading and
+   *                    trailing spaces are
+   *                    ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/tests/run.src/ref-mod.at
+++ b/tests/run.src/ref-mod.at
@@ -262,7 +262,6 @@ AT_CLEANUP
 
 
 AT_SETUP([Offset out of bounds in MOVE (2)])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
Fix CobolUtil.checkRefMod method so that a test in tests/run.src/ref-mod.at