### PR TITLE
Fix the runtime checking of OCCURS DEPENDING ON

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -1855,6 +1855,13 @@ static void joutput_funcall(cb_tree x) {
   } else {
     screenptr = p->screenptr;
     joutput("%s (", p->name);
+
+    int flag_func_is_check_odo = strcmp(p->name, "CobolCheck.checkOdo") == 0;
+    int save_flag = param_wrap_string_flag;
+    if (flag_func_is_check_odo) {
+      param_wrap_string_flag = 0;
+    }
+
     for (i = 0; i < p->argc; i++) {
       if (p->varcnt && i + 1 == p->argc) {
         joutput("%d, ", p->varcnt);
@@ -1872,6 +1879,7 @@ static void joutput_funcall(cb_tree x) {
         }
       }
     }
+    param_wrap_string_flag = save_flag;
     joutput(")");
     screenptr = 0;
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -18,6 +18,7 @@
  */
 package jp.osscons.opensourcecobol.libcobj.common;
 
+import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
@@ -62,6 +63,6 @@ public class CobolCheck {
   }
 
   public static void checkOdo(int i, int min, int max, byte[] name) throws CobolStopRunException {
-    CobolCheck.checkOdo(i, min, max, new String(name));
+    CobolCheck.checkOdo(i, min, max, new String(name, AbstractCobolField.charSetSJIS));
   }
 }

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -223,7 +223,6 @@ AT_CHECK([java prog], [1], [],
 AT_CLEANUP
 
 AT_SETUP([Nihongo field name in ODO test msg.])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.


### PR DESCRIPTION
This pull request fixes the runtime checking of OCCURS DEPENDING ON and resolves a test in user-defined-word.at.