### PR TITLE
Add the ability to specify input files to the cobj-idx command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,11 @@ cobj-idx <sub command> [options] <indexed file>
 
 Sub commands:
 
-cobj-idx info <indexed-file>   - Show information of the indexed file.
-cobj-idx load <indexed file>   - Load data inputted from stdin to the indexed file.
-                                 The default format of the input data is SQQUENTIAL of COBOL.
+cobj-idx info <indexed-file> - Show information of the indexed file.
+cobj-idx load <indexed file> - Load data inputted from stdin to the indexed file.
+                               The default format of the input data is SQUENTIAL of COBOL.
+cobj-idx load <indexed file> <input file>  - Load data inputted from the input fiile to the indexed file.
+                                             The default format of the input data is SQUENTIAL of COBOL.
 cobj-idx unload <indexed file> - Write records stored in the indexed file to stdout.
                                  The default format of the output data is SEQUENTIAL of COBOL.
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -170,9 +170,11 @@ cobj-idx <sub command> [options] <indexed file>
 
 Sub commands:
 
-cobj-idx info <indexed-file>   - Show information of the indexed file.
-cobj-idx load <indexed file>   - Load data inputted from stdin to the indexed file.
-                                 The default format of the input data is SQQUENTIAL of COBOL.
+cobj-idx info <indexed-file> - Show information of the indexed file.
+cobj-idx load <indexed file> - Load data inputted from stdin to the indexed file.
+                               The default format of the input data is SQUENTIAL of COBOL.
+cobj-idx load <indexed file> <input file>  - Load data inputted from the input fiile to the indexed file.
+                                             The default format of the input data is SQUENTIAL of COBOL.
 cobj-idx unload <indexed file> - Write records stored in the indexed file to stdout.
                                  The default format of the output data is SEQUENTIAL of COBOL.
 

--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -78,7 +78,9 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
 
 all: $(TARGET_JAR)
 

--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -75,7 +75,10 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
 
 all: $(TARGET_JAR)
 

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -358,7 +358,9 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
 
 all: all-am
 

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -355,7 +355,10 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java \
-	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
 
 all: all-am
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -199,7 +199,7 @@ public class CobolFile {
   protected CobolDataStorage sort_collating;
   protected Object extfh_ptr;
   protected int record_min;
-  protected int record_max;
+  public int record_max;
   protected int nkeys;
 
   protected char organization;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
@@ -50,6 +50,7 @@ public class FileLineSeqRecordReader implements RecordReader {
     try {
       this.reader.close();
     } catch (IOException e) {
+      return;
     }
   }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileLineSeqRecordReader.java
@@ -1,0 +1,55 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
+
+public class FileLineSeqRecordReader implements RecordReader {
+  protected int recordSize;
+  protected BufferedReader reader;
+  private String filePath;
+
+  public FileLineSeqRecordReader(int recordSize, String filePath) {
+    this.recordSize = recordSize;
+    this.filePath = filePath;
+  }
+
+  @Override
+  public void open() {
+    try {
+      this.reader = new BufferedReader(new FileReader(this.filePath));
+    } catch (IOException e) {
+      this.reader = null;
+    }
+  }
+
+  @Override
+  public LoadResult read(CobolDataStorage record) {
+    if (this.reader == null) {
+      return LoadResult.LoadResultOther;
+    }
+    try {
+      String line = this.reader.readLine();
+      if (line == null) {
+        return LoadResult.AtEnd;
+      }
+      byte[] readData = line.getBytes();
+      if (readData.length != this.recordSize) {
+        return LoadResult.LoadResultDataSizeMismatch;
+      }
+      record.memcpy(readData, this.recordSize);
+      return LoadResult.LoadResultSuccess;
+    } catch (IOException e) {
+      return LoadResult.LoadResultOther;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      this.reader.close();
+    } catch (IOException e) {
+    }
+  }
+}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java
@@ -54,6 +54,7 @@ public class FileSeqRecordReader implements RecordReader {
     try {
       this.reader.close();
     } catch (IOException e) {
+      return;
     }
   }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/FileSeqRecordReader.java
@@ -1,0 +1,59 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
+
+public class FileSeqRecordReader implements RecordReader {
+  private FileInputStream reader;
+  private String filePath;
+  private byte[] readData;
+
+  public FileSeqRecordReader(int recordSize, String filePath) {
+    this.filePath = filePath;
+    this.readData = new byte[recordSize];
+  }
+
+  @Override
+  public void open() {
+    try {
+      this.reader = new FileInputStream(this.filePath);
+    } catch (IOException e) {
+      this.reader = null;
+    }
+  }
+
+  @Override
+  public LoadResult read(CobolDataStorage record) {
+    if (this.reader == null) {
+      return LoadResult.LoadResultOther;
+    }
+    try {
+      int readSize = this.reader.read(this.readData);
+      if (readSize == -1) {
+        return LoadResult.AtEnd;
+      }
+      if (readSize != this.readData.length) {
+        if (readSize == 1 && this.readData[0] == '\n') {
+          return LoadResult.AtEnd;
+        } else if (readSize == 2 && this.readData[0] == '\r' && this.readData[1] == '\n') {
+          return LoadResult.AtEnd;
+        } else {
+          return LoadResult.LoadResultDataSizeMismatch;
+        }
+      }
+      record.memcpy(this.readData, this.readData.length);
+      return LoadResult.LoadResultSuccess;
+    } catch (IOException e) {
+      return LoadResult.LoadResultOther;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      this.reader.close();
+    } catch (IOException e) {
+    }
+  }
+}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java
@@ -8,4 +8,6 @@ public enum LoadResult {
   LoadResultDataSizeMismatch,
   /** The load operation failed because duplicate keys are detected or other error occurs. */
   LoadResultOther,
+  /** Reach the end of input data */
+  AtEnd,
 };

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java
@@ -1,0 +1,15 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
+
+public interface RecordReader {
+  void open();
+
+  LoadResult read(CobolDataStorage record);
+
+  void close();
+
+  static RecordReader getInstance(UserDataFormat userDataFormat, int recordSize) {
+    return StdinRecordReader.getInstance(userDataFormat, recordSize);
+  }
+}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordReader.java
@@ -1,5 +1,6 @@
 package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
 
+import java.util.Optional;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
 public interface RecordReader {
@@ -9,7 +10,19 @@ public interface RecordReader {
 
   void close();
 
-  static RecordReader getInstance(UserDataFormat userDataFormat, int recordSize) {
-    return StdinRecordReader.getInstance(userDataFormat, recordSize);
+  static RecordReader getInstance(
+      UserDataFormat userDataFormat, int recordSize, Optional<String> filePath) {
+    if (filePath.isPresent()) {
+      switch (userDataFormat) {
+        case LINE_SEQUENTIAL:
+          return new FileLineSeqRecordReader(recordSize, filePath.get());
+        case SEQUENTIAL:
+          return new FileSeqRecordReader(recordSize, filePath.get());
+        default:
+          return null;
+      }
+    } else {
+      return StdinRecordReader.getInstance(userDataFormat, recordSize);
+    }
   }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/RecordWriter.java
@@ -1,0 +1,9 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+public interface RecordWriter {
+  void open();
+
+  boolean write(byte[] record);
+
+  void close();
+}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/StdinRecordReader.java
@@ -1,0 +1,104 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+import java.util.Scanner;
+import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
+
+public class StdinRecordReader implements RecordReader {
+  protected int recordSize;
+  protected Scanner scan;
+
+  protected StdinRecordReader(int recordSize) {
+    this.recordSize = recordSize;
+  }
+
+  @Override
+  public void open() {
+    this.scan = new Scanner(System.in);
+  }
+
+  @Override
+  public LoadResult read(CobolDataStorage record) {
+    return null;
+  }
+
+  @Override
+  public void close() {
+    this.scan.close();
+  }
+
+  static class StdinLineSeqReader extends StdinRecordReader {
+    public StdinLineSeqReader(int recordSize) {
+      super(recordSize);
+    }
+
+    @Override
+    public LoadResult read(CobolDataStorage record) {
+      if (scan.hasNextLine()) {
+        byte[] readData = scan.nextLine().getBytes();
+        if (readData.length != this.recordSize) {
+          return LoadResult.LoadResultDataSizeMismatch;
+        }
+        record.memcpy(readData, this.recordSize);
+        return LoadResult.LoadResultSuccess;
+      } else {
+        return LoadResult.AtEnd;
+      }
+    }
+  }
+
+  static class StdinSeqReader extends StdinRecordReader {
+    private boolean firstFetchFail;
+    private byte[] readData;
+    private int readDataOffset;
+
+    public StdinSeqReader(int recordSize) {
+      super(recordSize);
+    }
+
+    @Override
+    public void open() {
+      super.open();
+      this.firstFetchFail = false;
+      this.readData = null;
+      this.readDataOffset = 0;
+    }
+
+    @Override
+    public LoadResult read(CobolDataStorage record) {
+      if (firstFetchFail) {
+        return LoadResult.LoadResultDataSizeMismatch;
+      }
+      if (readData == null) {
+        if (!this.scan.hasNextLine()) {
+          return LoadResult.AtEnd;
+        }
+        this.readData = this.scan.next().getBytes();
+        if (readData.length % this.recordSize != 0) {
+          this.firstFetchFail = true;
+          return LoadResult.LoadResultDataSizeMismatch;
+        }
+      }
+      if (readDataOffset >= readData.length) {
+        return LoadResult.AtEnd;
+      }
+      record.memcpy(this.readData, this.readDataOffset, this.recordSize);
+      this.readDataOffset += this.recordSize;
+      return LoadResult.LoadResultSuccess;
+    }
+  }
+
+  public static RecordReader getInstance(UserDataFormat userDataFormat, int recordSize) {
+    switch (userDataFormat) {
+      case LINE_SEQUENTIAL:
+        {
+          return new StdinLineSeqReader(recordSize);
+        }
+      case SEQUENTIAL:
+        {
+          return new StdinSeqReader(recordSize);
+        }
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -164,6 +164,21 @@ a0011b0011c0011d0010e001000011
 a0012b0012c0012d0012e001200012
 ])
 
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-sample input.txt --format=txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0002e000200002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0012e001200012
+])
+
 # test for duplicate keys
 AT_CHECK([cp idx-file work-sample])
 AT_DATA([input.txt],
@@ -171,6 +186,21 @@ AT_DATA([input.txt],
 a0012b0012c0012d0010e001000012
 ])
 AT_CHECK([${COBJ_IDX} load work-sample --format=txt < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0000e000000002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0010e001000012
+])
+
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0000b0000c0000d0000e000000000
 a0001b0001c0001d0001e000100001
@@ -192,6 +222,17 @@ a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
 
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
 ####### test for the file 'sample' with valid input #######
 # basic test
 AT_CHECK([cp idx-file work-sample])
@@ -199,6 +240,20 @@ AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002a0012b0012c0012d0012e001200012
 ])
 AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0002e000200002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0012e001200012
+])
+
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-sample input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0000b0000c0000d0000e000000000
 a0001b0001c0001d0001e000100001
@@ -223,11 +278,36 @@ a0011b0011c0011d0010e001000011
 a0012b0012c0012d0010e001000012
 ])
 
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-sample input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0002b0002c0002d0000e000000002
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+a0012b0012c0012d0010e001000012
+])
+
 # test with empty input
 AT_CHECK([cp idx-file work-sample])
 AT_DATA([input.txt],
 [])
 AT_CHECK([${COBJ_IDX} load work-sample < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-sample input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0000b0000c0000d0000e000000000
 a0001b0001c0001d0001e000100001
@@ -247,9 +327,25 @@ AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0002b0002c0002d0002e000200002
 a0012b0012c0012d0012e001200012
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load --new -f txt work-sample input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
 
 AT_CHECK([cp idx-file work-sample])
 AT_CHECK([${COBJ_IDX} load -n work-sample --format=txt < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([cp idx-file work-sample])
+AT_CHECK([${COBJ_IDX} load -n work-sample --format=txt input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0002b0002c0002d0002e000200002
 a0012b0012c0012d0012e001200012
@@ -261,9 +357,21 @@ AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0002b0002c0002d0002e000200002
 a0012b0012c0012d0012e001200012
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_CHECK([${COBJ_IDX} load -f txt work-sample --new input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
 
 AT_CHECK([cp idx-file work-sample])
 AT_CHECK([${COBJ_IDX} load work-sample --format=txt -n < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([cp idx-file work-sample])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt -n input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [a0002b0002c0002d0002e000200002
 a0012b0012c0012d0012e001200012
@@ -276,6 +384,12 @@ AT_DATA([input.txt],
 AT_CHECK([${COBJ_IDX} load work-sample -n < input.txt])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
 [])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-sample -n input.txt])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[])
 
 ####### test for the file 'sample' with invalid input and --format=txt option #######
 
@@ -286,6 +400,20 @@ AT_DATA([input.txt],
 a0012b0012c0012d0012e001200
 ])
 AT_CHECK([${COBJ_IDX} load work-sample --format=txt < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
 [error: all record must have the length of 30 bytes.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -310,6 +438,20 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input containing short records
 AT_CHECK([cp idx-file work-sample])
@@ -325,6 +467,19 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002a0012b001
+])
+AT_CHECK([${COBJ_IDX} load work-sample input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input violating the key duplication rule (primary key, #1)
 AT_CHECK([cp idx-file work-sample])
@@ -332,6 +487,19 @@ AT_DATA([input.txt],
 [a0000b0002c0002d0002e000200002
 ])
 AT_CHECK([${COBJ_IDX} load work-sample --format=txt < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0000b0002c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -357,12 +525,40 @@ a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
 
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+
 # test for input violating the key duplication rule (alternate key, #1)
 AT_CHECK([cp idx-file work-sample])
 AT_DATA([input.txt],
 [a0002b0001c0002d0002e000200002
 ])
 AT_CHECK([${COBJ_IDX} load work-sample --format=txt < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0001c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -387,6 +583,20 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-sample --format=txt input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input violating the key duplication rule (primary key, #1) with -f bin option
 AT_CHECK([cp idx-file work-sample])
@@ -394,6 +604,19 @@ AT_DATA([input.txt],
 [a0000b0002c0002d0002e000200002
 ])
 AT_CHECK([${COBJ_IDX} load work-sample -format=bin < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0000b0002c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load work-sample -format=bin input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -417,6 +640,19 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load -f bin work-sample input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input violating the key duplication rule (alternate key, #1) with -f bin option
 AT_CHECK([cp idx-file work-sample])
@@ -432,6 +668,19 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0001c0002d0002e000200002
+])
+AT_CHECK([${COBJ_IDX} load --format=bin work-sample input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input violating the key duplication rule (alternate key, #2) with -f bin option
 AT_CHECK([cp idx-file work-sample])
@@ -439,6 +688,19 @@ AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002a0003b0002c0003d0003e000300003
 ])
 AT_CHECK([${COBJ_IDX} load work-sample -f bin < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-sample -f bin input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -463,6 +725,20 @@ a0001b0001c0001d0001e000100001
 a0010b0010c0010d0010e001000010
 a0011b0011c0011d0010e001000011
 ])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load --new work-sample --format=txt input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
 
 # test for input violating the key duplication rule (alternate key) with --new option
 AT_CHECK([cp idx-file work-sample])
@@ -471,6 +747,20 @@ AT_DATA([input.txt],
 a0003b0002c0003d0003e000300003
 ])
 AT_CHECK([${COBJ_IDX} load --new work-sample --format=txt < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
+[a0000b0000c0000d0000e000000000
+a0001b0001c0001d0001e000100001
+a0010b0010c0010d0010e001000010
+a0011b0011c0011d0010e001000011
+])
+AT_CHECK([cp idx-file work-sample])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load --new work-sample --format=txt input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-sample java load], [0],
@@ -492,6 +782,16 @@ AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
 [a0002b0002c0002d0002e000200002
 a0012b0012c0012d0012e001200012
 ])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
 
 # test for duplicate keys
 AT_CHECK([cp idx-empty-file work-empty])
@@ -504,12 +804,28 @@ AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
 [a0002b0002c0002d0000e000000002
 a0012b0012c0012d0010e001000012
 ])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
 
 # test with empty input
 AT_CHECK([cp idx-empty-file work-empty])
 AT_DATA([input.txt],
 [])
 AT_CHECK([${COBJ_IDX} load work-empty --format=txt < input.txt])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt])
 AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
 [])
 
@@ -526,6 +842,16 @@ AT_CHECK([${COBJ_IDX} load work-empty --format=txt < input.txt], [1], [],
 ])
 AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
 [])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
 
 # test for input containing long records
 AT_CHECK([cp idx-empty-file work-empty])
@@ -534,6 +860,16 @@ AT_DATA([input.txt],
 a0012b0012c0012d0012e001200012aaa
 ])
 AT_CHECK([${COBJ_IDX} load work-empty --format=txt < input.txt], [1], [],
+[error: all record must have the length of 30 bytes.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt], [1], [],
 [error: all record must have the length of 30 bytes.
 ])
 AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
@@ -550,6 +886,16 @@ AT_CHECK([${COBJ_IDX} load work-empty --format=txt < input.txt], [1], [],
 ])
 AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
 [])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
 
 # test for input violating the key duplication rule (alternate key)
 AT_CHECK([cp idx-empty-file work-empty])
@@ -558,6 +904,16 @@ AT_DATA([input.txt],
 a0003b0002c0003d0003e000300003
 ])
 AT_CHECK([${COBJ_IDX} load work-empty --format=txt < input.txt], [1], [],
+[error: loading fails because of duplicate keys.
+])
+AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
+[])
+AT_CHECK([cp idx-empty-file work-empty])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-empty --format=txt input.txt], [1], [],
 [error: loading fails because of duplicate keys.
 ])
 AT_CHECK([IDX_FILE_PATH=work-empty java load], [0],
@@ -573,6 +929,14 @@ a0012b0012c0012d0012e001200012
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
 
 # test for duplicate keys
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -583,12 +947,26 @@ a0012b0012c0012d0010e001000012
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
 
 # test with idx-invalid-file input
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [])
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
 
@@ -605,6 +983,16 @@ AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1],
 ])
 AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
 [])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 # test for input containing long records
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -613,6 +1001,16 @@ AT_DATA([input.txt],
 a0012b0012c0012d0012e001200012aaa
 ])
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
 AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
@@ -629,6 +1027,16 @@ AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1],
 ])
 AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
 [])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 # test for input violating the key duplication rule (alternate key)
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -637,6 +1045,16 @@ AT_DATA([input.txt],
 a0003b0002c0003d0003e000300003
 ])
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
+[error: 'work-idx-invalid-file' is not a valid indexed file.
+])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
+AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
 AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
@@ -652,6 +1070,14 @@ a0012b0012c0012d0012e001200012
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
 
 # test for duplicate keys
 AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
@@ -662,12 +1088,26 @@ a0012b0012c0012d0010e001000012
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0000e000000002
+a0012b0012c0012d0010e001000012
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
 
 # test with dir-idx-file input
 AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
 AT_DATA([input.txt],
 [])
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
 
@@ -682,6 +1122,14 @@ a0012b0012c0012d0012e001200
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
 
 # test for input containing long records
 AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
@@ -690,6 +1138,14 @@ AT_DATA([input.txt],
 a0012b0012c0012d0012e001200012aaa
 ])
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0012b0012c0012d0012e001200012aaa
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
 
@@ -702,6 +1158,14 @@ a0002b0003c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0003c0003d0003e000300003
+a0002b0003c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
 
 # test for input violating the key duplication rule (alternate key)
 AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
@@ -710,6 +1174,14 @@ AT_DATA([input.txt],
 a0003b0002c0003d0003e000300003
 ])
 AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt < input.txt], [1], [],
+[error: 'work-dir-idx-file' is not a valid indexed file.
+])
+AT_CHECK([cp -r dir-idx-file work-dir-idx-file])
+AT_DATA([input.txt],
+[a0002b0002c0002d0002e000200002
+a0003b0002c0003d0003e000300003
+])
+AT_CHECK([${COBJ_IDX} load work-dir-idx-file --format=txt input.txt], [1], [],
 [error: 'work-dir-idx-file' is not a valid indexed file.
 ])
 

--- a/tests/cobj-idx.src/misc.at
+++ b/tests/cobj-idx.src/misc.at
@@ -16,9 +16,6 @@ AT_CHECK([${COBJ_IDX} unload], [1], [],
 AT_CHECK([${COBJ_IDX} info file1 file2], [1], [],
 [error: too many indexed files are specified.
 ])
-AT_CHECK([${COBJ_IDX} load file1 file2], [1], [],
-[error: too many indexed files are specified.
-])
 AT_CHECK([${COBJ_IDX} unload], [1], [],
 [error: no indexed file is specified.
 ])


### PR DESCRIPTION
Previously, cobj-idx could only read input data from stdin.
This PR adds the ability to specify input files to the cobj-idx command.
```
cobj-idx load <indexed file> <input file>
```