### PR TITLE
Fix a test in tests/run.src/miscellaneous.at

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2947,8 +2947,6 @@ static void joutput_call(struct cb_call *p) {
     if (CB_LITERAL_P(p->name)) {
       callp = cb_encode_program_id((char *)(CB_LITERAL(p->name)->data));
       lookup_call(callp);
-      joutput_line("if (call_%s == null) {", callp);
-      joutput_indent_level += 2;
       if (cb_java_package_name) {
         joutput_line("call_%s = CobolResolve.resolve(\"%s\", \"%s\", call_%s);",
                      callp, cb_java_package_name,
@@ -2957,8 +2955,6 @@ static void joutput_call(struct cb_call *p) {
         joutput_line("call_%s = CobolResolve.resolve(null, \"%s\", call_%s);",
                      callp, (char *)(CB_LITERAL(p->name)->data), callp);
       }
-      joutput_indent_level -= 2;
-      joutput_line("}");
     } else {
       callp = NULL;
       joutput_prefix();

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -1799,7 +1799,6 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 AT_SETUP([CALL with OMITTED parameter])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION   DIVISION.
@@ -1829,9 +1828,8 @@ AT_DATA([caller.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_MODULE} callee.cob])
-AT_CHECK([${COMPILE} -o caller caller.cob])
-AT_CHECK([./caller], [0],
+AT_CHECK([${COMPILE} callee.cob caller.cob])
+AT_CHECK([java caller], [0],
 [OKOKOK
 ])
 


### PR DESCRIPTION
This PR fixes a test in tests/run.src/miscellaneous.at and revert the change of CALL statements commited in #269