### PR TITLE
[WIP] Start developping CLI command that handles indexed files

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax"]
+        test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax", "cobj-idx"]
         os: ["ubuntu:22.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-other.yml
     with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax"]
+        test_name: ["command-line-options", "data-rep", "i18n_sjis", "jp-compat", "run", "syntax", "cobj-idx"]
         os: ["ubuntu:22.04"]
     uses: ./.github/workflows/test-other.yml
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ tests/data-rep
 tests/i18n_sjis
 tests/i18n_utf8
 tests/jp-compat
+tests/cobj-idx
 tests/misc
 tests/run
 tests/*.log

--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -1,4 +1,5 @@
 TARGET_JAR = app/build/libs/libcobj.jar
+COBJ_IDX = bin/cobj-idx
 
 SRC_FILES = \	
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java \
@@ -68,7 +69,8 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
 
 all: $(TARGET_JAR)
 
@@ -78,6 +80,7 @@ $(TARGET_JAR): $(SRC_FILES)
 clean:
 	rm -rf $(TARGET_JAR)
 
-install: $(TARGET_JAR)
+install: $(TARGET_JAR) $(COBJ_IDX)
 	mkdir -p $(DESTDIR)$(prefix)/lib/opensourcecobol4j/
 	install $(TARGET_JAR) $(DESTDIR)$(prefix)/lib/opensourcecobol4j/
+	install $(COBJ_IDX) $(DESTDIR)$(prefix)/bin/

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -280,6 +280,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 TARGET_JAR = app/build/libs/libcobj.jar
+COBJ_IDX = bin/cobj-idx
 SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolCallDataContent.java \
@@ -348,7 +349,8 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
 
 all: all-am
 
@@ -549,9 +551,10 @@ $(TARGET_JAR): $(SRC_FILES)
 clean:
 	rm -rf $(TARGET_JAR)
 
-install: $(TARGET_JAR)
+install: $(TARGET_JAR) $(COBJ_IDX)
 	mkdir -p $(DESTDIR)$(prefix)/lib/opensourcecobol4j/
 	install $(TARGET_JAR) $(DESTDIR)$(prefix)/lib/opensourcecobol4j/
+	install $(COBJ_IDX) $(DESTDIR)$(prefix)/bin/
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -1,0 +1,7 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+public class IndexedFileUtilMain {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}

--- a/libcobj/bin/cobj-idx
+++ b/libcobj/bin/cobj-idx
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java jp.osscons.opensourcecobol.libcobj.user_util.indexed_file.IndexedFileUtilMain $@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@ TESTS = syntax \
 	i18n_utf8 \
 	jp-compat \
 	command-line-options \
+	cobj-idx \
 	misc
 else
 TESTS = syntax \
@@ -39,6 +40,7 @@ TESTS = syntax \
 	i18n_sjis \
 	jp-compat \
 	command-line-options \
+	cobj-idx \
 	misc
 endif
 
@@ -166,6 +168,12 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/debug.at \
 	command-line-options.src/jar.at
 
+cobj_idx_DEPENDENCIES = \
+	cobj-idx.src/info.at \
+	cobj-idx.src/load.at \
+	cobj-idx.src/unload.at \
+	cobj-idx.src/help.at
+
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \
 	misc.src/index-comp.at \
@@ -201,6 +209,7 @@ EXTRA_DIST = $(srcdir)/package.m4 \
 	$(i18n_sjis_DEPENDENCIES) \
 	$(jp_compat_DEPENDENCIES) \
 	$(command_line_options_DEPENDENCIES) \
+	$(cobj_idx_DEPENDENCIES) \
 	$(misc_DEPENDENCIES)
 
 DISTCLEANFILES = atconfig
@@ -232,4 +241,5 @@ $(srcdir)/i18n_utf8: $(i18n_utf8_DEPENDENCIES)
 $(srcdir)/i18n_sjis: $(i18n_sjis_DEPENDENCIES)
 $(srcdir)/jp-compat: $(jp_compat_DEPENDENCIES)
 $(srcdir)/command-line-options: $(command_line_options_DEPENDENCIES)
+$(srcdir)/cobj-idx: $(cobj_idx_DEPENDENCIES)
 $(srcdir)/misc: $(misc_DEPENDENCIES)

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -571,6 +571,7 @@ SUBDIRS = cobol85
 @I18N_UTF8_FALSE@	i18n_sjis \
 @I18N_UTF8_FALSE@	jp-compat \
 @I18N_UTF8_FALSE@	command-line-options \
+@I18N_UTF8_FALSE@	cobj-idx \
 @I18N_UTF8_FALSE@	misc
 
 @I18N_UTF8_TRUE@TESTS = syntax \
@@ -581,6 +582,7 @@ SUBDIRS = cobol85
 @I18N_UTF8_TRUE@	i18n_utf8 \
 @I18N_UTF8_TRUE@	jp-compat \
 @I18N_UTF8_TRUE@	command-line-options \
+@I18N_UTF8_TRUE@	cobj-idx \
 @I18N_UTF8_TRUE@	misc
 
 syntax_DEPENDENCIES = \
@@ -707,6 +709,12 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/debug.at \
 	command-line-options.src/jar.at
 
+cobj_idx_DEPENDENCIES = \
+	cobj-idx.src/info.at \
+	cobj-idx.src/load.at \
+	cobj-idx.src/unload.at \
+	cobj-idx.src/help.at
+
 misc_DEPENDENCIES = \
 	misc.src/signed-comp3.at \
 	misc.src/index-comp.at \
@@ -742,6 +750,7 @@ EXTRA_DIST = $(srcdir)/package.m4 \
 	$(i18n_sjis_DEPENDENCIES) \
 	$(jp_compat_DEPENDENCIES) \
 	$(command_line_options_DEPENDENCIES) \
+	$(cobj_idx_DEPENDENCIES) \
 	$(misc_DEPENDENCIES)
 
 DISTCLEANFILES = atconfig
@@ -1083,6 +1092,13 @@ command-line-options.log: command-line-options
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+cobj-idx.log: cobj-idx
+	@p='cobj-idx'; \
+	b='cobj-idx'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 misc.log: misc
 	@p='misc'; \
 	b='misc'; \
@@ -1321,6 +1337,7 @@ $(srcdir)/i18n_utf8: $(i18n_utf8_DEPENDENCIES)
 $(srcdir)/i18n_sjis: $(i18n_sjis_DEPENDENCIES)
 $(srcdir)/jp-compat: $(jp_compat_DEPENDENCIES)
 $(srcdir)/command-line-options: $(command_line_options_DEPENDENCIES)
+$(srcdir)/cobj-idx: $(cobj_idx_DEPENDENCIES)
 $(srcdir)/misc: $(misc_DEPENDENCIES)
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/tests/cobj-idx.at
+++ b/tests/cobj-idx.at
@@ -1,0 +1,7 @@
+AT_INIT([cobj-idx])
+
+m4_include([info.at])
+m4_include([load.at])
+m4_include([unload.at])
+m4_include([help.at])
+

--- a/tests/cobj-idx.src/help.at
+++ b/tests/cobj-idx.src/help.at
@@ -1,0 +1,5 @@
+AT_SETUP([help])
+
+AT_CHECK([echo -n hello], [0], [hello])
+
+AT_CLEANUP

--- a/tests/cobj-idx.src/info.at
+++ b/tests/cobj-idx.src/info.at
@@ -1,5 +1,264 @@
 AT_SETUP([info])
 
-AT_CHECK([echo -n hello], [0], [hello])
+# Create a sample indexed file named 'idx-file'
+
+AT_DATA([sample.cbl],[
+       identification division.
+       program-id. sample.
+       environment division.
+       input-output section.
+       file-control.
+       select f assign to 'idx-file'
+           organization is indexed
+           access mode is random
+           record key is rec-key
+           alternate record key is alt-key-1
+           alternate record key is alt-key-2
+           alternate record key is alt-key-dup-1 with duplicates
+           alternate record key is alt-key-dup-2 with duplicates.
+       data division.
+       file section.
+       fd f.
+       01 rec.
+         03 rec-key pic x(5).
+         03 alt-key-1 pic x(5).
+         03 alt-key-2 pic x(5).
+         03 alt-key-dup-1 pic x(5).
+         03 alt-key-dup-2 pic x(5).
+         03 rec-value pic x(5).
+       working-storage section.
+       procedure division.
+       main-proc.
+           open output f.
+           move 'a0000' to rec-key.
+           move 'b0000' to alt-key-1.
+           move 'c0000' to alt-key-2.
+           move 'd0000' to alt-key-dup-1.
+           move 'e0000' to alt-key-dup-2.
+           move '00000' to rec-value.
+           write rec.
+           move 'a0001' to rec-key.
+           move 'b0001' to alt-key-1.
+           move 'c0001' to alt-key-2.
+           move 'd0001' to alt-key-dup-1.
+           move 'e0001' to alt-key-dup-2.
+           move '00001' to rec-value.
+           write rec.
+           move 'a0010' to rec-key.
+           move 'b0010' to alt-key-1.
+           move 'c0010' to alt-key-2.
+           move 'd0010' to alt-key-dup-1.
+           move 'e0010' to alt-key-dup-2.
+           move '00010' to rec-value.
+           write rec.
+           move 'a0011' to rec-key.
+           move 'b0011' to alt-key-1.
+           move 'c0011' to alt-key-2.
+           move 'd0010' to alt-key-dup-1.
+           move 'e0010' to alt-key-dup-2.
+           move '00011' to rec-value.
+           write rec.
+           close f.
+])
+
+AT_CHECK([${COMPILE} sample.cbl])
+AT_CHECK([java sample])
+
+# Create an empty indexed file named 'idx-empty-file'
+
+AT_DATA([empty.cbl],[
+       identification division.
+       program-id. empty.
+       environment division.
+       input-output section.
+       file-control.
+       select f assign to 'idx-empty-file'
+           organization is indexed
+           access mode is random
+           record key is rec-key
+           alternate record key is alt-key-1
+           alternate record key is alt-key-2
+           alternate record key is alt-key-dup-1 with duplicates
+           alternate record key is alt-key-dup-2 with duplicates.
+       data division.
+       file section.
+       fd f.
+       01 rec.
+         03 rec-key pic x(5).
+         03 alt-key-1 pic x(5).
+         03 alt-key-2 pic x(5).
+         03 alt-key-dup-1 pic x(5).
+         03 alt-key-dup-2 pic x(5).
+         03 rec-value pic x(5).
+       working-storage section.
+       procedure division.
+       main-proc.
+           open output f.
+           close f.
+])
+
+AT_CHECK([${COMPILE} empty.cbl])
+AT_CHECK([java empty])
+
+## a test for an indexed file
+#AT_CHECK([cobj-idx info idx-file], [0],
+#[Size of a record: 30
+#Number of records: 4
+#Primary key position: 1-5
+#Alterernate key position (No duplicate): 6-10
+#Alterernate key position (No duplicate): 11-15
+#Alterernate key position (Duplicates): 16-20
+#Alterernate key position (Duplicates): 21-25
+#])
+#
+## a test for an empty indexed file
+#AT_CHECK([cobj-idx info idx-empty-file], [0],
+#[Size of a record: 30
+#Number of records: 0
+#Primary key position: 1-5
+#Alterernate key position (No duplicate): 6-10
+#Alterernate key position (No duplicate): 11-15
+#Alterernate key position (Duplicates): 16-20
+#Alterernate key position (Duplicates): 21-25
+#])
+#
+## a test for an not-existing file
+#AT_CHECK([cobj-idx info not-existing-file], [1], [],
+#[error: 'not-existing-file' does not exist
+#])
+#
+## a test for a directory
+#AT_CHECK([mkdir indexed-file-dir])
+#AT_CHECK([cobj-idx info indexed-file-dir], [1], [],
+#[error: 'indexed-file-dir' is a directory
+#])
+#
+## a test for an invalid format file
+#AT_CHECK([echo "info" > invalid-format-indexed-file])
+#AT_CHECK([cobj-idx info invalid-format-indexed-file], [1], [],
+#[error: The format of 'invalid-format-indexed-file' is invalid.
+#])
+
+# Shuffle the order of key definitions of an indexed file
+
+AT_DATA([sample.cbl],[
+       identification division.
+       program-id. sample.
+       environment division.
+       input-output section.
+       file-control.
+       select f assign to 'idx-file'
+           organization is indexed
+           access mode is random
+           alternate record key is alt-key-dup-1 with duplicates
+           alternate record key is alt-key-1
+           alternate record key is alt-key-dup-2 with duplicates
+           alternate record key is alt-key-2
+           record key is rec-key.
+       data division.
+       file section.
+       fd f.
+       01 rec.
+         03 rec-key pic x(5).
+         03 alt-key-1 pic x(5).
+         03 alt-key-2 pic x(5).
+         03 alt-key-dup-1 pic x(5).
+         03 alt-key-dup-2 pic x(5).
+         03 rec-value pic x(5).
+       working-storage section.
+       procedure division.
+       main-proc.
+           open output f.
+           move 'a0000' to rec-key.
+           move 'b0000' to alt-key-1.
+           move 'c0000' to alt-key-2.
+           move 'd0000' to alt-key-dup-1.
+           move 'e0000' to alt-key-dup-2.
+           move '00000' to rec-value.
+           write rec.
+           move 'a0001' to rec-key.
+           move 'b0001' to alt-key-1.
+           move 'c0001' to alt-key-2.
+           move 'd0001' to alt-key-dup-1.
+           move 'e0001' to alt-key-dup-2.
+           move '00001' to rec-value.
+           write rec.
+           move 'a0010' to rec-key.
+           move 'b0010' to alt-key-1.
+           move 'c0010' to alt-key-2.
+           move 'd0010' to alt-key-dup-1.
+           move 'e0010' to alt-key-dup-2.
+           move '00010' to rec-value.
+           write rec.
+           move 'a0011' to rec-key.
+           move 'b0011' to alt-key-1.
+           move 'c0011' to alt-key-2.
+           move 'd0010' to alt-key-dup-1.
+           move 'e0010' to alt-key-dup-2.
+           move '00011' to rec-value.
+           write rec.
+           close f.
+])
+
+AT_CHECK([${COMPILE} sample.cbl])
+AT_CHECK([java sample])
+
+# Shuffle the order of key definitions of an empty indexed file
+
+AT_DATA([empty.cbl],[
+       identification division.
+       program-id. empty.
+       environment division.
+       input-output section.
+       file-control.
+       select f assign to 'idx-empty-file'
+           organization is indexed
+           access mode is random
+           alternate record key is alt-key-dup-1 with duplicates
+           alternate record key is alt-key-1
+           alternate record key is alt-key-dup-2 with duplicates
+           alternate record key is alt-key-2
+           record key is rec-key.
+       data division.
+       file section.
+       fd f.
+       01 rec.
+         03 rec-key pic x(5).
+         03 alt-key-1 pic x(5).
+         03 alt-key-2 pic x(5).
+         03 alt-key-dup-1 pic x(5).
+         03 alt-key-dup-2 pic x(5).
+         03 rec-value pic x(5).
+       working-storage section.
+       procedure division.
+       main-proc.
+           open output f.
+           close f.
+])
+
+AT_CHECK([${COMPILE} empty.cbl])
+AT_CHECK([java empty])
+
+## a test for an indexed file
+#AT_CHECK([cobj-idx info idx-file], [0],
+#[Size of a record: 30
+#Number of records: 4
+#Primary key position: 1-5
+#Alterernate key position (Duplicates): 16-20
+#Alterernate key position (No duplicate): 6-10
+#Alterernate key position (Duplicates): 21-25
+#Alterernate key position (No duplicate): 11-15
+#])
+#
+## a test for an empty indexed file
+#AT_CHECK([cobj-idx info idx-empty-file], [0],
+#[Size of a record: 30
+#Number of records: 0
+#Primary key position: 1-5
+#Alterernate key position (Duplicates): 16-20
+#Alterernate key position (No duplicate): 6-10
+#Alterernate key position (Duplicates): 21-25
+#Alterernate key position (No duplicate): 11-15
+#])
 
 AT_CLEANUP

--- a/tests/cobj-idx.src/info.at
+++ b/tests/cobj-idx.src/info.at
@@ -1,0 +1,5 @@
+AT_SETUP([info])
+
+AT_CHECK([echo -n hello], [0], [hello])
+
+AT_CLEANUP

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -1,0 +1,5 @@
+AT_SETUP([load])
+
+AT_CHECK([echo -n hello], [0], [hello])
+
+AT_CLEANUP

--- a/tests/cobj-idx.src/unload.at
+++ b/tests/cobj-idx.src/unload.at
@@ -1,0 +1,5 @@
+AT_SETUP([unload])
+
+AT_CHECK([echo -n hello], [0], [hello])
+
+AT_CLEANUP

--- a/tests/package.m4
+++ b/tests/package.m4
@@ -1,6 +1,6 @@
 # Signature of the current package.
 m4_define([AT_PACKAGE_NAME],	  [opensource COBOL 4J])
-m4_define([AT_PACKAGE_TARNAME],	  [opensource-cobol-4j-1.0.17])
-m4_define([AT_PACKAGE_VERSION],	  [1.0.17])
-m4_define([AT_PACKAGE_STRING],	  [opensource COBOL 4J 1.0.17])
+m4_define([AT_PACKAGE_TARNAME],	  [opensource-cobol-4j-1.0.18])
+m4_define([AT_PACKAGE_VERSION],	  [1.0.18])
+m4_define([AT_PACKAGE_STRING],	  [opensource COBOL 4J 1.0.18])
 m4_define([AT_PACKAGE_BUGREPORT], [ws-opensource-cobol-contact@osscons.jp])


### PR DESCRIPTION
I plan to develop a new CLI tool named `cobj-idx` that handles indexed files of opensource COBOL 4J.
Using the command, users can do the followings.

* extract information of an indexed file, such as the record size, number of records in the file and positions of record keys and alternate keys in records
* import data stored in a line sequential file into an indexed file
* export data stored in an indexed file into a line sequential file

This PR provides fundamental resources for consequent developments of `cobj-idx`.

* Change the build system so that `cobj-idx` command installed when executing `make install`. Note that the current version of `cobj-idx` is a stub.
* Add test files which verifies the behaviour of `cobj-idx`. Note that the current version of the test files are stub.
* Update workflow files so that GitHub Actions execute tests for `cobj-idx`.