### PR TITLE
Fix error handlings of 0 divisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix the message of COB_VERBOSE file sort (#260)
 * Fix the process that checks MOVE statements (#266, #267)
 * Fix `INSPECT` statement (#268)
+* Fix error handlings of 0 divisions (#273)
 ### Optimized
 * Optimize the file reading process (#257)
 

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3563,7 +3563,7 @@ static void joutput_stmt(cb_tree x, enum joutput_stmt_type output_type) {
         ((strcmp(p->name, "DIVIDE") == 0) ||
          (strcmp(p->name, "COMPUTE") == 0)) &&
         (!p->handler1 && !p->handler2)) {
-      joutput_line("cobolErrorOnExitFlag = true;");
+      joutput_line("CobolUtil.cobErrorOnExitFlag = true;");
     }
 
     if (p->null_check) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -377,9 +377,9 @@ public class CobolDecimal {
     if (decimal.getValue().signum() == 0) {
       this.setScale(DECIMAL_NAN);
       if (CobolUtil.cobErrorOnExitFlag) {
-        // TODO より正確な実装に変更
-        System.err.println("Detected division by zero");
-        CobolStopRunException.throwException(1);
+        CobolUtil.runtimeError("Detected division by zero.");
+        CobolStopRunException.stopRunAndThrow(1);
+        ;
       }
       return;
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -136,7 +136,8 @@ jp_compat_DEPENDENCIES = \
 	jp-compat.src/greater-less-than-equal.at \
 	jp-compat.src/file-desc.at \
 	jp-compat.src/abort-on-file-error.at \
-	jp-compat.src/system-routine.at
+	jp-compat.src/system-routine.at \
+	jp-compat.src/catch-exception.at
 
 command_line_options_DEPENDENCIES = \
 	command-line-options.src/free.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -677,7 +677,8 @@ jp_compat_DEPENDENCIES = \
 	jp-compat.src/greater-less-than-equal.at \
 	jp-compat.src/file-desc.at \
 	jp-compat.src/abort-on-file-error.at \
-	jp-compat.src/system-routine.at
+	jp-compat.src/system-routine.at \
+	jp-compat.src/catch-exception.at
 
 command_line_options_DEPENDENCIES = \
 	command-line-options.src/free.at \

--- a/tests/jp-compat.src/catch-exception.at
+++ b/tests/jp-compat.src/catch-exception.at
@@ -49,7 +49,6 @@ AT_CLEANUP
 # 3) DONE
 
 AT_SETUP([Divide by zero: by variable - option yes])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -150,7 +149,6 @@ AT_CLEANUP
 # 7) DONE
 
 AT_SETUP([Divide by zero: by variable compute - option yes])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.

--- a/tests/jp-compat.src/catch-exception.at
+++ b/tests/jp-compat.src/catch-exception.at
@@ -204,7 +204,6 @@ AT_CLEANUP
 # 9) DONE
 
 AT_SETUP([Divide by zero: by variable with on size error])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This PR fixes error handlings of 0 divisions so that 3 tests in `tests/jp-compat.src/catch-exception.at`