### PR TITLE
Implement DISPLAY/ACCEPT for environment variables

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -218,6 +218,7 @@ public class CobolTerminal {
       CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
       return;
     }
+    CobolUtil.setEnv(CobolUtil.cobLocalEnv, f.getString());
   }
 
   /**

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -1104,7 +1104,6 @@ abcdef
 AT_CLEANUP
 
 AT_SETUP([Environment/Argument variable])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.


### PR DESCRIPTION
This pull request adds `DISPLAY ~~~ UPON ENVIRONMENT NAME` and `ACCEPT ~~~ FROM ENVIRONMENT-VALUE`.
With this modification, one test in tests/run.src/extensions.at become successful.