### PR TITLE
Support Amazon Linux 2023

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["ubuntu:22.04", "almalinux:9"]
+        os: ["ubuntu:22.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax"]
-        os: ["ubuntu:22.04", "almalinux:9"]
+        os: ["ubuntu:22.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:22.04", "almalinux:9"]
+        os: ["ubuntu:22.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:22.04", "almalinux:9"]
+        os: ["ubuntu:22.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["ubuntu:22.04", "amazonlinux:2023"]
+        os: ["ubuntu:22.04"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax"]
-        os: ["ubuntu:22.04", "amazonlinux:2023"]
+        os: ["ubuntu:22.04"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:22.04", "amazonlinux:2023"]
+        os: ["ubuntu:22.04"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:22.04", "amazonlinux:2023"]
+        os: ["ubuntu:22.04"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ["ubuntu:22.04"]
+        os: ["ubuntu:22.04", "amazonlinux:2023"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax"]
-        os: ["ubuntu:22.04"]
+        os: ["ubuntu:22.04", "amazonlinux:2023"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:22.04"]
+        os: ["ubuntu:22.04", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:22.04"]
+        os: ["ubuntu:22.04", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+* Support Amazon Linux 2023 (#282)
 * Implement runtime numeric checkings (#253)
 * Implement sorting a table based on ebcdic (#254)
 * Implement KEY IS option of SORT statements (#259)

--- a/tests/command-line-options.src/fsyntax-only.at
+++ b/tests/command-line-options.src/fsyntax-only.at
@@ -39,7 +39,7 @@ AT_CHECK([for f in ./*; do echo $f; done | sort], [0],
 ./prog2.cbl
 ./prog3.cbl
 ])
-AT_CHECK([cobj --help | grep '\-fsyntax\-only' > /dev/null], [0])
+AT_CHECK([cobj --help | grep '@<:@-@:>@fsyntax@<:@-@:>@only' > /dev/null], [0])
 
 
 AT_CLEANUP

--- a/tests/command-line-options.src/jar.at
+++ b/tests/command-line-options.src/jar.at
@@ -25,8 +25,8 @@ AT_DATA([sub.cbl], [
            DISPLAY B.
 ])
 
-AT_CHECK([${COBJ} --help | grep ' \-jar' > /dev/null], [0])
-AT_CHECK([${COBJ} --help | grep '\-single-jar' > /dev/null], [0])
+AT_CHECK([${COBJ} --help | grep ' @<:@-@:>@jar' > /dev/null], [0])
+AT_CHECK([${COBJ} --help | grep '@<:@-@:>@single@<:@-@:>@jar' > /dev/null], [0])
 
 AT_CHECK([mkdir tmp])
 


### PR DESCRIPTION
opensource COBOL 4J v1.0.17 are tested on Ubuntu 22.04 and AlmaLinux 9.
As this PR fixes some tests, it is ensured that all tests of opensource COBOL 4J run successfully on Amazon Linux 2023.