### PR TITLE
Resolve gcc warnings which are suppressed in the older versions

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1688,7 +1688,7 @@ static void package_name_to_path(char *buff, char *package_name) {
 
 static int process_compile(struct filename *fn) {
   char buff[COB_MEDIUM_BUFF];
-  char buff2[COB_MEDIUM_BUFF];
+  char buff2[COB_SMALL_BUFF];
   char name[COB_MEDIUM_BUFF];
   int ret = 0;
 
@@ -1957,7 +1957,7 @@ static int process_link(struct filename *l) {
 
 static int process_build_single_jar() {
   char buff[COB_MEDIUM_BUFF];
-  char buff2[COB_MEDIUM_BUFF];
+  char buff2[COB_SMALL_BUFF];
   int ret;
 
   char *output_name_a = output_name == NULL ? (char *)"./" : output_name;

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1784,7 +1784,7 @@ static int process_library(struct filename *l) {
   size_t bufflen;
   int ret;
   char buff[COB_MEDIUM_BUFF];
-  char name[COB_MEDIUM_BUFF];
+  char name[COB_SMALL_BUFF];
   char objs[COB_MEDIUM_BUFF] = "\0";
 
   bufflen = 0;
@@ -1877,7 +1877,7 @@ static int process_link(struct filename *l) {
   size_t bufflen;
   int ret;
   char buff[COB_MEDIUM_BUFF];
-  char name[COB_MEDIUM_BUFF];
+  char name[COB_SMALL_BUFF];
   char objs[COB_MEDIUM_BUFF] = "\0";
 
   bufflen = 0;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -705,7 +705,8 @@ static void create_sorted_data_storage_cache() {
     }
   }
   qsort(sorted_data_storage_cache, data_storage_cache_count,
-        sizeof(struct data_storage_list *), comp_data_storage_cache);
+        sizeof(struct data_storage_list *),
+        (int (*)(const void *, const void *))comp_data_storage_cache);
 }
 
 static void destroy_sorted_data_storage_cache() {
@@ -4199,7 +4200,7 @@ static void joutput_initial_values(struct cb_field *p) {
 }
 
 struct call_parameter_list {
-  struct call_paramter_list *next;
+  struct call_parameter_list *next;
   struct cb_field *field;
   cb_tree x;
 };
@@ -5664,7 +5665,7 @@ static void create_label_id_map(struct cb_program *prog) {
   label_id_counter = 0;
   label_id_map_head = NULL;
   label_id_map_last = NULL;
-  cb_tree *l;
+  cb_tree l;
 
   for (l = prog->exec_list; l; l = CB_CHAIN(l)) {
     if (CB_TREE_TAG(CB_VALUE(l)) == CB_TAG_LABEL) {
@@ -5760,7 +5761,7 @@ static void joutput_execution_list(struct cb_program *prog) {
       "public Optional<CobolControl> run() throws CobolRuntimeException, "
       "CobolGoBackException, CobolStopRunException {");
   joutput_indent_level += 2;
-  cb_tree *l;
+  cb_tree l;
   flag_execution_begin = EXECUTION_NORMAL;
   flag_execution_end = EXECUTION_NORMAL;
   for (l = prog->exec_list; l; l = CB_CHAIN(l)) {

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -241,7 +241,7 @@ typedef struct cb_tree_common *cb_tree;
 #ifdef __GNUC__
 #define CB_TREE_CAST(tg, ty, x)                                                \
   ({                                                                           \
-    cb_tree _x = (x);                                                          \
+    cb_tree _x = (cb_tree)(x);                                                 \
     if (!_x || CB_TREE_TAG(_x) != tg) {                                        \
       cobc_tree_cast_error(_x, __FILE__, __LINE__, tg);                        \
     }                                                                          \

--- a/configure
+++ b/configure
@@ -24776,7 +24776,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure
+++ b/configure
@@ -24776,7 +24776,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure
+++ b/configure
@@ -24776,7 +24776,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-y2k -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure
+++ b/configure
@@ -24776,7 +24776,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure
+++ b/configure
@@ -24776,7 +24776,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-y2k -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wwrite-strings -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ esac
 
 if test "`basename $CC`" = "gcc"
 then
-	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types -Wno-format-truncation"
+	CFLAGS="$CFLAGS -fsigned-char -Wall -Wmissing-prototypes -Wno-format-security -Wno-incompatible-pointer-types"
 fi
 
 if test "x$lt_cv_dlopen_self" != "xyes"


### PR DESCRIPTION
This pull request resolves almost all gcc warnings which are suppressed in the older versions.
For instance, gcc options `-Wno-format-y2k`, `-Wno-incompatible-pointer-types` and `-Wno-format-truncation` are disabled and warnings involved with these options are resolved.