### PR TITLE
Update the encoding of runtime error message of subscript tests

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -30,7 +30,9 @@ public class CobolCheck {
     if (i < min || max < i) {
       CobolRuntimeException.setException(CobolExceptionId.COB_EC_BOUND_SUBSCRIPT);
       CobolUtil.runtimeError(
-          String.format("Subscript of '%s' out of bounds: %d", new String(name), i));
+          String.format(
+              "Subscript of '%s' out of bounds: %d",
+              new String(name, AbstractCobolField.charSetSJIS), i));
       CobolStopRunException.stopRunAndThrow(1);
     }
   }

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -245,7 +245,6 @@ AT_CHECK([java prog], [1], [],
 AT_CLEANUP
 
 AT_SETUP([Nihongo field name in Subscript test msg.])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION    DIVISION.


### PR DESCRIPTION
This pull request updates the encoding of runtime error message of subscript tests and resolve a test in user-defined-word.at.