### PR TITLE
Fixed a Bug of SonarQube

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2693,17 +2693,22 @@ static void joutput_search_all(cb_tree table, cb_tree stmt, cb_tree cond,
                                cb_tree when) {
   struct cb_field *p;
   cb_tree idx;
+  int occurs;
 
   p = cb_field(table);
   idx = CB_VALUE(p->index_list);
+
+  if (p->occurs_depending) {
+    occurs = p->occurs_depending;
+  } else {
+    occurs = p->occurs_max;
+  }
+
   /* Header */
   joutput_indent("{");
   joutput_line("int ret;");
-  joutput_line("int head = %d - 1;", p->occurs_min);
-  joutput_prefix();
-  joutput("int tail = ");
-  joutput_occurs(p);
-  joutput(" + 1;\n");
+  joutput_line("int head = %d;", p->occurs_min - 1);
+  joutput_line("int tail = %d;", occurs + 1);
 
   /* Start loop */
   joutput_line("for (;;)");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2697,7 +2697,12 @@ static void joutput_search_all(cb_tree table, cb_tree stmt, cb_tree cond,
 
   p = cb_field(table);
   idx = CB_VALUE(p->index_list);
-  occurs = p->occurs_max;
+
+  if (p->occurs_depending) {
+    occurs = CB_INTEGER(p->occurs_depending)->val;
+  } else {
+    occurs = p->occurs_max;
+  }
 
   /* Header */
   joutput_indent("{");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2697,12 +2697,7 @@ static void joutput_search_all(cb_tree table, cb_tree stmt, cb_tree cond,
 
   p = cb_field(table);
   idx = CB_VALUE(p->index_list);
-
-  if (p->occurs_depending) {
-    occurs = p->occurs_depending;
-  } else {
-    occurs = p->occurs_max;
-  }
+  occurs = p->occurs_max;
 
   /* Header */
   joutput_indent("{");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2693,22 +2693,22 @@ static void joutput_search_all(cb_tree table, cb_tree stmt, cb_tree cond,
                                cb_tree when) {
   struct cb_field *p;
   cb_tree idx;
-  int occurs;
 
   p = cb_field(table);
   idx = CB_VALUE(p->index_list);
-
-  if (p->occurs_depending) {
-    occurs = CB_INTEGER(p->occurs_depending)->val;
-  } else {
-    occurs = p->occurs_max;
-  }
 
   /* Header */
   joutput_indent("{");
   joutput_line("int ret;");
   joutput_line("int head = %d;", p->occurs_min - 1);
-  joutput_line("int tail = %d;", occurs + 1);
+  joutput_prefix();
+  joutput("int tail = ");
+  if (p->occurs_depending) {
+    joutput_integer(p->occurs_depending);
+    joutput(" + 1;\n");
+  } else {
+    joutput("%d;\n", p->occurs_max + 1);
+  }
 
   /* Start loop */
   joutput_line("for (;;)");


### PR DESCRIPTION
Fixed generated Java code that was detected as a bug in SonarQube.

Before:
```
int ret;
int head = 1 - 1;
int tail = 10 + 1;
```
After:
```
int ret;
int head = 0;
int tail = 11;
```