### PR TITLE
Update C files based on the result of cppcheck

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,6 +42,6 @@ jobs:
           cd libcobj
           ./gradlew pmdMain
 
-      - name: Run cppcheck (ignore results)
+      - name: Run cppcheck
         run: |
-          cd cobj && cppcheck cobj.c cobj.h codegen.c config.c error.c field.c ppparse.c ppparse.h reserved.c tree.c tree.h typeck.c
+          cd cobj && cppcheck --error-exitcode=1 cobj.c cobj.h codegen.c config.c error.c field.c ppparse.c ppparse.h reserved.c tree.c tree.h typeck.c

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run cppcheck (ignore results)
         run: |
-          cd cobj && cppcheck cobj.c cobj.h codegen.c config.c error.c field.c pplex.c ppparse.c ppparse.h reserved.c tree.c tree.h typeck.c
+          cd cobj && cppcheck cobj.c cobj.h codegen.c config.c error.c field.c ppparse.c ppparse.h reserved.c tree.c tree.h typeck.c

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1745,7 +1745,7 @@ static int process_compile(struct filename *fn) {
 }
 
 static int process_build_module(struct filename *fn) {
-  int ret;
+  int ret = 0;
   char buff[COB_MEDIUM_BUFF];
   char name[COB_MEDIUM_BUFF];
 

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1712,39 +1712,36 @@ static int process_compile(struct filename *fn) {
   char *output_name_a = output_name == NULL ? "./" : output_name;
   char *java_source_dir_a = java_source_dir == NULL ? "./" : java_source_dir;
 
-  if (!cb_single_jar_name) {
-    char **program_id;
-    for (program_id = program_id_list; *program_id; ++program_id) {
-      sprintf(buff, "javac %s -encoding SJIS -d %s %s/%s.java", cob_java_flags,
-              output_name_a, java_source_dir_a, *program_id);
-      ret = process(buff);
+  char **program_id;
+  for (program_id = program_id_list; *program_id; ++program_id) {
+    sprintf(buff, "javac %s -encoding SJIS -d %s %s/%s.java", cob_java_flags,
+            output_name_a, java_source_dir_a, *program_id);
+    ret = process(buff);
 
+    if (ret) {
+      return ret;
+    }
+    if (cb_flag_jar) {
+      char *package_dir;
+      if (cb_java_package_name) {
+        package_name_to_path(buff2, cb_java_package_name);
+        package_dir = buff2;
+      } else {
+        package_dir = ".";
+      }
+      sprintf(buff,
+              "cd %s && jar --create --main-class=%s --file=%s.jar %s/*.class",
+              output_name_a, *program_id, *program_id, package_dir);
+      ret = process(buff);
       if (ret) {
         return ret;
       }
-      if (cb_flag_jar) {
-        char *package_dir;
-        if (cb_java_package_name) {
-          package_name_to_path(buff2, cb_java_package_name);
-          package_dir = buff2;
-        } else {
-          package_dir = ".";
-        }
-        sprintf(
-            buff,
-            "cd %s && jar --create --main-class=%s --file=%s.jar %s/*.class",
-            output_name_a, *program_id, *program_id, package_dir);
-        ret = process(buff);
-        if (ret) {
-          return ret;
-        }
-        sprintf(buff, "rm -rf %s/%s.class %s/%s$*.class", output_name_a,
-                *program_id, output_name_a, *program_id);
-        process(buff);
-      }
+      sprintf(buff, "rm -rf %s/%s.class %s/%s$*.class", output_name_a,
+              *program_id, output_name_a, *program_id);
+      process(buff);
     }
-    return ret;
   }
+  return ret;
 }
 
 static int process_build_module(struct filename *fn) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -4917,7 +4917,7 @@ static void *list_cache_sort(void *inlist,
       }
       p = q;
     }
-    if(tail) {
+    if (tail) {
       tail->next = NULL;
     }
     if (nmerges <= 1) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -4917,7 +4917,9 @@ static void *list_cache_sort(void *inlist,
       }
       p = q;
     }
-    tail->next = NULL;
+    if(tail) {
+      tail->next = NULL;
+    }
     if (nmerges <= 1) {
       return (void *)list;
     }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -2432,6 +2432,11 @@ cb_tree cb_build_cond(cb_tree x) {
   cb_tree d2;
   cb_tree err = NULL;
 
+  if (!x) {
+    cb_error_x(x, _("Invalid expression"));
+    return cb_error_node;
+  }
+
   switch (CB_TREE_TAG(x)) {
   case CB_TAG_CONST:
   case CB_TAG_FUNCALL:


### PR DESCRIPTION
This PR updates some files based on the result of  cppcheck and all errors are resolved.
Although the results of cppcheck are ignored with older versions, CI fails with the newer version when errors and warnings are occured.