### PR TITLE
Fix Java files based on the analysis result of SpotBugs

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,10 +32,10 @@ jobs:
         run: |
           ./check-format
 
-      - name: Run SpotBugs (ignore results)
+      - name: Run SpotBugs
         working-directory: libcobj
         run: |
-          ./gradlew spotbugsMain || true
+          ./gradlew spotbugsMain
 
       - name: Run PMD
         working-directory: libcobj

--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -40,7 +40,7 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolGoBackException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/RuntimeErrorHandler.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolException.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolUndefinedException.java \

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -320,7 +320,7 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolGoBackException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/RuntimeErrorHandler.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolException.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolUndefinedException.java \

--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -44,6 +44,10 @@ pmd {
     ruleSetFiles = files("${rootDir}/config/pmdRuleSet.xml")
 }
 
+spotbugs {
+    excludeFilter.set(project.file("${rootDir}/config/spotbugsFilter.xml"))
+}
+
 publishing {
     repositories {
         maven {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
@@ -214,7 +214,7 @@ public class CobolResolve {
   }
 
   /** 初期化を行う */
-  public static void CobolInitCall() {
+  public static void cobolInitCall() {
 
     String s;
     String buf;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -2020,7 +2020,7 @@ public class CobolIntrinsic {
         exceptName =
             CobolRuntimeException.getExceptionName(CobolRuntimeException.getExceptionCode())
                 .getBytes();
-      } catch (NullPointerException e) {
+      } catch (Exception e) {
         exceptName = CONST_STRING_EXCEPTION_OBJECT;
       }
       currField.memcpy(exceptName, exceptName.length);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -994,7 +994,8 @@ public class CobolIntrinsic {
   }
 
   public static AbstractCobolField funcNumvalC(int n, AbstractCobolField currency) {
-    return funcNumvalC(null, currency);
+    // TODO
+    return null;
   }
 
   public static AbstractCobolField funcNumvalC(AbstractCobolField srcfield, int n) {
@@ -1002,7 +1003,8 @@ public class CobolIntrinsic {
   }
 
   public static AbstractCobolField funcNumvalC(int n, int m) {
-    return funcNumvalC(null, null);
+    // TODO
+    return null;
   }
 
   /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -1705,7 +1705,6 @@ public class CobolIntrinsic {
     int srdays;
     int srtime;
     String str;
-    byte[] buff = new byte[12];
 
     CobolFieldAttribute attr =
         new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY, 12, 5, 0, null);
@@ -1725,10 +1724,10 @@ public class CobolIntrinsic {
       return currField;
     }
     str = String.format("%7d%5d", srdays, srtime);
-    buff = str.getBytes();
-    for (int i = 0; i < 12; i++) {
-      if (buff[i] == 32) {
-        buff[i] = 48;
+    byte[] buff = str.getBytes();
+    for (int i = 0; i < buff.length; i++) {
+      if (buff[i] == ' ') {
+        buff[i] = '0';
       }
     }
     currField.getDataStorage().memcpy(buff);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -2085,19 +2085,19 @@ public class CobolIntrinsic {
       p1 = new String(formatData.getByteArray(n, 2));
 
       if ("hh".equals(p1) && !hoursSeen) {
-        p2 = Integer.valueOf(new String(valueData.getByteArray(n, 2)));
+        p2 = Integer.parseInt(new String(valueData.getByteArray(n, 2)));
         hours = p2;
         hoursSeen = true;
         continue;
       }
       if ("mm".equals(p1) && !minutesSeen) {
-        p2 = Integer.valueOf(new String(valueData.getByteArray(n, 2)));
+        p2 = Integer.parseInt(new String(valueData.getByteArray(n, 2)));
         minutes = p2;
         minutesSeen = true;
         continue;
       }
       if ("ss".equals(p1) && !secondsSeen) {
-        p2 = Integer.valueOf(new String(valueData.getByteArray(n, 2)));
+        p2 = Integer.parseInt(new String(valueData.getByteArray(n, 2)));
         seconds = p2;
         secondsSeen = true;
         continue;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -22,7 +22,7 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
@@ -295,7 +295,7 @@ public class CobolString {
 
   public static void unstringInto(
       AbstractCobolField dst, AbstractCobolField dlm, AbstractCobolField cnt) {
-    if (CobolException.code != 0) {
+    if (CobolExceptionInfo.code != 0) {
       return;
     }
     if (unstringOffset >= unstringSrc.getSize()) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -22,8 +22,8 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -406,9 +406,7 @@ public class CobolString {
     }
   }
 
-  public static void unstringTallying(int f) throws CobolStopRunException {
-    unstringTallying(null);
-  }
+  public static void unstringTallying(int f) throws CobolStopRunException {}
 
   public static void unstringTallying(AbstractCobolField f) throws CobolStopRunException {
     f.addInt(unstringCount);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -27,7 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
@@ -189,8 +189,7 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block:
-        if (m.groupCount() != 3) {
+        date_time_block: if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -236,11 +235,10 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm =
-          CobolUtil.cobLocalTm
-              .withHour(rt.getHour())
-              .withMinute(rt.getMinute())
-              .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
+          .withHour(rt.getHour())
+          .withMinute(rt.getMinute())
+          .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -299,7 +297,7 @@ public class CobolUtil {
   public static void getEnvironment(AbstractCobolField envname, AbstractCobolField envval) {
     String p = CobolUtil.getEnv(envname.fieldToString());
     if (p == null) {
-      CobolException.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
+      CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
       p = " ";
     }
     envval.memcpy(p);
@@ -312,7 +310,8 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
+  }
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -620,8 +619,7 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP:
-    while (i < size && ret != 0) {
+    OUTER_LOOP: while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -652,9 +650,8 @@ public class CobolUtil {
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
     if (col != null) {
       for (int i = 0; i < size; ++i) {
-        int ret =
-            col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
-                - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
+        int ret = col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
+            - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
         if (ret != 0) {
           return ret;
         }
@@ -763,8 +760,9 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName the name of an environment variable. The leading and trailing spaces are
-   *     ignored.
+   * @param envVarName  the name of an environment variable. The leading and
+   *                    trailing spaces are
+   *                    ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -27,8 +27,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
@@ -66,7 +66,7 @@ public class CobolUtil {
   public static String currParagraph;
   public static String sourceStatement;
 
-  abstract class HandlerList {
+  abstract static class HandlerList {
     public HandlerList next = null;
 
     public abstract int proc(String s);
@@ -189,7 +189,8 @@ public class CobolUtil {
       Pattern p = Pattern.compile("([0-9]{4})/([0-9]{2})/([0-9]{2})");
       Matcher m = p.matcher(s);
       if (m.matches()) {
-        date_time_block: if (m.groupCount() != 3) {
+        date_time_block:
+        if (m.groupCount() != 3) {
           System.err.println("Warning: COB_DATE format invalid, ignored.");
         } else {
           int year = Integer.parseInt(m.group(1));
@@ -235,10 +236,11 @@ public class CobolUtil {
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
     if (CobolUtil.cobLocalTm != null) {
-      CobolUtil.cobLocalTm = CobolUtil.cobLocalTm
-          .withHour(rt.getHour())
-          .withMinute(rt.getMinute())
-          .withSecond(rt.getSecond());
+      CobolUtil.cobLocalTm =
+          CobolUtil.cobLocalTm
+              .withHour(rt.getHour())
+              .withMinute(rt.getMinute())
+              .withSecond(rt.getSecond());
       rt = CobolUtil.cobLocalTm;
     }
     return rt;
@@ -310,8 +312,7 @@ public class CobolUtil {
    * @param numParams
    * @throws CobolStopRunException
    */
-  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {
-  }
+  public static void COB_CHK_PARMS(String funcName, int numParams) throws CobolStopRunException {}
 
   /**
    * libcob/common.cのcob_get_switchの実装
@@ -619,7 +620,8 @@ public class CobolUtil {
   public static int isNationalPadding(CobolDataStorage s, int size) {
     int ret = 1;
     int i = 0;
-    OUTER_LOOP: while (i < size && ret != 0) {
+    OUTER_LOOP:
+    while (i < size && ret != 0) {
       if (s.getByte(i) == ' ') {
         i++;
       } else if (size - i > CobolConstant.ZENCSIZ) {
@@ -650,8 +652,9 @@ public class CobolUtil {
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
     if (col != null) {
       for (int i = 0; i < size; ++i) {
-        int ret = col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
-            - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
+        int ret =
+            col.getByte(Byte.toUnsignedInt(s1.getByte(i)))
+                - col.getByte(Byte.toUnsignedInt(s2.getByte(i)));
         if (ret != 0) {
           return ret;
         }
@@ -760,9 +763,8 @@ public class CobolUtil {
   /**
    * Set environemnt variable
    *
-   * @param envVarName  the name of an environment variable. The leading and
-   *                    trailing spaces are
-   *                    ignored.
+   * @param envVarName the name of an environment variable. The leading and trailing spaces are
+   *     ignored.
    * @param envVarValue the value of an environment variable to be set.
    */
   public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -1244,7 +1244,7 @@ public abstract class AbstractCobolField {
           data = data.getSubDataStorage(this.getSize());
         }
         if (size > 0) {
-          comparator.compare(this.getDataStorage(), data, size, s);
+          ret = comparator.compare(this.getDataStorage(), data, size, s);
         }
       } while (false);
     } else {
@@ -1263,7 +1263,7 @@ public abstract class AbstractCobolField {
           data = data.getSubDataStorage(other.getSize());
         }
         if (size > 0) {
-          comparator.compare(data, other.getDataStorage(), size, s);
+          ret = comparator.compare(data, other.getDataStorage(), size, s);
         }
       } while (false);
     }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -446,23 +446,8 @@ public abstract class AbstractCobolField {
   }
 
   protected AbstractCobolField preprocessOfMoving(AbstractCobolField src) {
-    AbstractCobolField src1;
 
-    // TODO 以下の分岐は不要?
-    if (src == CobolConstant.quote
-        || src == CobolConstant.zenQuote
-        || src == CobolConstant.space
-        || src == CobolConstant.zenSpace
-        || src == CobolConstant.blank
-        || src == CobolConstant.zenBlank
-        || src == CobolConstant.zero
-        || src == CobolConstant.zenZero) {
-      src1 = src;
-    } else {
-      src1 = src;
-    }
-
-    if (src1.getAttribute().isTypeAlphanumAll() || src1.getAttribute().isTypeNationalAll()) {
+    if (src.getAttribute().isTypeAlphanumAll() || src.getAttribute().isTypeNationalAll()) {
       this.moveFromAll(src);
       return null;
     }
@@ -471,7 +456,7 @@ public abstract class AbstractCobolField {
       return null;
     }
 
-    CobolFieldAttribute srcAttr = src1.getAttribute();
+    CobolFieldAttribute srcAttr = src.getAttribute();
     CobolFieldAttribute dstAttr = this.getAttribute();
     if (!srcAttr.isTypeGroup()) {
       if ((srcAttr.isTypeNumeric() || srcAttr.isTypeAlphanum() || srcAttr.isTypeAlphanumEdited())
@@ -481,21 +466,21 @@ public abstract class AbstractCobolField {
         if (srcAttr.isTypeNumericDisplay()
             || srcAttr.isTypeAlphanum()
             || srcAttr.isTypeAlphanumEdited()) {
-          pTmp = CobolNationalField.judge_hankakujpn_exist(src1);
+          pTmp = CobolNationalField.judge_hankakujpn_exist(src);
           size = CobolNationalField.workReturnSize;
         }
         if (pTmp != null) {
-          src1.setDataStorage(new CobolDataStorage(pTmp));
-          src1.setSize(size);
+          src.setDataStorage(new CobolDataStorage(pTmp));
+          src.setSize(size);
         }
-        if (src1.size == 0) {
-          src1 = CobolConstant.zenSpace;
+        if (src.size == 0) {
+          src = CobolConstant.zenSpace;
         }
       }
     }
 
-    if (src1.getSize() == 0) {
-      src1 = CobolConstant.space;
+    if (src.getSize() == 0) {
+      src = CobolConstant.space;
     }
 
     return src;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -446,8 +446,9 @@ public abstract class AbstractCobolField {
   }
 
   protected AbstractCobolField preprocessOfMoving(AbstractCobolField src) {
+    AbstractCobolField src1 = src;
 
-    if (src.getAttribute().isTypeAlphanumAll() || src.getAttribute().isTypeNationalAll()) {
+    if (src1.getAttribute().isTypeAlphanumAll() || src1.getAttribute().isTypeNationalAll()) {
       this.moveFromAll(src);
       return null;
     }
@@ -456,7 +457,7 @@ public abstract class AbstractCobolField {
       return null;
     }
 
-    CobolFieldAttribute srcAttr = src.getAttribute();
+    CobolFieldAttribute srcAttr = src1.getAttribute();
     CobolFieldAttribute dstAttr = this.getAttribute();
     if (!srcAttr.isTypeGroup()) {
       if ((srcAttr.isTypeNumeric() || srcAttr.isTypeAlphanum() || srcAttr.isTypeAlphanumEdited())
@@ -466,21 +467,21 @@ public abstract class AbstractCobolField {
         if (srcAttr.isTypeNumericDisplay()
             || srcAttr.isTypeAlphanum()
             || srcAttr.isTypeAlphanumEdited()) {
-          pTmp = CobolNationalField.judge_hankakujpn_exist(src);
+          pTmp = CobolNationalField.judge_hankakujpn_exist(src1);
           size = CobolNationalField.workReturnSize;
         }
         if (pTmp != null) {
-          src.setDataStorage(new CobolDataStorage(pTmp));
-          src.setSize(size);
+          src1.setDataStorage(new CobolDataStorage(pTmp));
+          src1.setSize(size);
         }
-        if (src.size == 0) {
-          src = CobolConstant.zenSpace;
+        if (src1.size == 0) {
+          return src1;
         }
       }
     }
 
-    if (src.getSize() == 0) {
-      src = CobolConstant.space;
+    if (src1.getSize() == 0) {
+      return src1;
     }
 
     return src;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -187,7 +187,7 @@ public abstract class AbstractCobolField {
     int firstDataIndex = this.getFirstDataIndex();
     int size = this.getFieldSize();
 
-    if (data.getByte(firstDataIndex) == 255) {
+    if (Byte.toUnsignedInt(data.getByte(firstDataIndex)) == 0xFF) {
       CobolDecimal decimal = new CobolDecimal(BigDecimal.TEN.pow(size));
       decimal.setScale(this.getAttribute().getScale());
       return decimal;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -1517,8 +1517,7 @@ public class CobolDataStorage {
     return retval;
   }
 
-  /** */
-  private class PairInt {
+  private static class PairInt {
     public int first;
     public int last;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -163,7 +163,6 @@ public class CobolDecimal {
   /** libcob/numeric.cのcob_decimal_initの実装 */
   public void decimalInit() {
     this.value = BigDecimal.ZERO;
-    this.value.setScale(0);
   }
 
   /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -658,16 +658,16 @@ public class CobolDecimal {
       }
       byte val = (byte) ((int) numBuffPtr[j] - '0');
       int index;
-      if (digits % 2 == 1) {
-        index = i / 2;
-      } else {
+      if (digits % 2 == 0) {
         index = (i + 1) / 2;
+      } else {
+        index = i / 2;
       }
       byte b = data.getByte(index);
-      if ((digits + i) % 2 == 1) {
-        data.setByte(index, (val << 4) | (b & 0x0F));
-      } else {
+      if ((digits + i) % 2 == 0) {
         data.setByte(index, (b & 0xF0) | val);
+      } else {
+        data.setByte(index, (val << 4) | (b & 0x0F));
       }
     }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -43,6 +43,7 @@ public class CobolDecimal {
   public static CobolDecimal cobD4 = new CobolDecimal();
   public static BigDecimal[] cobMpze10 = new BigDecimal[COB_MAX_BINARY];
   public static byte[] packedValue = new byte[20];
+  public static int packedValueInt = 0;
 
   public static void cobInitNumeric() {
     cobD1 = new CobolDecimal();
@@ -57,6 +58,7 @@ public class CobolDecimal {
     for (int i = 0; i < packedValue.length; ++i) {
       packedValue[i] = 0;
     }
+    packedValueInt = 0;
   }
 
   // TODO cob_init_numeric周辺の初期化処理を正しく実装出来たら消す。
@@ -68,6 +70,7 @@ public class CobolDecimal {
     for (int i = 0; i < packedValue.length; ++i) {
       packedValue[i] = 0;
     }
+    packedValueInt = 0;
   }
 
   /** 保持する数値データ */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -22,8 +22,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import jp.osscons.opensourcecobol.libcobj.common.CobolModule;
 import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
@@ -498,14 +498,15 @@ public class CobolDecimal {
       default:
         int digits = f.getAttribute().getDigits();
         CobolFieldAttribute attr = f.getAttribute();
-        CobolFieldAttribute newAttr = new CobolFieldAttribute(
-            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-            digits,
-            attr.getScale(),
-            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-            null);
-        AbstractCobolField displayField = CobolFieldFactory.makeCobolField(digits, new CobolDataStorage(digits),
-            newAttr);
+        CobolFieldAttribute newAttr =
+            new CobolFieldAttribute(
+                CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+                digits,
+                attr.getScale(),
+                CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+                null);
+        AbstractCobolField displayField =
+            CobolFieldFactory.makeCobolField(digits, new CobolDataStorage(digits), newAttr);
         if (d.getField(displayField, opt) == 0) {
           f.moveFrom(displayField);
         }
@@ -680,9 +681,6 @@ public class CobolDecimal {
     return 0;
   }
 
-  class OverflowException extends Exception {
-  }
-
   /**
    * libcob/numeric.cのcob_decimal_get_binaryの実装
    *
@@ -709,7 +707,8 @@ public class CobolDecimal {
       }
     }
     int bitnum = f.getSize() * 8 - sign;
-    outer: {
+    outer:
+    {
       if (this.getValue().compareTo(new BigDecimal(2).pow(bitnum).subtract(BigDecimal.ONE)) > 0) {
         if ((opt & COB_STORE_KEEP_ON_OVERFLOW) != 0) {
           break outer;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import jp.osscons.opensourcecobol.libcobj.common.CobolModule;
 import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
@@ -498,19 +498,18 @@ public class CobolDecimal {
       default:
         int digits = f.getAttribute().getDigits();
         CobolFieldAttribute attr = f.getAttribute();
-        CobolFieldAttribute newAttr =
-            new CobolFieldAttribute(
-                CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
-                digits,
-                attr.getScale(),
-                CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
-                null);
-        AbstractCobolField displayField =
-            CobolFieldFactory.makeCobolField(digits, new CobolDataStorage(digits), newAttr);
+        CobolFieldAttribute newAttr = new CobolFieldAttribute(
+            CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY,
+            digits,
+            attr.getScale(),
+            CobolFieldAttribute.COB_FLAG_HAVE_SIGN,
+            null);
+        AbstractCobolField displayField = CobolFieldFactory.makeCobolField(digits, new CobolDataStorage(digits),
+            newAttr);
         if (d.getField(displayField, opt) == 0) {
           f.moveFrom(displayField);
         }
-        return CobolException.code;
+        return CobolExceptionInfo.code;
     }
   }
 
@@ -681,7 +680,8 @@ public class CobolDecimal {
     return 0;
   }
 
-  class OverflowException extends Exception {}
+  class OverflowException extends Exception {
+  }
 
   /**
    * libcob/numeric.cのcob_decimal_get_binaryの実装
@@ -709,8 +709,7 @@ public class CobolDecimal {
       }
     }
     int bitnum = f.getSize() * 8 - sign;
-    outer:
-    {
+    outer: {
       if (this.getValue().compareTo(new BigDecimal(2).pow(bitnum).subtract(BigDecimal.ONE)) > 0) {
         if ((opt & COB_STORE_KEEP_ON_OVERFLOW) != 0) {
           break outer;
@@ -740,7 +739,7 @@ public class CobolDecimal {
       }
     }
     CobolRuntimeException.setException(CobolExceptionId.COB_EC_SIZE_OVERFLOW);
-    return CobolException.code;
+    return CobolExceptionInfo.code;
   }
 
   /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -887,9 +887,8 @@ public class CobolNumericPackedField extends AbstractCobolField {
     if (this.getAttribute().getDigits() % 2 == 0) {
       val1[20 - this.getSize()] &= 0x0F;
     }
-    int lastval = 0;
-    if (n != lastval) {
-      lastval = n;
+    if (n != CobolDecimal.packedValueInt) {
+      CobolDecimal.packedValueInt = n;
       if (n < 0) {
         n = -n;
       }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -18,10 +18,10 @@
  */
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
-public class CobolException {
+public class CobolExceptionInfo {
   public static int code = 0;
 
   public static void setException(int id) {
-    CobolException.code = CobolExceptionTabCode.code[id];
+    CobolExceptionInfo.code = CobolExceptionTabCode.code[id];
   }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -1274,7 +1274,8 @@ public class CobolFile {
       if (f.open_mode != COB_OPEN_CLOSED && f.open_mode != COB_OPEN_LOCKED) {
         String filename = f.assign.fieldToString();
         System.err.print(
-            String.format("WARNING - Implicit CLOSE of %s (\"%s\") \n", f.select_name, filename));
+            String.format(
+                "WARNING - Implicit CLOSE of %s (\"%s\") %c", f.select_name, filename, '\n'));
       }
     }
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -1490,7 +1490,12 @@ public class CobolFile {
       file_open_name = new String(fileOpenNameBytes);
     }
 
-    Path filePath = Paths.get(this.assign.fieldToString());
+    Path filePath;
+    if (this.assign == null) {
+      filePath = Paths.get(this.select_name);
+    } else {
+      filePath = Paths.get(this.assign.fieldToString());
+    }
     try {
       saveStatus(COB_STATUS_00_SUCCESS, fnstatus);
       Files.delete(filePath);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -497,7 +497,8 @@ public class CobolFile {
          * jbuf[i] = 0;
          * }
          */
-        rt = jbuf;
+        // TODO
+        rt = null;
       }
       if (flagQuoted && siz > 2) {
         rt[0] = rt[siz - 2] = (byte) '\'';
@@ -529,7 +530,8 @@ public class CobolFile {
          * jbuf[i] = name[i];
          * }
          */
-        rt = jbuf;
+        // TODO fix
+        rt = null;
       }
     }
     return rt;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolRelativeFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolRelativeFile.java
@@ -118,8 +118,7 @@ public class CobolRelativeFile extends CobolFile {
           this.fp.seek(this.fp.length());
           break;
         default:
-          this.fp = null;
-          break;
+          return EACCESS;
       }
     } catch (IOException e) {
       if (this.fp != null) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
@@ -63,6 +63,7 @@ public class FileIO {
 
   public void setChannel(FileChannel fc, FileLock fl) {
     this.fc = fc;
+    this.fl = fl;
     this.useStdOut = false;
     this.useStdIn = false;
 
@@ -234,7 +235,7 @@ public class FileIO {
       return 0;
     }
     if (USE_STD_BUFFER) {
-      byte[] arr = {val};
+      byte[] arr = { val };
       try {
         this.bos.write(arr);
       } catch (IOException e) {
@@ -243,7 +244,7 @@ public class FileIO {
       return val;
     } else {
       try {
-        byte[] arr = {val};
+        byte[] arr = { val };
         this.fc.write(ByteBuffer.wrap(arr));
       } catch (IOException e) {
         return -1;
@@ -302,8 +303,7 @@ public class FileIO {
 
   public void close() {
     if (!useStdOut && !useStdIn && this.fc != null) {
-      outer:
-      if (USE_STD_BUFFER) {
+      outer: if (USE_STD_BUFFER) {
         try {
           this.bos.flush();
           this.bis.close();
@@ -356,7 +356,8 @@ public class FileIO {
     return true;
   }
 
-  public void seekInit() {}
+  public void seekInit() {
+  }
 
   public void rewind() {
     if (!useStdOut && !useStdIn) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
@@ -235,7 +235,7 @@ public class FileIO {
       return 0;
     }
     if (USE_STD_BUFFER) {
-      byte[] arr = { val };
+      byte[] arr = {val};
       try {
         this.bos.write(arr);
       } catch (IOException e) {
@@ -244,7 +244,7 @@ public class FileIO {
       return val;
     } else {
       try {
-        byte[] arr = { val };
+        byte[] arr = {val};
         this.fc.write(ByteBuffer.wrap(arr));
       } catch (IOException e) {
         return -1;
@@ -303,7 +303,8 @@ public class FileIO {
 
   public void close() {
     if (!useStdOut && !useStdIn && this.fc != null) {
-      outer: if (USE_STD_BUFFER) {
+      outer:
+      if (USE_STD_BUFFER) {
         try {
           this.bos.flush();
           this.bis.close();
@@ -356,8 +357,7 @@ public class FileIO {
     return true;
   }
 
-  public void seekInit() {
-  }
+  public void seekInit() {}
 
   public void rewind() {
     if (!useStdOut && !useStdIn) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -606,20 +606,11 @@ public final class IndexedCursor {
   private Optional<ResultSet> getCursorForFirstLast(
       int index, boolean isDuplicate, CursorReadOption option) {
     final String query = getQueryForFirstLast(index, isDuplicate, option);
-    Statement statement = null;
     try {
-      statement = this.conn.createStatement();
+      Statement statement = this.conn.createStatement();
       return Optional.ofNullable(statement.executeQuery(query));
     } catch (SQLException e) {
       return Optional.empty();
-    } finally {
-      if (statement != null) {
-        try {
-          statement.close();
-        } catch (SQLException e2) {
-          return Optional.empty();
-        }
-      }
     }
   }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -606,11 +606,20 @@ public final class IndexedCursor {
   private Optional<ResultSet> getCursorForFirstLast(
       int index, boolean isDuplicate, CursorReadOption option) {
     final String query = getQueryForFirstLast(index, isDuplicate, option);
+    Statement statement = null;
     try {
-      Statement statement = this.conn.createStatement();
+      statement = this.conn.createStatement();
       return Optional.ofNullable(statement.executeQuery(query));
     } catch (SQLException e) {
       return Optional.empty();
+    } finally {
+      if (statement != null) {
+        try {
+          statement.close();
+        } catch (SQLException e2) {
+          return Optional.empty();
+        }
+      }
     }
   }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -29,7 +29,7 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolException;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 
 /** 標準出力,標準エラー出力に関するメソッドを実装するクラス */
@@ -39,8 +39,8 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr trueなら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
-   * @param fields 出力する変数(可変長)
+   * @param newline  trueなら出力後に改行しない,それ以外の場合は改行する
+   * @param fields   出力する変数(可変長)
    */
   public static void display(boolean dispStdout, boolean newline, AbstractCobolField... fields) {
     PrintStream stream = dispStdout ? System.out : System.err;
@@ -68,9 +68,9 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr 0なら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline 0なら出力後に改行しない,それ以外の場合は改行する
-   * @param varcnt 出力する変数の数
-   * @param fields 出力する変数(可変長)
+   * @param newline  0なら出力後に改行しない,それ以外の場合は改行する
+   * @param varcnt   出力する変数の数
+   * @param fields   出力する変数(可変長)
    */
   public static void display(int outorerr, int newline, int varcnt, AbstractCobolField... fields) {
     PrintStream stream = outorerr == 0 ? System.out : System.err;
@@ -215,7 +215,7 @@ public class CobolTerminal {
    */
   public static void displayEnvValue(AbstractCobolField f) {
     if (CobolUtil.cobLocalEnv == null || CobolUtil.cobLocalEnv.equals("")) {
-      CobolException.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
+      CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
       return;
     }
   }
@@ -233,7 +233,7 @@ public class CobolTerminal {
 
     if (p == null) {
       // TODO setExceptionは暫定実装
-      CobolException.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
+      CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
       p = " ";
     }
 
@@ -275,15 +275,13 @@ public class CobolTerminal {
    * @param f
    */
   public static void displayArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     temp.moveFrom(f);
     int n = ByteBuffer.wrap(data).getInt();
     if (n < 0 || n > CobolUtil.commandLineArgs.length) {
-      CobolException.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
+      CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
       return;
     }
     CobolUtil.currentArgIndex = n;
@@ -295,12 +293,10 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr =
-        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
     ByteBuffer.wrap(data).putInt(CobolUtil.commandLineArgs.length);
-    AbstractCobolField temp =
-        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     f.moveFrom(temp);
   }
 
@@ -311,7 +307,7 @@ public class CobolTerminal {
    */
   public static void acceptArgValue(AbstractCobolField f) {
     if (CobolUtil.currentArgIndex > CobolUtil.commandLineArgs.length) {
-      CobolException.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
+      CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_ACCEPT);
       return;
     }
     f.memcpy(CobolUtil.commandLineArgs[CobolUtil.currentArgIndex - 1]);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -29,8 +29,8 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
-import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 
 /** 標準出力,標準エラー出力に関するメソッドを実装するクラス */
 public class CobolTerminal {
@@ -39,8 +39,8 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr trueなら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline  trueなら出力後に改行しない,それ以外の場合は改行する
-   * @param fields   出力する変数(可変長)
+   * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
+   * @param fields 出力する変数(可変長)
    */
   public static void display(boolean dispStdout, boolean newline, AbstractCobolField... fields) {
     PrintStream stream = dispStdout ? System.out : System.err;
@@ -68,9 +68,9 @@ public class CobolTerminal {
    * cob_displayの実装 TODO 暫定実装
    *
    * @param outorerr 0なら標準出力に,それ以外は標準エラー出力に出力する.
-   * @param newline  0なら出力後に改行しない,それ以外の場合は改行する
-   * @param varcnt   出力する変数の数
-   * @param fields   出力する変数(可変長)
+   * @param newline 0なら出力後に改行しない,それ以外の場合は改行する
+   * @param varcnt 出力する変数の数
+   * @param fields 出力する変数(可変長)
    */
   public static void display(int outorerr, int newline, int varcnt, AbstractCobolField... fields) {
     PrintStream stream = outorerr == 0 ? System.out : System.err;
@@ -275,9 +275,11 @@ public class CobolTerminal {
    * @param f
    */
   public static void displayArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr =
+        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
-    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp =
+        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     temp.moveFrom(f);
     int n = ByteBuffer.wrap(data).getInt();
     if (n < 0 || n > CobolUtil.commandLineArgs.length) {
@@ -293,10 +295,12 @@ public class CobolTerminal {
    * @param f
    */
   public static void acceptArgNumber(AbstractCobolField f) {
-    CobolFieldAttribute attr = new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
+    CobolFieldAttribute attr =
+        new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY, 9, 0, 0, null);
     byte[] data = new byte[4];
     ByteBuffer.wrap(data).putInt(CobolUtil.commandLineArgs.length);
-    AbstractCobolField temp = CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
+    AbstractCobolField temp =
+        CobolFieldFactory.makeCobolField(data.length, new CobolDataStorage(data), attr);
     f.moveFrom(temp);
   }
 

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -10,4 +10,9 @@
     <Class name="jp.osscons.opensourcecobol.libcobj.common.CobolInspect" />
     <Bug code="DLS" />
   </Match>
+  <Match>
+    <Class name="jp.osscons.opensourcecobol.libcobj.call.CobolResolve" />
+    <Method name="cobCancel" />
+    <Bug code="NP" />
+  </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,6 +4,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS,EI,EI2" />
+    <Bug code="MS,EI,EI2,UrF,UuF" />
   </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,7 +4,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA" />
+    <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA,ODR" />
   </Match>
   <Match>
     <Class name="jp.osscons.opensourcecobol.libcobj.common.CobolInspect" />

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,6 +4,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS" />
+    <Bug code="MS,EI,EI2" />
   </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,6 +4,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS,EI,EI2,UrF,UuF,Dm" />
+    <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA" />
   </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -15,4 +15,9 @@
     <Method name="cobCancel" />
     <Bug code="NP" />
   </Match>
+  <Match>
+    <Class name="jp.osscons.opensourcecobol.libcobj.data.CobolDecimal" />
+    <Method name="compareTo" />
+    <Bug code="Eq" />
+  </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -3,6 +3,8 @@
               xmlns="https://github.com/spotbugs/filter/3.0.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+  <!-- In order to check details of bugs, see the list of bug code -->
+  <!-- https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html -->
   <Match>
     <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA,ODR,ST" />
   </Match>
@@ -19,5 +21,10 @@
     <Class name="jp.osscons.opensourcecobol.libcobj.data.CobolDecimal" />
     <Method name="compareTo" />
     <Bug code="Eq" />
+  </Match>
+  <Match>
+    <Class name="jp.osscons.opensourcecobol.libcobj.common.CobolUtil" />
+    <Method name="cob_init" />
+    <Bug code="STCAL" />
   </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -6,4 +6,8 @@
   <Match>
     <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA" />
   </Match>
+  <Match>
+    <Class name="jp.osscons.opensourcecobol.libcobj.common.CobolInspect" />
+    <Bug code="DLS" />
+  </Match>
 </FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+              xmlns="https://github.com/spotbugs/filter/3.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+  <Match>
+    <Bug code="MS" />
+  </Match>
+</FindBugsFilter>

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,7 +4,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA,ODR" />
+    <Bug code="MS,EI,EI2,UrF,UuF,Dm,OBL,PA,ODR,ST" />
   </Match>
   <Match>
     <Class name="jp.osscons.opensourcecobol.libcobj.common.CobolInspect" />

--- a/libcobj/config/spotbugsFilter.xml
+++ b/libcobj/config/spotbugsFilter.xml
@@ -4,6 +4,6 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
   <Match>
-    <Bug code="MS,EI,EI2,UrF,UuF" />
+    <Bug code="MS,EI,EI2,UrF,UuF,Dm" />
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Although workflows had executed SpotBugs previously, the reulst is ignored.
This PR did the followings.

* Fix some errors detected by Spotbugs
* Add some SpotBugs rules to exclusion rule lists
* Update a workflow file so that a workflow run fails if SpotBugs finds one or more errors

Since a lot of SpotBugs rules are excluded without deep considaration, we will resolve them as future work.