### PR TITLE
Simplify the process that checks the test result

### DIFF
--- a/.github/workflows/mstest.yml
+++ b/.github/workflows/mstest.yml
@@ -49,5 +49,5 @@ jobs:
         cd ..\tests\cobol85\${{ inputs.test-name }}
         perl ..\report.pl
         type report.txt
-        findstr "Successfully executed:" .\report.txt
-        findstr "100.00%" .\result-check .\report.txt
+        findstr "Successfully executed:" .\report.txt > .\result-check
+        findstr "100.00%" .\result-check

--- a/.github/workflows/mstest.yml
+++ b/.github/workflows/mstest.yml
@@ -49,15 +49,5 @@ jobs:
         cd ..\tests\cobol85\${{ inputs.test-name }}
         perl ..\report.pl
         type report.txt
-        findstr "Successfully executed:" .\report.txt > result-check
-
-    - name: Read file
-      id: package
-      uses: juliangruber/read-file-action@v1
-      with: 
-        path: .\tests\cobol85\${{ inputs.test-name }}\result-check
-    
-    - name: Check result of tests
-      if: ${{ !contains(steps.package.outputs.content, '100.00%') }}
-      run: |
-        exit 1
+        findstr "Successfully executed:" .\report.txt
+        findstr "100.00%" .\result-check .\report.txt


### PR DESCRIPTION
This pull request updates mstest.yml which runs tests on Windows. Instead of juliangruber/read-file-action@v1, run findstr command in order to check the test results