### PR TITLE
Fix #315

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -95,6 +95,10 @@ public final class IndexedCursor {
     this.comparator = comparator;
   }
 
+  public int getComparator() {
+    return this.comparator;
+  }
+
   private IndexedCursor(
       Connection conn, byte[] key, int tableIndex, boolean isDuplicate, int comparator) {
     this.conn = conn;


### PR DESCRIPTION
This draft pull request will resolve the issue #315.
Currently this pull request fixes READ statements which are called after START statements with comparator <=.
```cobol
       start f key is <= f-rec-key.
       read f previous record.
```

I will fix other cases and add tests for this modification.