### PR TITLE
Implement the sub command `load`

### DIFF
--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -70,7 +70,8 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
 
 all: $(TARGET_JAR)
 

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -350,7 +350,8 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
 
 all: all-am
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
@@ -33,4 +33,25 @@ public class ErrorLib {
     System.err.println("error: IO error.");
     return 1;
   }
+
+  /**
+   * Error when some keys in input data have conflicts
+   *
+   * @return
+   */
+  public static int errorDuplicateKeys() {
+    System.err.println("error: loading fails because of duplicate keys.");
+    return 1;
+  }
+
+  /**
+   * Error when some records in input data have invalid size
+   *
+   * @param correctSize
+   * @return
+   */
+  public static int errorDataSizeMismatch(int correctSize) {
+    System.err.println("error: all record must have the length of " + correctSize + " bytes.");
+    return 1;
+  }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -176,9 +176,9 @@ public class IndexedFileUtilMain {
   }
 
   enum LoadResult {
-    Success,
-    DataSizeMismatch,
-    Other,
+    LoadResultSuccess,
+    LoadResultDataSizeMismatch,
+    LoadResultOther,
   };
   /**
    * Process load sub command, which loads data inputted from stdin to the indexed file.
@@ -216,33 +216,33 @@ public class IndexedFileUtilMain {
     // Read records from stdin and write them to the indexed file
     String line = null;
     Scanner scan = new Scanner(System.in);
-    LoadResult loadResult = LoadResult.Success;
+    LoadResult loadResult = LoadResult.LoadResultSuccess;
     while (scan.hasNextLine()) {
       line = scan.nextLine();
       CobolRuntimeException.code = 0;
       byte[] readData = line.getBytes();
       if (readData.length != cobolIndexedFile.record.getSize()) {
-        loadResult = LoadResult.DataSizeMismatch;
+        loadResult = LoadResult.LoadResultDataSizeMismatch;
         break;
       }
       cobolIndexedFile.record.getDataStorage().memcpy(readData);
       try {
         cobolIndexedFile.write(cobolIndexedFile.record, 0, null);
       } catch (CobolStopRunException e) {
-        loadResult = LoadResult.Other;
+        loadResult = LoadResult.LoadResultOther;
         break;
       }
       if (CobolRuntimeException.code != 0) {
-        loadResult = LoadResult.Other;
+        loadResult = LoadResult.LoadResultOther;
         break;
       }
     }
 
     scan.close();
 
-    if (loadResult == LoadResult.DataSizeMismatch) {
+    if (loadResult == LoadResult.LoadResultDataSizeMismatch) {
       return ErrorLib.errorDataSizeMismatch(cobolIndexedFile.record.getSize());
-    } else if (loadResult == LoadResult.Other) {
+    } else if (loadResult == LoadResult.LoadResultOther) {
       return ErrorLib.errorDuplicateKeys();
     } else {
       cobolIndexedFile.commitJdbcTransaction();

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -147,386 +147,378 @@ AT_CHECK([echo "invalid data" > idx-invalid-file])
 # Create a directory (This is not a valid indexed file)
 AT_CHECK([mkdir dir-idx-file])
 
-######## test for the file 'sample' with valid input #######
-## basic test
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0002b0002c0002d0002e000200002
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#a0012b0012c0012d0012e001200012
-#])
-#
-## test for duplicate keys
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0000e000000002
-#a0012b0012c0012d0010e001000012
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0002b0002c0002d0000e000000002
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#a0012b0012c0012d0010e001000012
-#])
-#
-## test with empty input
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-######## test for the file 'sample' with invalid input #######
-#
-## test for input containing short records
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: all record must have the length of 30 bytes
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-## test for input containing long records
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012aaa
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: all record must have the length of 30 bytes
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-## test for input violating the key duplication rule (primary key, #1)
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0000b0002c0002d0002e000200002
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-## test for input violating the key duplication rule (primary key, #2)
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0003c0003d0003e000300003
-#a0002b0003c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-## test for input violating the key duplication rule (alternate key, #1)
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0001c0002d0002e000200002
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-## test for input violating the key duplication rule (alternate key, #2)
-#AT_CHECK([cp sample work-sample])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0003b0002c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
-#[a0000b0000c0000d0000e000000000
-#a0001b0001c0001d0001e000100001
-#a0010b0010c0010d0010e001000010
-#a0011b0011c0011d0010e001000011
-#])
-#
-######## test for the file 'empty' with valid input #######
-## basic test
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012
-#])
-#
-## test for duplicate keys
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0000e000000002
-#a0012b0012c0012d0010e001000012
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[a0002b0002c0002d0000e000000002
-#a0012b0012c0012d0010e001000012
-#])
-#
-## test with empty input
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[])
-#
-######## test for the file 'empty' with invalid input #######
-#
-## test for input containing short records
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
-#[error: all record must have the length of 30 bytes
-#])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[])
-#
-## test for input containing long records
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012aaa
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
-#[error: all record must have the length of 30 bytes
-#])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (primary key)
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0003c0003d0003e000300003
-#a0002b0003c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (alternate key)
-#AT_CHECK([cp empty work-empty])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0003b0002c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
-#[error: loading fails because of duplicate keys
-#])
-#AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
-#[])
-#
-######## test for the file 'idx-invalid-file' with valid input #######
-## basic test
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#
-## test for duplicate keys
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0000e000000002
-#a0012b0012c0012d0010e001000012
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#
-## test with idx-invalid-file input
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#
-######## test for the file 'idx-invalid-file' with invalid input #######
-#
-## test for input containing short records
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-#[])
-#
-## test for input containing long records
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012aaa
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (primary key)
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0003c0003d0003e000300003
-#a0002b0003c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (alternate key)
-#AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0003b0002c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
-#[error: 'work-idx-invalid-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-#[])
-#
-######## test for the file 'dir-idx-file' with valid input #######
-## basic test
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#
-## test for duplicate keys
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0000e000000002
-#a0012b0012c0012d0010e001000012
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#
-## test with dir-idx-file input
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#
-######## test for the file 'dir-idx-file' with invalid input #######
-#
-## test for input containing short records
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-dir-idx-file java load], [0],
-#[])
-#
-## test for input containing long records
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0012b0012c0012d0012e001200012aaa
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-dir-idx-file java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (primary key)
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0003c0003d0003e000300003
-#a0002b0003c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-dir-idx-file java load], [0],
-#[])
-#
-## test for input violating the key duplication rule (alternate key)
-#AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
-#AT_DATA([input.txt],
-#[a0002b0002c0002d0002e000200002
-#a0003b0002c0003d0003e000300003
-#])
-#AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
-#[error: 'work-dir-idx-file' is not a valid indexed file.
-#])
-#AT_CHECK([IDX_FILE_PATH=work-dir-idx-file java load], [0],
-#[])
-#
+####### test for the file 'sample' with valid input #######
+# basic test
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0002e000200002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0012e001200012
+])
+
+# test for duplicate keys
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0000e000000002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0010e001000012
+])
+
+# test with empty input
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+####### test for the file 'sample' with invalid input #######
+
+# test for input containing short records
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+# test for input containing long records
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+# test for input violating the key duplication rule (primary key, #1)
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0000b0002c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+# test for input violating the key duplication rule (primary key, #2)
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+# test for input violating the key duplication rule (alternate key, #1)
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0001c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+# test for input violating the key duplication rule (alternate key, #2)
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-sample < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+####### test for the file 'empty' with valid input #######
+# basic test
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+
+# test for duplicate keys
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+
+# test with empty input
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+
+####### test for the file 'empty' with invalid input #######
+
+# test for input containing short records
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+
+# test for input containing long records
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+
+# test for input violating the key duplication rule (primary key)
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+
+# test for input violating the key duplication rule (alternate key)
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-empty < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+
+####### test for the file 'idx-invalid-file' with valid input #######
+# basic test
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+
+# test for duplicate keys
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+
+# test with idx-invalid-file input
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+
+####### test for the file 'idx-invalid-file' with invalid input #######
+
+# test for input containing short records
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+
+# test for input containing long records
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+
+# test for input violating the key duplication rule (primary key)
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+
+# test for input violating the key duplication rule (alternate key)
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+
+####### test for the file 'dir-idx-file' with valid input #######
+# basic test
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+# test for duplicate keys
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+# test with dir-idx-file input
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+####### test for the file 'dir-idx-file' with invalid input #######
+
+# test for input containing short records
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+# test for input containing long records
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+# test for input violating the key duplication rule (primary key)
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
+# test for input violating the key duplication rule (alternate key)
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+
 AT_CLEANUP


### PR DESCRIPTION
This PR implements the sub command `load`, which writes data from stdin to an indexed file.
All tests for `load` are passed.