### PR TITLE
Add a build test using gcc-9 and update documents

### DIFF
--- a/.github/workflows/build-gcc9.yml
+++ b/.github/workflows/build-gcc9.yml
@@ -1,0 +1,26 @@
+name: build opensource COBOL 4J using gcc 9
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies on Ubuntu 22.04
+        run: |
+          sudo apt update -y
+          sudo apt install -y gcc-9 build-essential gettext autoconf
+
+      - name: Checkout opensource COBOL 4J
+        uses: actions/checkout@v3
+      
+      - name: Install opensource COBOL 4J
+        run: |
+          ./configure --prefix=/usr/ CC=gcc-9
+          make

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -50,7 +50,10 @@ jobs:
       test-name: ${{ matrix.test_name }}
       check-result: false
       os: ${{ matrix.os }}
-  
+
+  build-gcc9:
+    uses: ./.github/workflows/build-gcc9.yml
+
   javadoc:
     uses: ./.github/workflows/javadoc.yml
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,6 +50,9 @@ jobs:
       check-result: false
       os: ${{ matrix.os }}
 
+  build-gcc9:
+    uses: ./.github/workflows/build-gcc9.yml
+
   javadoc:
     uses: ./.github/workflows/javadoc.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Add built-in subroutines 
   * `C$CALLEDBY` (#262)
   * `C$LIST-DIRECTORY` (#264)
-* Implement `NUMBER-OF-PARAMETERS` (#270)
+* Implement `NUMBER-OF-CALL-PARAMETERS` (#270)
 ### Fixed
 * Fix the message of COB_VERBOSE file sort (#260)
 * Fix the process that checks MOVE statements (#266, #267)

--- a/NEWS
+++ b/NEWS
@@ -30,7 +30,7 @@ NEWS - user visible changes				-*- outline -*-
   (7) Add built-in subroutines
     (a) `C$CALLEDBY`
     (b) `C$LIST-DIRECTORY`
-  (8) Implement `NUMBER-OF-PARAMETERS`
+  (8) Implement `NUMBER-OF-CALL-PARAMETERS`
 ** Bug fixes
   (1) Fix the message of COB_VERBOSE file sort
   (2) Fix the process that checks MOVE statements

--- a/cobj/field.c
+++ b/cobj/field.c
@@ -639,10 +639,9 @@ static int validate_field_1(struct cb_field *f) {
       switch (f->pic->category) {
       case CB_CATEGORY_NUMERIC:
         /* reconstruct the picture string */
-        unsigned char *pstr;
         if (f->pic->scale > 0) {
           f->pic->str = cobc_malloc(20);
-          pstr = (unsigned char *)(f->pic->str);
+          unsigned char *pstr = (unsigned char *)(f->pic->str);
           *pstr++ = '9';
           vorint = f->pic->digits - f->pic->scale;
           memcpy(pstr, (unsigned char *)&vorint, sizeof(int));
@@ -657,7 +656,7 @@ static int validate_field_1(struct cb_field *f) {
           f->pic->size++;
         } else {
           f->pic->str = cobc_malloc(8);
-          pstr = (unsigned char *)(f->pic->str);
+          unsigned char *pstr = (unsigned char *)(f->pic->str);
           *pstr++ = '9';
           vorint = f->pic->digits;
           memcpy(pstr, (unsigned char *)&vorint, sizeof(int));


### PR DESCRIPTION
Since building opensource COBOL 4J v1.0.19 using gcc-9 fails, this PR resolve a gcc error and add a new build test.
In addition, this PR fixes NEWS and CHANGELOG.md