### PR TITLE
Add a comman line option `-Wimplicit-define`

### DIFF
--- a/cobj/warning-help.def
+++ b/cobj/warning-help.def
@@ -45,6 +45,9 @@ CB_WARNDEF (cb_warn_parentheses, "parentheses", 1,
 CB_WARNDEF (cb_warn_strict_typing, "strict-typing", 1,
 	    N_("Warn type mismatch strictly"))
 
+CB_WARNDEF (cb_warn_implicit_define, "implicit-define", 1,
+	    N_("Warn implicitly defined data items"))
+
 CB_WARNDEF (cb_warn_call_params, "call-params", 0,
 	    N_("Warn non 01/77 items for CALL params"))
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -175,7 +175,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/debug.at \
 	command-line-options.src/jar.at \
 	command-line-options.src/std.at \
-	command-line-options.src/conf.at
+	command-line-options.src/conf.at \
+	command-line-options.src/Wimplicit-define.at
 
 cobj_idx_DEPENDENCIES = \
 	cobj-idx.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -716,7 +716,8 @@ command_line_options_DEPENDENCIES = \
 	command-line-options.src/debug.at \
 	command-line-options.src/jar.at \
 	command-line-options.src/std.at \
-	command-line-options.src/conf.at
+	command-line-options.src/conf.at \
+	command-line-options.src/Wimplicit-define.at
 
 cobj_idx_DEPENDENCIES = \
 	cobj-idx.at \

--- a/tests/command-line-options.at
+++ b/tests/command-line-options.at
@@ -33,5 +33,6 @@ m4_include([debug.at])
 m4_include([jar.at])
 m4_include([std.at])
 m4_include([conf.at])
+m4_include([Wimplicit-define.at])
 
 # m4_include([edit-code-command.at])

--- a/tests/command-line-options.src/Wimplicit-define.at
+++ b/tests/command-line-options.src/Wimplicit-define.at
@@ -1,0 +1,24 @@
+AT_SETUP([-Wimplicit-define])
+
+AT_DATA([prog.cbl],
+[       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       ENVIRONMENT      DIVISION.
+       INPUT-OUTPUT     SECTION.
+       FILE-CONTROL.
+       SELECT TEST-FILE ASSIGN TEST-FILE-PATH.
+       DATA             DIVISION.
+       FILE             SECTION.
+       FD TEST-FILE  RECORD CONTAINS 8.
+       01 TEST-REC      PIC X(7).
+       PROCEDURE        DIVISION.
+           STOP RUN.
+])
+
+AT_CHECK([${COBJ} -Wimplicit-define prog.cbl], [0], [],
+[prog.cbl:11: Warning: 'TEST-FILE-PATH' will be implicitly defined
+])
+
+AT_CHECK([${COBJ} --help | grep '\-Wimplicit-define' > /dev/null])
+
+AT_CLEANUP


### PR DESCRIPTION
This pull request adds a comman line option `-Wimplicit-define`.
With this option, cobj shows warning messages if there exist select statements whose assign parameters are not define in DATA DIVISION. 