### PR TITLE
Implement `COB_FILE_SEQ_WRITE_BUFFER_SIZE`

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -231,7 +231,7 @@ public class CobolUtil {
 
     s = System.getenv("COB_FILE_SEQ_WRITE_BUFFER_SIZE");
     if (s != null) {
-      int size = Integer.valueOf(s);
+      int size = Integer.parseInt(s);
       if (size >= 0) {
         CobolUtil.fileSeqWriteBufferSize = size;
       }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -57,6 +57,8 @@ public class CobolUtil {
   public static boolean cobErrorOnExitFlag = false;
   public static Calendar cal;
 
+  public static int fileSeqWriteBufferSize = 10;
+
   private static boolean lineTrace = false;
 
   public static String sourceFile;
@@ -225,6 +227,14 @@ public class CobolUtil {
     s = CobolUtil.getEnv("COB_NIBBLE_C_UNSIGNED");
     if (s != null && s.length() > 0 && (s.charAt(0) == 'y' || s.charAt(0) == 'Y')) {
       CobolUtil.nibbleCForUnsigned = true;
+    }
+
+    s = System.getenv("COB_FILE_SEQ_WRITE_BUFFER_SIZE");
+    if (s != null) {
+      int size = Integer.valueOf(s);
+      if (size >= 0) {
+        CobolUtil.fileSeqWriteBufferSize = size;
+      }
     }
   }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -834,6 +834,11 @@ public class CobolFile {
       Linage lingptr = this.getLinorkeyptr();
       lingptr.getLinageCtr().setInt(1);
     }
+    if ((this.organization == COB_ORG_SEQUENTIAL || this.organization == COB_ORG_LINE_SEQUENTIAL)
+        && (mode == COB_OPEN_OUTPUT || mode == COB_OPEN_EXTEND)
+        && CobolUtil.fileSeqWriteBufferSize > 0) {
+      this.file.prepareWriteBuffer(CobolUtil.fileSeqWriteBufferSize * this.record_max);
+    }
     return 0;
   }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -332,13 +332,13 @@ public class CobolFileSort {
   private static boolean writeItem(FileIO fp, CobolItem q, CobolSort hp) {
     byte[] blockByteData = new byte[1];
     blockByteData[0] = q.getBlockByte();
-    if (fp.write(blockByteData, 1, 1) != 1) {
+    if (!fp.write(blockByteData, 1)) {
       return true;
     }
-    if (fp.write(q.getUnique(), 8, 1) != 1) {
+    if (!fp.write(q.getUnique(), 8)) {
       return true;
     }
-    return fp.write(q.getItem(), hp.getSize(), 1) != 1;
+    return fp.write(q.getItem(), hp.getSize());
   }
 
   /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolLineSequentialFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolLineSequentialFile.java
@@ -183,7 +183,7 @@ public class CobolLineSequentialFile extends CobolFile {
           this.file.putc(data.getByte(p));
         }
       } else {
-        if (this.file.write(this.record.getDataStorage(), size, 1) != 1) {
+        if (!this.file.write(this.record.getDataStorage(), size)) {
           return COB_STATUS_30_PERMANENT_ERROR;
         }
       }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSequentialFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSequentialFile.java
@@ -141,13 +141,13 @@ public class CobolSequentialFile extends CobolFile {
 
     if (this.record_min != this.record_max) {
       ByteBuffer.wrap(sbuff).putInt(this.record.getSize());
-      if (this.file.write(sbuff, 4, 1) != 1) {
+      if (!this.file.write(sbuff, 4)) {
         return COB_STATUS_30_PERMANENT_ERROR;
       }
     }
 
     /* write the record */
-    if (this.file.write(this.record.getDataStorage(), this.record.getSize(), 1) != 1) {
+    if (!this.file.write(this.record.getDataStorage(), this.record.getSize())) {
       return COB_STATUS_30_PERMANENT_ERROR;
     }
 
@@ -167,7 +167,7 @@ public class CobolSequentialFile extends CobolFile {
     if (!this.file.seek(-this.record.getSize(), FileIO.SEEK_CUR)) {
       return COB_STATUS_30_PERMANENT_ERROR;
     }
-    if (this.file.write(this.record.getDataStorage(), this.record.getSize(), 1) != 1) {
+    if (!this.file.write(this.record.getDataStorage(), this.record.getSize())) {
       return COB_STATUS_30_PERMANENT_ERROR;
     }
     return COB_STATUS_00_SUCCESS;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.NonReadableChannelException;
@@ -107,11 +106,7 @@ public class FileIO {
       ByteBuffer data = ByteBuffer.wrap(bytes);
       try {
         readSize = this.fc.read(data);
-      } catch (ClosedChannelException e) {
-        return 0;
-      } catch (IOException e) {
-        return 0;
-      } catch (NonReadableChannelException e) {
+      } catch (IOException | NonReadableChannelException e) {
         return 0;
       }
 
@@ -140,12 +135,8 @@ public class FileIO {
           }
           storage.setByte(i, b[0]);
         }
-      } catch (ClosedChannelException e) {
-        throw new IOException();
-      } catch (IOException e) {
-        throw new IOException();
-      } catch (NonReadableChannelException e) {
-        throw new IOException();
+      } catch (IOException | NonReadableChannelException e) {
+        throw e;
       }
       return size;
     }
@@ -162,11 +153,7 @@ public class FileIO {
   private boolean writeByteBuffer(ByteBuffer bb) {
     try {
       this.fc.write(bb);
-    } catch (ClosedChannelException e) {
-      return false;
-    } catch (IOException e) {
-      return false;
-    } catch (NonWritableChannelException e) {
+    } catch (IOException | NonWritableChannelException e) {
       return false;
     }
     return true;
@@ -267,11 +254,7 @@ public class FileIO {
           } else {
             this.readBufferEndIndex = readBytes;
           }
-        } catch (ClosedChannelException e) {
-          return -1;
-        } catch (IOException e) {
-          return -1;
-        } catch (NonReadableChannelException e) {
+        } catch (IOException | NonReadableChannelException e) {
           return -1;
         }
       }
@@ -291,11 +274,7 @@ public class FileIO {
         } else {
           return -1;
         }
-      } catch (ClosedChannelException e) {
-        return -1;
-      } catch (IOException e) {
-        return -1;
-      } catch (NonReadableChannelException e) {
+      } catch (IOException | NonReadableChannelException e) {
         return -1;
       }
     }
@@ -308,17 +287,18 @@ public class FileIO {
         destroyWriteBuffer();
         this.fc.close();
       } catch (IOException e) {
+        return;
       }
     }
   }
 
   public void flush() {
-    if (useStdOut) {
-    } else {
+    if (!useStdOut) {
       try {
         outputWriteBuffer();
         this.fc.force(false);
       } catch (IOException e) {
+        return;
       }
     }
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
@@ -18,16 +18,16 @@
  */
 package jp.osscons.opensourcecobol.libcobj.file;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.NonReadableChannelException;
+import java.nio.channels.NonWritableChannelException;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
 public class FileIO {
@@ -36,17 +36,17 @@ public class FileIO {
   private FileLock fl = null;
   private boolean useStdOut = true;
   private boolean useStdIn = true;
-  private BufferedInputStream bis;
-  private BufferedOutputStream bos;
   private boolean atEnd = false;
-
-  private static final boolean USE_STD_BUFFER = false;
 
   private static final boolean USE_READ_BUFFER = false;
   private static final int READ_BUFFER_SIZE = 1024;
   private int readBufferIndex;
   private byte[] readBuffer;
   private int readBufferEndIndex;
+
+  private int writeBufferSize = 0;
+  private int writeBufferEndIndex = 0;
+  private byte[] writeBuffer;
 
   public FileIO() {
     this.useStdOut = true;
@@ -66,22 +66,12 @@ public class FileIO {
     this.fl = fl;
     this.useStdOut = false;
     this.useStdIn = false;
-
-    if (USE_STD_BUFFER) {
-      this.bis = new BufferedInputStream(Channels.newInputStream(this.fc));
-      this.bos = new BufferedOutputStream(Channels.newOutputStream(this.fc));
-    }
   }
 
   public void setRandomAccessFile(RandomAccessFile ra, FileLock fl) {
     this.useStdOut = false;
     this.useStdIn = false;
     this.fc = ra.getChannel();
-
-    if (USE_STD_BUFFER) {
-      this.bis = new BufferedInputStream(Channels.newInputStream(this.fc));
-      this.bos = new BufferedOutputStream(Channels.newOutputStream(this.fc));
-    }
   }
 
   public void setOut(PrintStream out) {
@@ -92,6 +82,21 @@ public class FileIO {
     this.useStdIn = true;
   }
 
+  public void prepareWriteBuffer(int bufferSize) {
+    if (bufferSize > 0) {
+      this.writeBufferSize = bufferSize;
+      this.writeBufferEndIndex = 0;
+      if (this.writeBuffer == null || this.writeBuffer.length < bufferSize) {
+        this.writeBuffer = new byte[bufferSize];
+      }
+    }
+  }
+
+  private void destroyWriteBuffer() {
+    this.writeBufferSize = 0;
+    this.writeBufferEndIndex = 0;
+  }
+
   public int read(byte[] bytes, int size) {
     if (useStdIn) {
       // 標準入力を使う
@@ -99,19 +104,15 @@ public class FileIO {
       return 0;
     } else {
       int readSize;
-      if (USE_STD_BUFFER) {
-        try {
-          readSize = this.bis.read(bytes, 0, size);
-        } catch (IOException e) {
-          return 0;
-        }
-      } else {
-        ByteBuffer data = ByteBuffer.wrap(bytes);
-        try {
-          readSize = this.fc.read(data);
-        } catch (IOException e) {
-          return 0;
-        }
+      ByteBuffer data = ByteBuffer.wrap(bytes);
+      try {
+        readSize = this.fc.read(data);
+      } catch (ClosedChannelException e) {
+        return 0;
+      } catch (IOException e) {
+        return 0;
+      } catch (NonReadableChannelException e) {
+        return 0;
       }
 
       this.atEnd = readSize == -1;
@@ -126,37 +127,27 @@ public class FileIO {
     if (useStdIn) {
       return 0;
     } else {
-      if (USE_STD_BUFFER) {
-        int i = 0;
-        try {
+      if (this.fc == null) {
+        throw new IOException();
+      }
+      int i = 0;
+      try {
+        for (i = 0; i < size; ++i) {
           byte[] b = new byte[1];
-          for (i = 0; i < size; ++i) {
-            if (this.bis.read(b, 0, 1) != 1) {
-              return i;
-            }
-            storage.setByte(i, b[0]);
-          }
-        } catch (IOException e) {
-          return i;
-        }
-        return size;
-      } else {
-        if (this.fc == null) {
-          throw new IOException();
-        }
-        int i = 0;
-        try {
-          byte[] b = new byte[size];
           ByteBuffer bb = ByteBuffer.wrap(b);
-          if (this.fc.read(bb) == -1) {
+          if (this.fc.read(bb) != 1) {
             return i;
           }
-          storage.setBytes(b);
-        } catch (IOException e) {
-          throw e;
+          storage.setByte(i, b[0]);
         }
-        return size;
+      } catch (ClosedChannelException e) {
+        throw new IOException();
+      } catch (IOException e) {
+        throw new IOException();
+      } catch (NonReadableChannelException e) {
+        throw new IOException();
       }
+      return size;
     }
   }
 
@@ -168,168 +159,166 @@ public class FileIO {
     return 0;
   }
 
-  public int write(byte[] bytes, int size, int n) {
-    if (this.fc == null) {
-      return 0;
-    } else {
-      if (USE_STD_BUFFER) {
-        int i = 0;
-        try {
-          for (i = 0; i < n; ++i) {
-            this.bos.write(bytes, 0, size);
-          }
-        } catch (IOException e) {
-          return i;
-        }
-        return i;
-
-      } else {
-        byte[] data = new byte[size];
-        System.arraycopy(bytes, 0, data, 0, size);
-        ByteBuffer bb = ByteBuffer.wrap(data);
-        int i = 0;
-        try {
-          for (i = 0; i < n; ++i) {
-            this.fc.write(bb);
-          }
-        } catch (IOException e) {
-          return i;
-        }
-        return i;
-      }
+  private boolean writeByteBuffer(ByteBuffer bb) {
+    try {
+      this.fc.write(bb);
+    } catch (ClosedChannelException e) {
+      return false;
+    } catch (IOException e) {
+      return false;
+    } catch (NonWritableChannelException e) {
+      return false;
     }
+    return true;
   }
 
-  public int write(CobolDataStorage storage, int size, int n) {
-    if (this.fc == null) {
-      return 0;
-    } else {
-      if (USE_STD_BUFFER) {
-        byte[] data = storage.getByteArray(0, size);
-        int i = 0;
-        try {
-          for (i = 0; i < n; ++i) {
-            this.bos.write(data, 0, size);
-          }
-        } catch (IOException e) {
-          return i;
-        }
-        return i;
-      } else {
-        ByteBuffer data = storage.getByteBuffer(size);
-        int i = 0;
-        try {
-          for (i = 0; i < n; ++i) {
-            this.fc.write(data);
-          }
-        } catch (IOException e) {
-          return i;
-        }
-        return i;
+  private boolean outputWriteBuffer() {
+    if (writeBufferEndIndex > 0 && writeBufferSize > 0) {
+      ByteBuffer bb = ByteBuffer.wrap(writeBuffer, 0, writeBufferEndIndex);
+      if (!writeByteBuffer(bb)) {
+        return false;
       }
+      writeBufferEndIndex = 0;
     }
+    return true;
+  }
+
+  public boolean write(byte[] bytes, int size) {
+    if (this.fc == null) {
+      return false;
+    }
+    if (writeBufferSize > 0 && size <= writeBufferSize - writeBufferEndIndex) {
+      System.arraycopy(bytes, 0, writeBuffer, writeBufferEndIndex, size);
+      writeBufferEndIndex += size;
+      return true;
+    }
+    if (!outputWriteBuffer()) {
+      return false;
+    }
+    if (writeBufferSize > 0 && size <= writeBufferSize - writeBufferEndIndex) {
+      System.arraycopy(bytes, 0, writeBuffer, writeBufferEndIndex, size);
+      writeBufferEndIndex += size;
+      return true;
+    }
+    ByteBuffer bb = ByteBuffer.wrap(bytes, 0, size);
+    return writeByteBuffer(bb);
+  }
+
+  public boolean write(CobolDataStorage storage, int size) {
+    if (this.fc == null) {
+      return false;
+    }
+    if (writeBufferSize > 0 && size <= writeBufferSize - writeBufferEndIndex) {
+      for (int i = 0; i < size; ++i) {
+        writeBuffer[writeBufferEndIndex + i] = storage.getByte(i);
+      }
+      writeBufferEndIndex += size;
+      return true;
+    }
+    if (!outputWriteBuffer()) {
+      return false;
+    }
+    if (writeBufferSize > 0 && size <= writeBufferSize - writeBufferEndIndex) {
+      for (int i = 0; i < size; ++i) {
+        writeBuffer[writeBufferEndIndex + i] = storage.getByte(i);
+      }
+      writeBufferEndIndex += size;
+      return true;
+    }
+    ByteBuffer bb = storage.getByteBuffer(size);
+    return writeByteBuffer(bb);
   }
 
   public byte putc(byte val) {
     if (this.fc == null) {
       return 0;
     }
-    if (USE_STD_BUFFER) {
-      byte[] arr = {val};
-      try {
-        this.bos.write(arr);
-      } catch (IOException e) {
-        return -1;
-      }
+    if (writeBufferSize > 0 && 1 <= writeBufferSize - writeBufferEndIndex) {
+      writeBuffer[writeBufferEndIndex++] = val;
+      return val;
+    }
+    if (!outputWriteBuffer()) {
+      return -1;
+    }
+    if (writeBufferSize > 0 && 1 <= writeBufferSize - writeBufferEndIndex) {
+      writeBuffer[writeBufferEndIndex++] = val;
+      return val;
+    }
+    byte[] arr = {val};
+    if (writeByteBuffer(ByteBuffer.wrap(arr))) {
       return val;
     } else {
-      try {
-        byte[] arr = {val};
-        this.fc.write(ByteBuffer.wrap(arr));
-      } catch (IOException e) {
-        return -1;
-      }
-      return val;
+      return -1;
     }
   }
 
   public int getc() {
     if (this.fc == null) {
       return 0;
-    } else {
-      if (USE_STD_BUFFER) {
+    }
+    if (USE_READ_BUFFER) {
+      if (readBufferIndex >= READ_BUFFER_SIZE) {
+        this.readBufferIndex = 0;
         try {
-          return this.bis.read();
-        } catch (IOException e) {
-          return -1;
-        }
-      } else if (USE_READ_BUFFER) {
-        if (readBufferIndex >= READ_BUFFER_SIZE) {
-          this.readBufferIndex = 0;
-          try {
-            ByteBuffer bb = ByteBuffer.wrap(readBuffer);
-            int readBytes = this.fc.read(bb);
-            if (readBytes <= 0) {
-              this.readBufferEndIndex = -1;
-            } else {
-              this.readBufferEndIndex = readBytes;
-            }
-          } catch (IOException e) {
-            return -1;
-          }
-        }
-
-        if (this.readBufferIndex >= this.readBufferEndIndex) {
-          return -1;
-        }
-
-        return readBuffer[readBufferIndex++];
-
-      } else {
-        try {
-          byte[] b = new byte[1];
-          ByteBuffer bb = ByteBuffer.wrap(b);
-          if (this.fc.read(bb) == 1) {
-            return b[0];
+          ByteBuffer bb = ByteBuffer.wrap(readBuffer);
+          int readBytes = this.fc.read(bb);
+          if (readBytes <= 0) {
+            this.readBufferEndIndex = -1;
           } else {
-            return -1;
+            this.readBufferEndIndex = readBytes;
           }
+        } catch (ClosedChannelException e) {
+          return -1;
         } catch (IOException e) {
           return -1;
+        } catch (NonReadableChannelException e) {
+          return -1;
         }
+      }
+
+      if (this.readBufferIndex >= this.readBufferEndIndex) {
+        return -1;
+      }
+
+      return readBuffer[readBufferIndex++];
+
+    } else {
+      try {
+        byte[] b = new byte[1];
+        ByteBuffer bb = ByteBuffer.wrap(b);
+        if (this.fc.read(bb) == 1) {
+          return b[0];
+        } else {
+          return -1;
+        }
+      } catch (ClosedChannelException e) {
+        return -1;
+      } catch (IOException e) {
+        return -1;
+      } catch (NonReadableChannelException e) {
+        return -1;
       }
     }
   }
 
   public void close() {
     if (!useStdOut && !useStdIn && this.fc != null) {
-      outer:
-      if (USE_STD_BUFFER) {
-        try {
-          this.bos.flush();
-          this.bis.close();
-          this.bos.close();
-        } catch (IOException e) {
-          break outer;
-        }
-      }
       try {
+        outputWriteBuffer();
+        destroyWriteBuffer();
         this.fc.close();
       } catch (IOException e) {
-        return;
       }
     }
   }
 
   public void flush() {
-    if (!useStdOut) {
+    if (useStdOut) {
+    } else {
       try {
-        if (USE_STD_BUFFER) {
-          this.bos.flush();
-        }
+        outputWriteBuffer();
         this.fc.force(false);
       } catch (IOException e) {
-        return;
       }
     }
   }


### PR DESCRIPTION
This PR implement a new feature `COB_FILE_SEQ_WRITE_BUFFER_SIZE`.
This is a environment variable that configures the buffer size for wrting data to sequential files.
Since the default size is set to 10, the perfomance of wrting sequential files is optimized by default.