### PR TITLE
Fix the runtime checking of national fieds whose variable name contains Shift_JIS characters

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -108,12 +108,12 @@ public class CobolUtil {
 
   public static void cobCheckRefModNational(int offset, long length, int size, byte[] name)
       throws CobolStopRunException {
-    CobolUtil.cobCheckRefMod(offset, length, size, name);
+    CobolUtil.cobCheckRefMod((offset + 1) / 2, length / 2, size / 2, name);
   }
 
   public static void cobCheckRefModNational(int offset, long length, int size, String name)
       throws CobolStopRunException {
-    CobolUtil.cobCheckRefMod(offset, length, size, name);
+    CobolUtil.cobCheckRefMod((offset + 1) / 2, length / 2, size / 2, name);
   }
 
   public static void cobCheckRefMod(

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -313,7 +313,6 @@ AT_CHECK([java prog], [1], [],
 AT_CLEANUP
 
 AT_SETUP([Nihongo field name in length of N_refmod test msg.])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.
@@ -336,7 +335,6 @@ AT_CHECK([java prog], [1], [],
 AT_CLEANUP
 
 AT_SETUP([Nihongo field name in offset of N_refmod test msg.])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.


### PR DESCRIPTION
This PR fixes the runtime checking of national fieds whose variable name contains Shift_JIS character.
Due to this modification, two tests in tests/i18n_sjis.src/user-defined-word.at are resolved.