### PR TITLE
Change the schema of json files of -info-json-dir

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -4312,7 +4312,6 @@ static void write_json_info(struct cb_program *prog) {
   }
 
   fprintf(fp, "{\n");
-  fprintf(fp, "  \"json_format_version\": \"1.0.0\",\n");
   fprintf(fp, "  \"opensourcecobol4j_version\": \"%s\",\n", PACKAGE_VERSION);
   fprintf(fp, "  \"program_id\": \"%s\",\n", prog->program_id);
   fprintf(fp, "  \"procedure_division_using_parameters\": [\n");
@@ -4321,8 +4320,8 @@ static void write_json_info(struct cb_program *prog) {
     struct cb_field *arg_field = cb_field(CB_VALUE(l));
     int type = cb_tree_type(CB_TREE(arg_field));
     fprintf(fp, "    {\n");
-    fprintf(fp, "      \"name\": \"%s\",\n", arg_field->name);
-    fprintf(fp, "      \"type\": ");
+    fprintf(fp, "      \"variable_name\": \"%s\",\n", arg_field->name);
+    fprintf(fp, "      \"java_type\": ");
     if (type & COB_TYPE_NUMERIC) {
       if (arg_field->pic->scale > 0) {
         fprintf(fp, "\"double\"");

--- a/tests/command-line-options.src/info-java-dir.at
+++ b/tests/command-line-options.src/info-java-dir.at
@@ -28,17 +28,16 @@ AT_DATA([prog.cbl], [
 AT_CHECK([${COBJ} -info-json-dir=./ callee.cbl prog.cbl])
 AT_CHECK([cat info_callee.json], [0],
 [{
-  "json_format_version": "1.0.0",
   "opensourcecobol4j_version": "1.0.20",
   "program_id": "callee",
   "procedure_division_using_parameters": @<:@
     {
-      "name": "P1",
-      "type": "String"
+      "variable_name": "P1",
+      "java_type": "String"
     },
     {
-      "name": "P2",
-      "type": "int"
+      "variable_name": "P2",
+      "java_type": "int"
     }
   @:>@
 }
@@ -46,7 +45,6 @@ AT_CHECK([cat info_callee.json], [0],
 
 AT_CHECK([cat info_prog.json], [0],
 [{
-  "json_format_version": "1.0.0",
   "opensourcecobol4j_version": "1.0.20",
   "program_id": "prog",
   "procedure_division_using_parameters": @<:@
@@ -66,17 +64,16 @@ AT_CHECK([${COBJ} -info-json-dir=bbb callee.cbl prog.cbl])
 
 AT_CHECK([cat bbb/info_callee.json], [0],
 [{
-  "json_format_version": "1.0.0",
   "opensourcecobol4j_version": "1.0.20",
   "program_id": "callee",
   "procedure_division_using_parameters": @<:@
     {
-      "name": "P1",
-      "type": "String"
+      "variable_name": "P1",
+      "java_type": "String"
     },
     {
-      "name": "P2",
-      "type": "int"
+      "variable_name": "P2",
+      "java_type": "int"
     }
   @:>@
 }
@@ -84,7 +81,6 @@ AT_CHECK([cat bbb/info_callee.json], [0],
 
 AT_CHECK([cat bbb/info_prog.json], [0],
 [{
-  "json_format_version": "1.0.0",
   "opensourcecobol4j_version": "1.0.20",
   "program_id": "prog",
   "procedure_division_using_parameters": @<:@


### PR DESCRIPTION
This pull request changes the schema of json files generated by a new option `-info-json-dir`. (See #362)
The following is an example.

callee.cbl
```cobol
       IDENTIFICATION   DIVISION.
       PROGRAM-ID.      callee.
       DATA             DIVISION.
       WORKING-STORAGE  SECTION.
       LINKAGE          SECTION.
       01 P1            PIC X ANY LENGTH.
       01 P2            PIC 99.
       PROCEDURE        DIVISION USING P1 P2.
           GOBACK.
```

the JSON file
```json
{
  "opensourcecobol4j_version": "1.0.20",
  "program_id": "callee",
  "procedure_division_using_parameters": [
    {
      "variable_name": "P1",
      "java_type": "String"
    },
    {
      "variable_name": "P2",
      "type": "int"
    }
  ]
}
```