### PR TITLE
Fix FUNCTION VARIANCE and a test case of FUNCTION SQRT

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -1554,18 +1554,17 @@ public class CobolIntrinsic {
     }
     CobolDataStorage data = new CobolDataStorage(8);
     field.setDataStorage(data);
-    d4.getDisplayField(field, 0);
-    long n = data.longValue();
+    d4.getField(field, 0);
+    long n = field.getLong();
     int i = 0;
     while (n != 0) {
       n /= 10;
       ++i;
     }
-    field.setDataStorage(null);
+    makeFieldEntry(field);
     if (i <= 18) {
       attr.setScale(18 - i);
     }
-    makeDoubleEntry();
     d4.getField(currField, 0);
     return currField;
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -335,7 +335,7 @@ public class CobolNumericField extends AbstractCobolField {
           // TODO Moduleの情報を参照するコードに編集する
         } else if (c == (byte) '.') {
           ++count;
-          if (count > 0) {
+          if (count > 1) {
             break outer;
           }
 

--- a/tests/run.src/functions.at
+++ b/tests/run.src/functions.at
@@ -1537,7 +1537,6 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 AT_SETUP([FUNCTION SQRT])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -1548,8 +1547,8 @@ AT_DATA([prog.cob], [
        01  Y   PIC   S9V9(17)   COMP.
        PROCEDURE        DIVISION.
            MOVE FUNCTION SQRT ( X ) TO Y.
-           IF Y >= 1.22474487139158890 AND
-              Y <= 1.22474487139158899
+           IF Y >= 1.2247448713915890 AND
+              Y <= 1.2247448713915900
                    DISPLAY "OK"
                    END-DISPLAY
            ELSE
@@ -1855,7 +1854,6 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 AT_SETUP([FUNCTION VARIANCE])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
FUNCTION VARIANCE (CobolIntrinsic.java) was modified. 
Another issue was that the test case for FUNCTION SQRT was failing. 
This was found to be due to the precision of the double type in java. 
Therefore, the numerical value of the test case was corrected.