### PR TITLE
Resolve javadoc warnings

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -21,4 +21,5 @@ jobs:
       - name: Run javadoc
         working-directory: libcobj 
         run: |
-          ./gradlew javadoc
+          ./gradlew javadoc | tee javadoc.log
+          test "$(grep '[1-9][0-9]* warning' javadoc.log)" = ""

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolCallDataContent.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolCallDataContent.java
@@ -32,7 +32,7 @@ public class CobolCallDataContent {
   /**
    * TODO: 調査中
    *
-   * @param size
+   * @param size TODO: 調査中
    */
   public CobolCallDataContent(int size) {
     this.data = new CobolDataStorage(size);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
@@ -312,7 +312,7 @@ public class CobolResolve {
    * @param runner CobolRunnableを実装したクラス。nullでもよい。
    * @return runnerがnullでない場合はrunnerを返し、そうでないときはクラス名とパッケージ名を元に検索処理を実施する。
    *     検索して動的にクラスの読み込みに成功したら、それを返す。検索に失敗したら nullを返す。
-   * @throws CobolRuntimeException
+   * @throws CobolRuntimeException TODO: 調査中
    */
   public static CobolRunnable resolve(
       String packageName, AbstractCobolField cobolField, CobolRunnable runner)
@@ -337,7 +337,7 @@ public class CobolResolve {
    * @param runner CobolRunnableを実装したクラス。nullでもよい。
    * @return runnerがnullでない場合はrunnerを返し、そうでないときはクラス名とパッケージ名を元に検索処理を実施する。
    *     検索して動的にクラスの読み込みに成功したら、それを返す。検索に失敗したら nullを返す。
-   * @throws CobolRuntimeException
+   * @throws CobolRuntimeException TODO: 調査中
    */
   public static CobolRunnable resolve(String packageName, String name, CobolRunnable runner)
       throws CobolRuntimeException {
@@ -359,7 +359,7 @@ public class CobolResolve {
    * @param packageName パッケージ名
    * @param cobolField 読み込むクラスの名前
    * @return クラス名とパッケージ名を元に検索処理を実施する。 検索して動的にクラスの読み込みに成功したら、それを返す。検索に失敗したら nullを返す。
-   * @throws CobolRuntimeException
+   * @throws CobolRuntimeException TODO: 調査中
    */
   public static CobolRunnable resolve(String packageName, AbstractCobolField cobolField)
       throws CobolRuntimeException {
@@ -377,7 +377,7 @@ public class CobolResolve {
    * @param packageName パッケージ名
    * @param name 読み込むクラスの名前
    * @return クラス名とパッケージ名を元に検索処理を実施する。 検索して動的にクラスの読み込みに成功したら、それを返す。検索に失敗したら nullを返す。
-   * @throws CobolRuntimeException
+   * @throws CobolRuntimeException TODO: 調査中
    */
   public static CobolRunnable resolve(String packageName, String name)
       throws CobolRuntimeException {
@@ -488,7 +488,7 @@ public class CobolResolve {
    * 指定のプログラムのcancelメソッドを呼び出す
    *
    * @param f cancelを呼び出すプログラム名を示すCOBOL変数
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void fieldCancel(AbstractCobolField f) throws CobolStopRunException {
     CobolResolve.cobCancel(f.fieldToString());
@@ -497,7 +497,7 @@ public class CobolResolve {
    * 指定のプログラムのcancelメソッドを呼び出す
    *
    * @param name プログラム名
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void cobCancel(String name) throws CobolStopRunException {
     if (name == null || name.equals("")) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -212,7 +212,7 @@ public class CobolSystemRoutine {
    * @param data1 TODO: 調査中
    * @param data2 TODO: 調査中
    * @param length TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_OR(CobolDataStorage data1, CobolDataStorage data2, int length) {
     return CBL_COMMON_OPERATION(
@@ -253,7 +253,7 @@ public class CobolSystemRoutine {
    * @param data1 TODO: 調査中
    * @param data2 TODO: 調査中
    * @param length TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_NOR(CobolDataStorage data1, CobolDataStorage data2, int length) {
     return CBL_COMMON_OPERATION(
@@ -286,7 +286,7 @@ public class CobolSystemRoutine {
    * @param data1 TODO: 調査中
    * @param data2 TODO: 調査中
    * @param length TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_XOR(CobolDataStorage data1, CobolDataStorage data2, int length) {
     return CBL_COMMON_OPERATION(
@@ -319,7 +319,7 @@ public class CobolSystemRoutine {
    * @param data1 TODO: 調査中
    * @param data2 TODO: 調査中
    * @param length TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_NIMP(CobolDataStorage data1, CobolDataStorage data2, int length) {
     return CBL_COMMON_OPERATION(
@@ -352,7 +352,7 @@ public class CobolSystemRoutine {
    * @param data1 TODO: 調査中
    * @param data2 TODO: 調査中
    * @param length TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_EQ(CobolDataStorage data1, CobolDataStorage data2, int length) {
     return CBL_COMMON_OPERATION(
@@ -465,7 +465,7 @@ public class CobolSystemRoutine {
    * @param result TODO: 調査中
    * @param func TODO: 調査中
    * @param parm TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int CBL_X91(CobolDataStorage result, CobolDataStorage func, CobolDataStorage parm) {
     switch (func.getByte(0)) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -209,9 +209,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_ORの実装
    *
-   * @param data1
-   * @param data2
-   * @param length
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @param length TODO: 調査中
    * @return
    */
   public static int CBL_OR(CobolDataStorage data1, CobolDataStorage data2, int length) {
@@ -250,9 +250,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_NORの実装
    *
-   * @param data1
-   * @param data2
-   * @param length
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @param length TODO: 調査中
    * @return
    */
   public static int CBL_NOR(CobolDataStorage data1, CobolDataStorage data2, int length) {
@@ -283,9 +283,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_XORの実装
    *
-   * @param data1
-   * @param data2
-   * @param length
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @param length TODO: 調査中
    * @return
    */
   public static int CBL_XOR(CobolDataStorage data1, CobolDataStorage data2, int length) {
@@ -316,9 +316,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_NIMPの実装
    *
-   * @param data1
-   * @param data2
-   * @param length
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @param length TODO: 調査中
    * @return
    */
   public static int CBL_NIMP(CobolDataStorage data1, CobolDataStorage data2, int length) {
@@ -349,9 +349,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_EQの実装
    *
-   * @param data1
-   * @param data2
-   * @param length
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @param length TODO: 調査中
    * @return
    */
   public static int CBL_EQ(CobolDataStorage data1, CobolDataStorage data2, int length) {
@@ -382,9 +382,9 @@ public class CobolSystemRoutine {
   /**
    * TODO libcob/common.cのCBL_NOTの実装
    *
-   * @param data
-   * @param length
-   * @return
+   * @param data TODO: 調査中
+   * @param length TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int CBL_NOT(CobolDataStorage data, int length) {
     CobolUtil.COB_CHK_PARMS("CBL_NOT", 2);
@@ -405,9 +405,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_XF4の実装
    *
-   * @param data1
-   * @param data2
-   * @return
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int CBL_XF4(CobolDataStorage data1, CobolDataStorage data2) {
     CobolUtil.COB_CHK_PARMS("CBL_XF4", 2);
@@ -434,9 +434,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_XF5の実装
    *
-   * @param data1
-   * @param data2
-   * @return
+   * @param data1 TODO: 調査中
+   * @param data2 TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int CBL_XF5(CobolDataStorage data1, CobolDataStorage data2) {
     CobolUtil.COB_CHK_PARMS("CBL_XF5", 2);
@@ -462,9 +462,9 @@ public class CobolSystemRoutine {
   /**
    * libcob/common.cのCBL_X91の実装
    *
-   * @param result
-   * @param func
-   * @param parm
+   * @param result TODO: 調査中
+   * @param func TODO: 調査中
+   * @param parm TODO: 調査中
    * @return
    */
   public static int CBL_X91(CobolDataStorage result, CobolDataStorage func, CobolDataStorage parm) {
@@ -499,9 +499,9 @@ public class CobolSystemRoutine {
   /**
    * TODO libcob/common.cのCBL_TOLOWERの実装
    *
-   * @param data
-   * @param length
-   * @return
+   * @param data TODO: 調査中
+   * @param length TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int CBL_TOLOWER(CobolDataStorage data, int length) {
     CobolUtil.COB_CHK_PARMS("CBL_TOLOWER", 2);
@@ -525,9 +525,9 @@ public class CobolSystemRoutine {
   /**
    * TODO libcob/common.cのCBL_TOUPPERの実装
    *
-   * @param data
-   * @param length
-   * @return
+   * @param data TODO: 調査中
+   * @param length TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int CBL_TOUPPER(CobolDataStorage data, int length) {
     CobolUtil.COB_CHK_PARMS("CBL_TOUPPER", 2);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -66,7 +66,7 @@ public class CobolSystemRoutine {
    *
    * @param cmd コマンド文字列。Linux/Unix環境であればシェルコマンド、Windows環境であればコマンドプロンプトのコマンド。
    * @return コマンドの終了コード。
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    *     このメソッドは内部でCobolModule.getCurrentModule().cob_procedure_parametersを参照する。
    *     このリストの形式に問題がある場合にスローされる。
    */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -50,11 +50,11 @@ public class CobolCheck {
   /**
    * libcob/common.cのcob_check_odoの実装
    *
-   * @param i
-   * @param min
-   * @param max
-   * @param name
-   * @throws CobolStopRunException
+   * @param i TODO: 調査中
+   * @param min TODO: 調査中
+   * @param max TODO: 調査中
+   * @param name TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void checkOdo(int i, int min, int max, String name) throws CobolStopRunException {
     if (i < min || max < i) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -160,8 +160,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_initの実装
    *
-   * @param var
-   * @param replacing
+   * @param var TODO: 調査中
+   * @param replacing TODO: 調査中
    */
   public static void init(AbstractCobolField var, int replacing) {
     CobolInspect.inspectVarCopy = var;
@@ -194,7 +194,7 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_beforeの実装
    *
-   * @param str
+   * @param str TODO: 調査中
    */
   public static void before(AbstractCobolField str) {
     CobolDataStorage p2 = null;
@@ -237,7 +237,7 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_afterの実装
    *
-   * @param str
+   * @param str TODO: 調査中
    */
   public static void after(AbstractCobolField str) {
     CobolDataStorage data = str.getDataStorage();
@@ -254,7 +254,7 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_charactersの実装
    *
-   * @param f1
+   * @param f1 TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void characters(AbstractCobolField f1) throws CobolStopRunException {
@@ -292,8 +292,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_allの実装
    *
-   * @param f1
-   * @param f2
+   * @param f1 TODO: 調査中
+   * @param f2 TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void all(AbstractCobolField f1, AbstractCobolField f2)
@@ -304,8 +304,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_leadingの実装
    *
-   * @param f1
-   * @param f2
+   * @param f1 TODO: 調査中
+   * @param f2 TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void leading(AbstractCobolField f1, AbstractCobolField f2)
@@ -316,8 +316,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_firstの実装
    *
-   * @param f1
-   * @param f2
+   * @param f1 TODO: 調査中
+   * @param f2 TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void first(AbstractCobolField f1, AbstractCobolField f2)
@@ -328,8 +328,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_trailingの実装
    *
-   * @param f1
-   * @param f2
+   * @param f1 TODO: 調査中
+   * @param f2 TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void trailing(AbstractCobolField f1, AbstractCobolField f2)
@@ -340,8 +340,8 @@ public class CobolInspect {
   /**
    * libcob/strings.cのcob_inspect_convertingの実装
    *
-   * @param f1
-   * @param f2
+   * @param f1 TODO: 調査中
+   * @param f2 TODO: 調査中
    */
   public static void converting(AbstractCobolField f1, AbstractCobolField f2) {
     int type1 = f1.getAttribute().getType();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -255,7 +255,7 @@ public class CobolInspect {
    * libcob/strings.cのcob_inspect_charactersの実装
    *
    * @param f1 TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void characters(AbstractCobolField f1) throws CobolStopRunException {
     int mark = inspectStart;
@@ -294,7 +294,7 @@ public class CobolInspect {
    *
    * @param f1 TODO: 調査中
    * @param f2 TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void all(AbstractCobolField f1, AbstractCobolField f2)
       throws CobolStopRunException {
@@ -306,7 +306,7 @@ public class CobolInspect {
    *
    * @param f1 TODO: 調査中
    * @param f2 TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void leading(AbstractCobolField f1, AbstractCobolField f2)
       throws CobolStopRunException {
@@ -318,7 +318,7 @@ public class CobolInspect {
    *
    * @param f1 TODO: 調査中
    * @param f2 TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void first(AbstractCobolField f1, AbstractCobolField f2)
       throws CobolStopRunException {
@@ -330,7 +330,7 @@ public class CobolInspect {
    *
    * @param f1 TODO: 調査中
    * @param f2 TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void trailing(AbstractCobolField f1, AbstractCobolField f2)
       throws CobolStopRunException {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -292,6 +292,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_upper_caseの実装
    *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
    * @param srcfield TODO: 調査中
    * @return TODO: 調査中
    */
@@ -313,6 +315,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_lower_caseの実装
    *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
    * @param srcfield TODO: 調査中
    * @return TODO: 調査中
    */
@@ -334,6 +338,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_reverseの実装
    *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
    * @param srcfield TODO: 調査中
    * @return TODO: 調査中
    */
@@ -720,21 +726,36 @@ public class CobolIntrinsic {
     return currField;
   }
 
-  /** libcob/intrinsicのcob_intr_expの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_expの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcExp(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.pow(2.7182818284590452354, intrGetDouble(d1));
     return mathFunctionAfter2(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_exp10の実装 */
+  /**
+   * libcob/intrinsicのcob_intr_exp10の実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcExp10(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.pow(10, intrGetDouble(d1));
     return mathFunctionAfter2(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_absの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_absの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcAbs(AbstractCobolField srcfield) {
     makeFieldEntry(srcfield);
     CobolDecimal d1 = srcfield.getDecimal();
@@ -747,63 +768,108 @@ public class CobolIntrinsic {
     return currField;
   }
 
-  /** libcob/intrinsicのcob_intr_acosの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_acosの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcAcos(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore1(srcfield);
     double mathd2 = Math.acos(intrGetDouble(d1));
     return mathFunctionAfter1(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_asinの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_asinの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcAsin(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore1(srcfield);
     double mathd2 = Math.asin(intrGetDouble(d1));
     return mathFunctionAfter1(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_atanの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_atanの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcAtan(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore1(srcfield);
     double mathd2 = Math.atan(intrGetDouble(d1));
     return mathFunctionAfter1(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_cosの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_cosの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcCos(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore1(srcfield);
     double mathd2 = Math.cos(intrGetDouble(d1));
     return mathFunctionAfter1(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_logの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_logの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLog(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.log(intrGetDouble(d1));
     return mathFunctionAfter2(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_log10の実装 */
+  /**
+   * libcob/intrinsicのcob_intr_log10の実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLog10(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.log10(intrGetDouble(d1));
     return mathFunctionAfter2(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_sinの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_sinの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcSin(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore1(srcfield);
     double mathd2 = Math.sin(intrGetDouble(d1));
     return mathFunctionAfter1(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_sqrtの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_sqrtの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcSqrt(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.sqrt(intrGetDouble(d1));
     return mathFunctionAfter2(mathd2);
   }
 
-  /** libcob/intrinsicのcob_intr_tanの実装 */
+  /**
+   * libcob/intrinsicのcob_intr_tanの実装
+   *
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcTan(AbstractCobolField srcfield) {
     CobolDecimal d1 = mathFunctionBefore2(srcfield);
     double mathd2 = Math.tan(intrGetDouble(d1));
@@ -898,6 +964,7 @@ public class CobolIntrinsic {
    * libcob/intrinsicのcob_intr_numval_cの実装
    *
    * @param srcfield TODO: 調査中
+   * @param currency TODO: 調査中
    * @return TODO: 調査中
    */
   public static AbstractCobolField funcNumvalC(
@@ -997,15 +1064,36 @@ public class CobolIntrinsic {
     return currField;
   }
 
+  /**
+   * このメソッドは未実装
+   *
+   * @param n このメソッドは未実装
+   * @param currency このメソッドは未実装
+   * @return null
+   */
   public static AbstractCobolField funcNumvalC(int n, AbstractCobolField currency) {
     // TODO
     return null;
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param srcfield TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcNumvalC(AbstractCobolField srcfield, int n) {
     return funcNumvalC(srcfield, null);
   }
 
+  /**
+   * このメソッドは未実装
+   *
+   * @param n このメソッドは未実装
+   * @param m このメソッドは未実装
+   * @return null
+   */
   public static AbstractCobolField funcNumvalC(int n, int m) {
     // TODO
     return null;
@@ -2297,7 +2385,15 @@ public class CobolIntrinsic {
     return currField;
   }
 
-  /** Equivalent to cob_intr_trim */
+  /**
+   * Equivalent to cob_intr_trim
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param direction TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcTrim(
       int offset, int length, AbstractCobolField srcField, int direction) {
     makeFieldEntry(srcField);
@@ -2337,11 +2433,29 @@ public class CobolIntrinsic {
     return currField;
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param localeField TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLocaleDate(
       int offset, int length, AbstractCobolField srcField, int localeField) {
     return funcLocaleDate(offset, length, srcField, null);
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param localeField TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLocaleDate(
       int offset, int length, AbstractCobolField srcField, AbstractCobolField localeField) {
     AbstractCobolField field =
@@ -2428,6 +2542,15 @@ public class CobolIntrinsic {
     return currField;
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param localeField TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLocaleTime(
       int offset, int length, AbstractCobolField srcField, int localeField) {
     return funcLocaleTime(offset, length, srcField, null);
@@ -2501,11 +2624,29 @@ public class CobolIntrinsic {
     return currField;
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param localeField TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLocaleTimeFromSeconds(
       int offset, int length, AbstractCobolField srcField, int localeField) {
     return funcLocaleTime(offset, length, srcField, null);
   }
 
+  /**
+   * TODO: 調査中
+   *
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param srcField TODO: 調査中
+   * @param localeField TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static AbstractCobolField funcLocaleTimeFromSeconds(
       int offset, int length, AbstractCobolField srcField, AbstractCobolField localeField) {
     AbstractCobolField field =

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -91,8 +91,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_ordの実装
    *
-   * @param year
-   * @return
+   * @param year TODO: 調査中
+   * @return TODO: 調査中
    */
   private static boolean isLeapYear(int year) {
     return ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0));
@@ -124,9 +124,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcalc_ref_modの実装
    *
-   * @param f
-   * @param offset
-   * @param length
+   * @param f TODO: 調査中
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
    */
   private static void calcRefMod(AbstractCobolField f, int offset, int length) {
     if (offset <= f.getSize()) {
@@ -147,10 +147,10 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_get_binopの実装
    *
-   * @param f1
-   * @param op
-   * @param f2
-   * @return
+   * @param f1 TODO: 調査中
+   * @param op TODO: 調査中
+   * @param f2 TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField intrBinop(AbstractCobolField f1, int op, AbstractCobolField f2)
@@ -204,8 +204,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_lengthの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcLength(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -219,8 +219,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_integerの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcInteger(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -271,8 +271,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_integer_partの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcIntegerPart(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -292,8 +292,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_upper_caseの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcUpperCase(
       int offset, int length, AbstractCobolField srcfield) {
@@ -313,8 +313,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_lower_caseの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcLowerCase(
       int offset, int length, AbstractCobolField srcfield) {
@@ -334,8 +334,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_reverseの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcReverse(
       int offset, int length, AbstractCobolField srcfield) {
@@ -355,10 +355,10 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_when_compiledの実装
    *
-   * @param offset
-   * @param length
-   * @param f
-   * @return
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param f TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcWhenCompiled(int offset, int length, AbstractCobolField f) {
     makeFieldEntry(f);
@@ -372,9 +372,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_current_dateの実装
    *
-   * @param offset
-   * @param length
-   * @return
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcCurrentDate(int offset, int length) {
     CobolFieldAttribute attr =
@@ -404,8 +404,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_charの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcChar(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -425,8 +425,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_ordの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcOrd(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -441,8 +441,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_date_of_integerの実装
    *
-   * @param srcdays
-   * @return
+   * @param srcdays TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcDateOfInteger(AbstractCobolField srcdays) {
     CobolFieldAttribute attr =
@@ -492,8 +492,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_day_of_integerの実装
    *
-   * @param srcdays
-   * @return
+   * @param srcdays TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcDayOfInteger(AbstractCobolField srcdays) {
     CobolFieldAttribute attr =
@@ -529,8 +529,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_integer_of_dateの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcIntegerOfDate(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -598,8 +598,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_integer_of_dayの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcIntegerOfDay(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -639,8 +639,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_factorialの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcFactorial(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -813,8 +813,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_numvalの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcNumval(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -897,8 +897,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_numval_cの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcNumvalC(
       AbstractCobolField srcfield, AbstractCobolField currency) {
@@ -1014,9 +1014,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_annuityの実装
    *
-   * @param srcfield1
-   * @param srcfield2
-   * @return
+   * @param srcfield1 TODO: 調査中
+   * @param srcfield2 TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcAnnuity(
       AbstractCobolField srcfield1, AbstractCobolField srcfield2) {
@@ -1050,9 +1050,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_sumの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcSum(int params, AbstractCobolField... fields) {
     CobolDecimal d1 = new CobolDecimal();
@@ -1107,9 +1107,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_ord_minの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcOrdMin(int params, AbstractCobolField... fields) {
     CobolFieldAttribute attr =
@@ -1139,9 +1139,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_ord_maxの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcOrdMax(int params, AbstractCobolField... fields) {
     CobolFieldAttribute attr =
@@ -1171,9 +1171,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_minの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcMin(int params, AbstractCobolField... fields) {
     AbstractCobolField beasef = fields[0];
@@ -1190,9 +1190,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_maxの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcMax(int params, AbstractCobolField... fields) {
     AbstractCobolField beasef = fields[0];
@@ -1209,9 +1209,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_midrangeの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcMidrange(int params, AbstractCobolField... fields) {
     makeDoubleEntry();
@@ -1245,9 +1245,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_medianの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcMedian(int params, AbstractCobolField... fields) {
     if (fields.length == 1) {
@@ -1285,9 +1285,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_medianの実装
    *
-   * @param pramas
-   * @param fields
-   * @return
+   * @param pramas TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcMean(int pramas, AbstractCobolField... fields) {
     CobolFieldAttribute attr =
@@ -1342,9 +1342,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_modの実装
    *
-   * @param srcfield1
-   * @param srcfield2
-   * @return
+   * @param srcfield1 TODO: 調査中
+   * @param srcfield2 TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcMod(
@@ -1378,9 +1378,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_rangeの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcRange(int params, AbstractCobolField... fields)
@@ -1423,9 +1423,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_remの実装
    *
-   * @param srcfield1
-   * @param srcfield2
-   * @return
+   * @param srcfield1 TODO: 調査中
+   * @param srcfield2 TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcRem(
@@ -1460,9 +1460,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_randomの実装
    *
-   * @param prams
-   * @param fields
-   * @return
+   * @param prams TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcRandom(int prams, AbstractCobolField... fields) {
     CobolFieldAttribute attr =
@@ -1505,9 +1505,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_varianceの実装
    *
-   * @param prams
-   * @param fields
-   * @return
+   * @param prams TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcVariance(int prams, AbstractCobolField... fields)
@@ -1578,9 +1578,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_standard_deviationの実装
    *
-   * @param prams
-   * @param fields
-   * @return
+   * @param prams TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcStandardDeviation(int prams, AbstractCobolField... fields)
@@ -1640,9 +1640,9 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_present_valueの実装
    *
-   * @param prams
-   * @param fields
-   * @return
+   * @param prams TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   public static AbstractCobolField funcPresentValue(int prams, AbstractCobolField... fields)
@@ -1680,8 +1680,8 @@ public class CobolIntrinsic {
   /**
    * libcob/intrinsicのcob_intr_nationalの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcNational(AbstractCobolField srcfield) {
     int size = srcfield.getSize();
@@ -1700,9 +1700,9 @@ public class CobolIntrinsic {
   /**
    * cob_intr_combined_datetimeの実装
    *
-   * @param srcdays
-   * @param srctime
-   * @return
+   * @param srcdays TODO: 調査中
+   * @param srctime TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcCombinedDatetime(
       AbstractCobolField srcdays, AbstractCobolField srctime) {
@@ -1741,11 +1741,11 @@ public class CobolIntrinsic {
   /**
    * cob_intr_concatenateの実装
    *
-   * @param offset
-   * @param length
-   * @param params
-   * @param fields
-   * @return
+   * @param offset TODO: 調査中
+   * @param length TODO: 調査中
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcConcatenate(
       int offset, int length, int params, AbstractCobolField... fields) {
@@ -1780,9 +1780,9 @@ public class CobolIntrinsic {
   /**
    * cob_intr_date_to_yyyymmddの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcDateToYyyymmdd(int params, AbstractCobolField... fields) {
     int year;
@@ -1840,9 +1840,9 @@ public class CobolIntrinsic {
   /**
    * cob_intr_day_to_yyyydddの実装
    *
-   * @param params
-   * @param fields
-   * @return
+   * @param params TODO: 調査中
+   * @param fields TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcDayToYyyyddd(int params, AbstractCobolField... fields) {
     int year;
@@ -2034,8 +2034,8 @@ public class CobolIntrinsic {
   /**
    * cob_intr_fraction_partの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcFractionPart(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -2055,9 +2055,9 @@ public class CobolIntrinsic {
   /**
    * cob_intr_seconds_from_formatted_timeの実装
    *
-   * @param format
-   * @param value
-   * @return
+   * @param format TODO: 調査中
+   * @param value TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcSecondsFromFormattedTime(
       AbstractCobolField format, AbstractCobolField value) {
@@ -2138,8 +2138,8 @@ public class CobolIntrinsic {
   /**
    * cob_intr_signの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcSign(AbstractCobolField srcfield) {
     CobolFieldAttribute attr =
@@ -2165,8 +2165,8 @@ public class CobolIntrinsic {
   /**
    * cob_intr_stored_char_lengthの実装
    *
-   * @param srcfield
-   * @return
+   * @param srcfield TODO: 調査中
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcStoredCharLength(AbstractCobolField srcfield) {
     int count;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -151,7 +151,7 @@ public class CobolIntrinsic {
    * @param op TODO: 調査中
    * @param f2 TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField intrBinop(AbstractCobolField f1, int op, AbstractCobolField f2)
       throws CobolStopRunException {
@@ -1345,7 +1345,7 @@ public class CobolIntrinsic {
    * @param srcfield1 TODO: 調査中
    * @param srcfield2 TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcMod(
       AbstractCobolField srcfield1, AbstractCobolField srcfield2) throws CobolStopRunException {
@@ -1381,7 +1381,7 @@ public class CobolIntrinsic {
    * @param params TODO: 調査中
    * @param fields TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcRange(int params, AbstractCobolField... fields)
       throws CobolStopRunException {
@@ -1426,7 +1426,7 @@ public class CobolIntrinsic {
    * @param srcfield1 TODO: 調査中
    * @param srcfield2 TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcRem(
       AbstractCobolField srcfield1, AbstractCobolField srcfield2) throws CobolStopRunException {
@@ -1508,7 +1508,7 @@ public class CobolIntrinsic {
    * @param prams TODO: 調査中
    * @param fields TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcVariance(int prams, AbstractCobolField... fields)
       throws CobolStopRunException {
@@ -1581,7 +1581,7 @@ public class CobolIntrinsic {
    * @param prams TODO: 調査中
    * @param fields TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcStandardDeviation(int prams, AbstractCobolField... fields)
       throws CobolStopRunException {
@@ -1643,7 +1643,7 @@ public class CobolIntrinsic {
    * @param prams TODO: 調査中
    * @param fields TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static AbstractCobolField funcPresentValue(int prams, AbstractCobolField... fields)
       throws CobolStopRunException {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -1901,7 +1901,7 @@ public class CobolIntrinsic {
   /**
    * cob_intr_exception_fileの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcExceptionFile() {
     int flen;
@@ -1930,7 +1930,7 @@ public class CobolIntrinsic {
   /**
    * cob_intr_exception_locationの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcExceptionLocation() {
     String buff;
@@ -1984,7 +1984,7 @@ public class CobolIntrinsic {
   /**
    * cob_intr_exception_statementの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcExceptionStatement() {
     CobolFieldAttribute attr =
@@ -2007,7 +2007,7 @@ public class CobolIntrinsic {
   /**
    * cob_intr_exception_statusの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcExceptionStatus() {
     byte[] exceptName;
@@ -2121,7 +2121,7 @@ public class CobolIntrinsic {
   /**
    * cob_intr_seconds_past_midnightの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static AbstractCobolField funcSecondsPastMidnight() {
     int seconds;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
@@ -95,19 +95,19 @@ public class CobolModule {
   /**
    * コンストラクタ
    *
-   * @param next
-   * @param collatingSequence
-   * @param cutStatus
-   * @param cursorPos
-   * @param displaySign
-   * @param decimalPoint
-   * @param currencySymbol
-   * @param numericSeparator
-   * @param flagFilenameMapping
-   * @param flagBinaryTruncate
-   * @param flagPrettyDisplay
-   * @param spare8
-   * @param programId
+   * @param next TODO: 調査中
+   * @param collatingSequence TODO: 調査中
+   * @param cutStatus TODO: 調査中
+   * @param cursorPos TODO: 調査中
+   * @param displaySign TODO: 調査中
+   * @param decimalPoint TODO: 調査中
+   * @param currencySymbol TODO: 調査中
+   * @param numericSeparator TODO: 調査中
+   * @param flagFilenameMapping TODO: 調査中
+   * @param flagBinaryTruncate TODO: 調査中
+   * @param flagPrettyDisplay TODO: 調査中
+   * @param spare8 TODO: 調査中
+   * @param programId TODO: 調査中
    */
   public CobolModule(
       CobolModule next,
@@ -143,14 +143,14 @@ public class CobolModule {
   /**
    * TODO 実装
    *
-   * @param m
+   * @param m TODO: 調査中
    */
   public void setNext(CobolModule m) {}
 
   /**
    * TODO 実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean hasNext() {
     return false;
@@ -159,14 +159,14 @@ public class CobolModule {
   /**
    * TODO 実装
    *
-   * @param string
+   * @param string TODO: 調査中
    */
   public void setProgramID(String string) {}
 
   /**
    * TODO 実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public CobolModule getNext() {
     return null;
@@ -175,7 +175,7 @@ public class CobolModule {
   /**
    * TODO 実装
    *
-   * @param programName
+   * @param programName TODO: 調査中
    */
   public void setProgramId(String programName) {
     if (this.program_id != null) {
@@ -225,8 +225,8 @@ public class CobolModule {
   /**
    * パラメータリストの指定の要素を取得する
    *
-   * @param index
-   * @return
+   * @param index TODO: 調査中
+   * @return TODO: 調査中
    */
   public AbstractCobolField getParameter(int index) {
     return cob_procedure_parameters.get(index);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
@@ -69,7 +69,7 @@ public class CobolModule {
   /**
    * モジュールキューが空かどうか
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static boolean isQueueEmpty() {
     return moduleStack.isEmpty();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -165,8 +165,14 @@ public class CobolUtil {
     }
   }
 
-  /** libcob/common.cのcob_initの実装 TODO 未完成 */
+  /**
+   * libcob/common.cのcob_initの実装
+   *
+   * @param argv TODO: 調査中
+   * @param cobInitialized TODO: 調査中
+   */
   public static void cob_init(String[] argv, boolean cobInitialized) {
+    // TODO 未完成
     if (!cobInitialized) {
       CobolUtil.commandLineArgs = argv;
       CobolInspect.initString();
@@ -624,6 +630,7 @@ public class CobolUtil {
   /**
    * libcob/common.cのis_national_paddingの実装
    *
+   * @param offset TODO: 調査中
    * @param s TODO: 調査中
    * @param size TODO: 調査中
    * @return TODO: 調査中
@@ -763,7 +770,7 @@ public class CobolUtil {
    * get environemnt variable
    *
    * @param envVarName the name of an environment variable.
-   * @param envVarName the value to be set to the environment variable.
+   * @param envVarValue the value to be set to the environment variable.
    */
   public static void setEnv(String envVarName, String envVarValue) {
     CobolUtil.envVarTable.setProperty(envVarName, envVarValue);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -84,9 +84,9 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_check_envの実装
    *
-   * @param name
-   * @param value
-   * @return
+   * @param name TODO: 調査中
+   * @param value TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int checkEnv(String name, String value) {
     if (name == null || value == null) {
@@ -272,7 +272,7 @@ public class CobolUtil {
    * libcob/fileio.cのcob_rintime_errorの実装 opensourceCOBOLではprintfのように可変長引数を取るが,
    * こちらは呼び出し側で事前にString.format等を使用することを期待している.
    *
-   * @param s
+   * @param s TODO: 調査中
    */
   public static void runtimeError(String s) {
     if (hdlrs != null) {
@@ -305,8 +305,8 @@ public class CobolUtil {
   /**
    * libcob/common.c cob_get_environment
    *
-   * @param envname
-   * @param envval
+   * @param envname TODO: 調査中
+   * @param envval TODO: 調査中
    */
   public static void getEnvironment(AbstractCobolField envname, AbstractCobolField envval) {
     String p = CobolUtil.getEnv(envname.fieldToString());
@@ -320,16 +320,16 @@ public class CobolUtil {
   /**
    * libcob/common.cのCOB_CHK_PARMSの実装
    *
-   * @param funcName
-   * @param numParams
+   * @param funcName TODO: 調査中
+   * @param numParams TODO: 調査中
    */
   public static void COB_CHK_PARMS(String funcName, int numParams) {}
 
   /**
    * libcob/common.cのcob_get_switchの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public static boolean getSwitch(int n) {
     return CobolUtil.cobSwitch[n];
@@ -338,8 +338,8 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_set_switchの実装
    *
-   * @param n
-   * @param flag
+   * @param n TODO: 調査中
+   * @param flag TODO: 調査中
    */
   public static void setSwitch(int n, int flag) {
     if (flag == 0) {
@@ -352,7 +352,7 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_get_sign_asciiの実装
    *
-   * @param p
+   * @param p TODO: 調査中
    */
   public static void getSignAscii(CobolDataStorage p) {
     switch (p.getByte(0)) {
@@ -394,8 +394,8 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_get_sign_ebcdicの実装
    *
-   * @param p
-   * @return
+   * @param p TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int getSignEbcdic(CobolDataStorage p) {
     switch (p.getByte(0)) {
@@ -469,7 +469,7 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_put_sign_asciiの実装
    *
-   * @param p
+   * @param p TODO: 調査中
    */
   public static void putSignAscii(CobolDataStorage p) {
     switch (p.getByte(0)) {
@@ -511,8 +511,8 @@ public class CobolUtil {
   /**
    * libcob/common.cのcob_put_sign_ebcdicの実装
    *
-   * @param p
-   * @param sign
+   * @param p TODO: 調査中
+   * @param sign TODO: 調査中
    */
   public static void putSignEbcdic(CobolDataStorage p, int sign) {
     if (sign < 0) {
@@ -594,9 +594,9 @@ public class CobolUtil {
   /**
    * libcob/common.cのcommon_compcの実装
    *
-   * @param s1
-   * @param c
-   * @param size
+   * @param s1 TODO: 調査中
+   * @param c TODO: 調査中
+   * @param size TODO: 調査中
    * @return
    */
   public static int commonCmpc(CobolDataStorage s1, byte c, int size) {
@@ -624,9 +624,9 @@ public class CobolUtil {
   /**
    * libcob/common.cのis_national_paddingの実装
    *
-   * @param s
-   * @param size
-   * @return
+   * @param s TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int isNationalPadding(int offset, CobolDataStorage s, int size) {
     int ret = 1;
@@ -651,11 +651,11 @@ public class CobolUtil {
   /**
    * libcob/common.cのalnum_cmpsの実装
    *
-   * @param s1
-   * @param s2
-   * @param size
-   * @param col
-   * @return
+   * @param s1 TODO: 調査中
+   * @param s2 TODO: 調査中
+   * @param size TODO: 調査中
+   * @param col TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int alnumCmps(
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
@@ -682,11 +682,11 @@ public class CobolUtil {
   /**
    * libcob/common.cのnational_cmpsの実装
    *
-   * @param s1
-   * @param s2
-   * @param size
-   * @param col
-   * @return
+   * @param s1 TODO: 調査中
+   * @param s2 TODO: 調査中
+   * @param size TODO: 調査中
+   * @param col TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int nationalCmps(
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -241,7 +241,7 @@ public class CobolUtil {
   /**
    * libcob/common.cとcob_localtime
    *
-   * @return
+   * @return TODO: 調査中
    */
   public static LocalDateTime localtime() {
     LocalDateTime rt = LocalDateTime.now();
@@ -597,7 +597,7 @@ public class CobolUtil {
    * @param s1 TODO: 調査中
    * @param c TODO: 調査中
    * @param size TODO: 調査中
-   * @return
+   * @return TODO: 調査中
    */
   public static int commonCmpc(CobolDataStorage s1, byte c, int size) {
     CobolDataStorage s = CobolModule.getCurrentModule().collating_sequence;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -68,12 +68,20 @@ public abstract class AbstractCobolField {
     return dataStorage;
   }
 
-  /** メンバ変数dataStorageのsetter */
+  /**
+   * メンバ変数dataStorageのsetter
+   *
+   * @param dataStorage TODO: 調査中
+   */
   public void setDataStorage(CobolDataStorage dataStorage) {
     this.dataStorage = dataStorage;
   }
 
-  /** メンバ変数attirbuteのsetter */
+  /**
+   * メンバ変数attributeのsetter
+   *
+   * @param attribute TODO: 調査中
+   */
   public void setAttribute(CobolFieldAttribute attribute) {
     this.attribute = attribute;
   }
@@ -153,7 +161,11 @@ public abstract class AbstractCobolField {
    */
   public abstract String getString();
 
-  /** @return */
+  /**
+   * TODO: 調査中
+   *
+   * @return TODO: 調査中
+   */
   public int getInt() {
     CobolFieldAttribute attr =
         new CobolFieldAttribute(
@@ -168,7 +180,11 @@ public abstract class AbstractCobolField {
     return ByteBuffer.wrap(n.getByteArray(0, 4)).getInt();
   }
 
-  /** @return */
+  /**
+   * TODO: 調査中
+   *
+   * @return TODO: 調査中
+   */
   public double getDouble() {
     try {
       return Double.parseDouble(this.getString());
@@ -244,6 +260,7 @@ public abstract class AbstractCobolField {
   /**
    * thisの保持する数値データをint型で返す
    *
+   * @param size TODO: 調査中
    * @return thisの保持する数値データをintに変換した値
    */
   public int getInt(int size) {
@@ -272,6 +289,7 @@ public abstract class AbstractCobolField {
    * @param field 加算する数値を保持するフィールド
    * @param opt 加算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 加算後のthisの保持する数値データ
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int add(AbstractCobolField field, int opt) throws CobolStopRunException {
     CobolDecimal d1 = this.getDecimal();
@@ -286,6 +304,7 @@ public abstract class AbstractCobolField {
    * @param field 減算する数値を保持するフィールド
    * @param opt 減算に関するオプション.詳しくはopensourceCOBOLを参照
    * @return 減算後のthisの保持する数値データ
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int sub(AbstractCobolField field, int opt) throws CobolStopRunException {
     CobolDecimal d1 = this.getDecimal();
@@ -299,6 +318,7 @@ public abstract class AbstractCobolField {
    *
    * @param n thisの保持する数値データから加算する数値
    * @return 基本的に0が返される.詳しくはopensource COBOLを参照
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int addInt(int n) throws CobolStopRunException {
     if (n == 0) {
@@ -329,12 +349,21 @@ public abstract class AbstractCobolField {
    *
    * @param n thisの保持する数値データから減算する数値
    * @return 基本的に0が返される.詳しくはopensource COBOLを参照
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int subInt(int n) throws CobolStopRunException {
     return n == 0 ? 0 : this.addInt(-n);
   }
 
-  /** libcob/numeric.cのcob_div_quotientの実装 */
+  /**
+   * libcob/numeric.cのcob_div_quotientの実装
+   *
+   * @param divisor TODO: 調査中
+   * @param quotient TODO: 調査中
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
+   */
   public int divQuotient(AbstractCobolField divisor, AbstractCobolField quotient, int opt)
       throws CobolStopRunException {
     AbstractCobolField dividend = this;
@@ -365,6 +394,7 @@ public abstract class AbstractCobolField {
    *
    * @param opt TODO: 調査中
    * @return TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int divRemainder(int opt) throws CobolStopRunException {
     return CobolDecimal.cobD3.getField(this, opt);
@@ -678,6 +708,7 @@ public abstract class AbstractCobolField {
    * opensourceCOBOLのcob_check_numericの実装
    *
    * @param s TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public void checkNumeric(byte[] s) throws CobolStopRunException {
     if (!this.isNumeric()) {
@@ -913,6 +944,7 @@ public abstract class AbstractCobolField {
    * libcob/common.cのcob_check_mvstrnumの実装
    *
    * @param field TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public void checkMoveStrNum(AbstractCobolField field) throws CobolStopRunException {
     switch (this.getAttribute().getType()) {
@@ -985,7 +1017,11 @@ public abstract class AbstractCobolField {
     return new String(data.getByteArray(0, i + 1));
   }
 
-  /** libcob/move.cのcob_set_intの実装 */
+  /**
+   * libcob/move.cのcob_set_intの実装
+   *
+   * @param n TODO: 調査中
+   */
   public void setInt(int n) {
     CobolFieldAttribute attr =
         new CobolFieldAttribute(
@@ -999,7 +1035,11 @@ public abstract class AbstractCobolField {
     this.moveFrom(temp);
   }
 
-  /** libcob/move.cのcob_set_intの実装 */
+  /**
+   * libcob/move.cのcob_set_intの実装
+   *
+   * @param data TODO: 調査中
+   */
   public void setInt(CobolDataStorage data) {
     this.setInt((int) data.intValue());
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -90,7 +90,7 @@ public abstract class AbstractCobolField {
   /**
    * メンバ変数sizeのsetter
    *
-   * @param size
+   * @param size TODO: 調査中
    */
   public void setSize(int size) {
     this.size = size;
@@ -237,7 +237,7 @@ public abstract class AbstractCobolField {
   /**
    * TODO 確認 未使用?
    *
-   * @param decimal
+   * @param decimal TODO: 調査中
    */
   public abstract void setDecimal(BigDecimal decimal);
 
@@ -319,8 +319,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_add_packed
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public abstract int addPackedInt(int n);
 
@@ -363,8 +363,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_div_remainderの実装
    *
-   * @param opt
-   * @return
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    */
   public int divRemainder(int opt) throws CobolStopRunException {
     return CobolDecimal.cobD3.getField(this, opt);
@@ -373,8 +373,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_cmp_intの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpInt(int n) {
     CobolDecimal d1 = this.getDecimal();
@@ -386,8 +386,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_cmp_intの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpInt(long n) {
     return this.cmpInt((int) n);
@@ -396,8 +396,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_cmp_uintの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpUint(int n) {
     return this.cmpInt(n);
@@ -406,8 +406,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_cmp_uintの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpUint(long n) {
     return this.cmpUint((int) n);
@@ -416,8 +416,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/numeric.cのcob_numeric_cmpの実装
    *
-   * @param field
-   * @return
+   * @param field TODO: 調査中
+   * @return TODO: 調査中
    */
   public int numericCompareTo(AbstractCobolField field) {
     CobolDecimal d1 = this.getDecimal();
@@ -677,7 +677,7 @@ public abstract class AbstractCobolField {
   /**
    * opensourceCOBOLのcob_check_numericの実装
    *
-   * @param s
+   * @param s TODO: 調査中
    */
   public void checkNumeric(byte[] s) throws CobolStopRunException {
     if (!this.isNumeric()) {
@@ -812,11 +812,11 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcommon_cmpcの実装
    *
-   * @param s1
+   * @param s1 TODO: 調査中
    * @param s1StartIndex s1のバイトデータにアクセスるするときの最小の添え字の相対位置
-   * @param c
-   * @param size
-   * @return
+   * @param c TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   protected int commonCmpc(CobolDataStorage s1, int s1StartIndex, int c, int size) {
     // TODO moduleを参照するコードを書く
@@ -865,13 +865,13 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのalnum_cmpsの実装
    *
-   * @param s1
+   * @param s1 TODO: 調査中
    * @param s1Start s1のバイトデータにアクセスるするときの最初の添え字の相対位置
-   * @param s2
+   * @param s2 TODO: 調査中
    * @param s2Start s2のバイトデータにアクセスるするときの最初の添え字の相対位置
-   * @param size
-   * @param col
-   * @return
+   * @param size TODO: 調査中
+   * @param col TODO: 調査中
+   * @return TODO: 調査中
    */
   protected int alnumCmps(
       CobolDataStorage s1,
@@ -912,7 +912,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_check_mvstrnumの実装
    *
-   * @param field
+   * @param field TODO: 調査中
    */
   public void checkMoveStrNum(AbstractCobolField field) throws CobolStopRunException {
     switch (this.getAttribute().getType()) {
@@ -949,11 +949,11 @@ public abstract class AbstractCobolField {
   /**
    * libcob/move.c own_byte_memcpyの実装
    *
-   * @param s1
+   * @param s1 TODO: 調査中
    * @param s1StartIndex s1のバイトデータにアクセスるするときの最初の添え字の相対位置
-   * @param s2
+   * @param s2 TODO: 調査中
    * @param s2StartIndex s2のバイトデータにアクセスるするときの最初の添え字の相対位置
-   * @param size
+   * @param size TODO: 調査中
    */
   protected void ownByteMemcpy(
       CobolDataStorage s1, int s1StartIndex, CobolDataStorage s2, int s2StartIndex, int size) {
@@ -1020,8 +1020,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_memcpyの実装
    *
-   * @param src
-   * @param size
+   * @param src TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(byte[] src, int size) {
     CobolFieldAttribute attr =
@@ -1034,7 +1034,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_memcpyの実装
    *
-   * @param src
+   * @param src TODO: 調査中
    */
   public void memcpy(byte[] src) {
     this.memcpy(src, src.length);
@@ -1043,8 +1043,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_memcpyの実装
    *
-   * @param src
-   * @param size
+   * @param src TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(String src, int size) {
     byte[] bytes = src.getBytes();
@@ -1054,7 +1054,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_memcpyの実装
    *
-   * @param src
+   * @param src TODO: 調査中
    */
   public void memcpy(String src) {
     this.memcpy(src.getBytes());
@@ -1182,8 +1182,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_cmp_charの実装
    *
-   * @param c
-   * @return
+   * @param c TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpChar(byte c) {
     int sign = this.getSign();
@@ -1219,8 +1219,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_cmp_allの実装
    *
-   * @param other
-   * @return
+   * @param other TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpAll(AbstractCobolField other) {
     int ret = 0;
@@ -1278,8 +1278,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_cmp_simple_strの実装
    *
-   * @param other
-   * @return
+   * @param other TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpSimpleStr(AbstractCobolField other) {
     AbstractCobolField lf, sf;
@@ -1318,8 +1318,8 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_alnum_cmpsの実装
    *
-   * @param other
-   * @return
+   * @param other TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpAlnum(AbstractCobolField other) {
     int sign1 = this.getSign();
@@ -1395,7 +1395,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_real_put_signの実装
    *
-   * @param sign
+   * @param sign TODO: 調査中
    */
   public void realPutSign(int sign) {
     CobolDataStorage p;
@@ -1462,7 +1462,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/move.cのcob_hankaku_moveの実装
    *
-   * @param src
+   * @param src TODO: 調査中
    */
   public void hankakuMoveFrom(AbstractCobolField src) {
     // TODO 暫定実装

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -834,7 +834,7 @@ public abstract class AbstractCobolField {
    * libcob/common.cのcob_cmp_allの実装
    *
    * @param field thisと比較するフィールド
-   * @return
+   * @return TODO: 調査中
    */
   protected int compareAll(AbstractCobolField field) {
     int size = this.getSize();
@@ -1063,7 +1063,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_is_omittedの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean isOmitted() {
     return this.dataStorage == null;
@@ -1072,7 +1072,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_is_numericの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean isNumeric() {
     int i;
@@ -1137,7 +1137,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_is_alphaの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean isAlpha() {
     for (int i = 0; i < this.size; ++i) {
@@ -1152,7 +1152,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_is_upperの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean isUpper() {
     for (int i = 0; i < this.size; ++i) {
@@ -1167,7 +1167,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_is_lowerの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public boolean isLower() {
     for (int i = 0; i < this.size; ++i) {
@@ -1346,7 +1346,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/common.cのcob_real_get_signの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public int realGetSign() {
     CobolDataStorage p;
@@ -1438,7 +1438,7 @@ public abstract class AbstractCobolField {
   /**
    * libcob/move.cのcob_get_long_longの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   public long getLong() {
     CobolFieldAttribute attr =

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -134,7 +134,7 @@ public class CobolDataStorage {
   /**
    * 保持するバイト配列のコピーを返す
    *
-   * @return
+   * @return TODO: 調査中
    */
   public byte[] getData() {
     return this.getData(0);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -117,7 +117,7 @@ public class CobolDataStorage {
   /**
    * コンストラクタ.文字列からバイト配列を構成する.
    *
-   * @param str
+   * @param str TODO: 調査中
    */
   public CobolDataStorage(String str) {
     try {
@@ -180,8 +180,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemcpy
    *
-   * @param buf
-   * @param size
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(CobolDataStorage buf, int size) {
     for (int i = 0; i < size; ++i) {
@@ -192,8 +192,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemcpy
    *
-   * @param buf
-   * @param size
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(byte[] buf, int size) {
     for (int i = 0; i < size; ++i) {
@@ -204,8 +204,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemcpy
    *
-   * @param str
-   * @param size
+   * @param str TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(String str, int size) {
     try {
@@ -218,9 +218,9 @@ public class CobolDataStorage {
   /**
    * C言語のmemcpy (offset指定あり)
    *
-   * @param offset
-   * @param buf
-   * @param size
+   * @param offset TODO: 調査中
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memcpy(int offset, byte[] buf, int size) {
     for (int i = 0; i < size; ++i) {
@@ -245,8 +245,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
-   * @param ch
-   * @param size
+   * @param ch TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memset(byte ch, int size) {
     for (int i = 0; i < size; ++i) {
@@ -257,8 +257,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
-   * @param ch
-   * @param size
+   * @param ch TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memset(int ch, int size) {
     this.memset((byte) ch, size);
@@ -267,8 +267,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
-   * @param ch
-   * @param size
+   * @param ch TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memset(int offset, byte ch, int size) {
     for (int i = 0; i < size; ++i) {
@@ -279,8 +279,8 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
-   * @param ch
-   * @param size
+   * @param ch TODO: 調査中
+   * @param size TODO: 調査中
    */
   public void memset(int offset, int ch, int size) {
     this.memset(offset, (byte) ch, size);
@@ -289,9 +289,9 @@ public class CobolDataStorage {
   /**
    * C言語のmemcmp
    *
-   * @param buf
-   * @param size
-   * @return
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   public int memcmp(byte[] buf, int size) {
     for (int i = 0; i < size; ++i) {
@@ -307,9 +307,9 @@ public class CobolDataStorage {
   /**
    * C言語のmemcmp
    *
-   * @param buf
-   * @param size
-   * @return
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   public int memcmp(String buf, int size) {
     return this.memcmp(buf.getBytes(), size);
@@ -318,9 +318,9 @@ public class CobolDataStorage {
   /**
    * C言語のmemcmp
    *
-   * @param buf
-   * @param size
-   * @return
+   * @param buf TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   public int memcmp(CobolDataStorage buf, int size) {
     for (int i = 0; i < size; ++i) {
@@ -347,7 +347,7 @@ public class CobolDataStorage {
   /**
    * 引数で与えられたバイト配列をthis.dataの先頭からコピーする
    *
-   * @param data
+   * @param data TODO: 調査中
    */
   public void setData(byte[] data) {
     setData(data, 0);
@@ -583,7 +583,7 @@ public class CobolDataStorage {
   /**
    * TODO 暫定的な実装
    *
-   * @param str
+   * @param str TODO: 調査中
    */
   public void setString(String str) {
     this.fillBytes((byte) 0x20, this.data.length);
@@ -597,7 +597,7 @@ public class CobolDataStorage {
   /**
    * TODO 暫定的な実装(対応未定)
    *
-   * @param pointer
+   * @param pointer TODO: 調査中
    */
   public void setPointer(int pointer) {
     System.err.println("setPointer is not implemented");
@@ -661,8 +661,8 @@ public class CobolDataStorage {
   /**
    * this.dataにindexバイト目から4バイトでvalueを書き込む
    *
-   * @param value
-   * @param index
+   * @param value TODO: 調査中
+   * @param index TODO: 調査中
    */
   public void set(int value, int index) {
     ByteBuffer buffer = ByteBuffer.wrap(this.data, this.index + index, 4);
@@ -1430,9 +1430,9 @@ public class CobolDataStorage {
   /**
    * libcob/numeric.cのcob_cmp_numdispの実装
    *
-   * @param size
-   * @param n
-   * @return
+   * @param size TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpNumdisp(int size, long n) {
     int p = 0;
@@ -1446,18 +1446,18 @@ public class CobolDataStorage {
   /**
    * libcob/numeric.cのcob_cmp_long_numdispの実装
    *
-   * @param size
-   * @param n
-   * @return
+   * @param size TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpLongNumdisp(int size, long n) {
     return this.cmpNumdisp(size, n);
   }
 
   /**
-   * @param size
-   * @param n
-   * @return
+   * @param size TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public int cmpSignNumdisp(int size, long n) {
     int p = 0;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -267,6 +267,7 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
+   * @param offset TODO: 調査中
    * @param ch TODO: 調査中
    * @param size TODO: 調査中
    */
@@ -279,6 +280,7 @@ public class CobolDataStorage {
   /**
    * C言語のmemset
    *
+   * @param offset TODO: 調査中
    * @param ch TODO: 調査中
    * @param size TODO: 調査中
    */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -87,7 +87,7 @@ public class CobolDecimal {
   /**
    * コンストラクタ this.valueを引数で指定された値に設定する.
    *
-   * @param value
+   * @param value TODO: 調査中
    */
   public CobolDecimal(BigDecimal value) {
     this.setValue(value);
@@ -97,8 +97,8 @@ public class CobolDecimal {
   /**
    * コンストラクタ this.valueを指定された値に設定し,scaleも指定された値に設定する.
    *
-   * @param value
-   * @param scale
+   * @param value TODO: 調査中
+   * @param scale TODO: 調査中
    */
   public CobolDecimal(BigDecimal value, int scale) {
     this(value);
@@ -108,7 +108,7 @@ public class CobolDecimal {
   /**
    * コンストラクタ. this.valueを指定されたint型の値に対応する値に設定する
    *
-   * @param n
+   * @param n TODO: 調査中
    */
   public CobolDecimal(long n) {
     if (n == 0L) {
@@ -126,7 +126,7 @@ public class CobolDecimal {
   /**
    * コンストラクタ. this.valueを指定されたint型の値に対応する値に設定する
    *
-   * @param n
+   * @param n TODO: 調査中
    */
   public CobolDecimal(int n) {
     if (n == 0) {
@@ -144,7 +144,7 @@ public class CobolDecimal {
   /**
    * コピーコンストラクタ
    *
-   * @param other
+   * @param other TODO: 調査中
    */
   public CobolDecimal(CobolDecimal other) {
     this.setValue(other.getValue());
@@ -227,7 +227,7 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのcob_decimal_set_fieldの実装
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public void setField(AbstractCobolField f) {
     CobolDecimal decimal = f.getDecimal();
@@ -236,62 +236,10 @@ public class CobolDecimal {
   }
 
   /**
-   * libcob/numeric.cのcob_decimal_set_displayの実装
-   *
-   * @param f
-   */
-  /*
-   * public void decimalSetDisplay(AbstractCobolField f) {
-   * int firstIndex = f.getFirstDataIndex();
-   * int p = 0;
-   * int size = f.getFieldSize();
-   *
-   * CobolDataStorage data = f.getDataStorage();
-   * if(data.getByte(firstIndex + p) == 255) {
-   * this.value = BigDecimal.TEN.pow(size);
-   * this.setScale(f.getAttribute().getScale());
-   * return;
-   * }
-   * if(data.getByte(firstIndex + p) == 0) {
-   * this.value = BigDecimal.TEN.pow(size).negate();
-   * this.setScale(f.getAttribute().getScale());
-   * return;
-   * }
-   * int sign = f.getSign();
-   * // skip leading zeros
-   * while(size > 1 && data.getByte(p) == '0') {
-   * size--;
-   * p++;
-   * }
-   *
-   * // set value
-   * if(size < 10) {
-   * int n = 10;
-   * while(size-- != 0) {
-   * n = n * 10 + data.getByte(firstIndex + p++) - '0';
-   * }
-   * this.set(n);
-   * } else {
-   * byte[] numBuffPtr = new byte[size];
-   * for(int i=0; i<size; ++i) {
-   * numBuffPtr[i] = data.getByte(firstIndex + i);
-   * }
-   * this.value = new BigDecimal(new String(numBuffPtr));
-   * }
-   *
-   * if(sign < 0) {
-   * this.value = this.value.negate();
-   * }
-   * this.setScale(f.getAttribute().getScale());
-   * f.putSign(sign);
-   * }
-   */
-
-  /**
    * libcob/numeric.cのDECIMAL_CHECKマクロの代替
    *
-   * @param d1
-   * @param d2
+   * @param d1 TODO: 調査中
+   * @param d2 TODO: 調査中
    */
   private static boolean DECIMAL_CHECK(CobolDecimal d1, CobolDecimal d2) {
     if (d1.getScale() == DECIMAL_NAN || d2.getScale() == DECIMAL_NAN) {
@@ -427,7 +375,7 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのcob_decimal_set_doubleの実装
    *
-   * @param v
+   * @param v TODO: 調査中
    */
   private void decimalSetDouble(double v) {
     this.setValue(new BigDecimal(v * 1.0e9));
@@ -455,9 +403,9 @@ public class CobolDecimal {
   /**
    * libcob/numeric.c cob_decimal_get_fieldの実装 AbstractCobolFieldの保持する値をthisに設定する
    *
-   * @param f
-   * @param opt
-   * @return
+   * @param f TODO: 調査中
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    */
   public int getField(AbstractCobolField f, int opt) throws CobolStopRunException {
     if (this.getScale() == CobolDecimal.DECIMAL_NAN) {
@@ -535,7 +483,7 @@ public class CobolDecimal {
   /**
    * libcob/numeric.c shift_decimalの実装 this.valueを値10^n,スケールをn増加させる
    *
-   * @param n
+   * @param n TODO: 調査中
    */
   public void shiftDecimal(int n) {
     if (n == 0) {
@@ -576,9 +524,9 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのcob_decimal_get_displayの実装
    *
-   * @param f
-   * @param opt
-   * @return
+   * @param f TODO: 調査中
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    */
   public int getDisplayField(AbstractCobolField f, int opt) throws CobolStopRunException {
     int sign = this.value.signum();
@@ -622,9 +570,9 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのcob_decimal_get_packedの実装
    *
-   * @param f
-   * @param opt
-   * @return
+   * @param f TODO: 調査中
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    */
   public int getPackedField(AbstractCobolField f, int opt) {
     int sign = this.value.signum();
@@ -686,9 +634,9 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのcob_decimal_get_binaryの実装
    *
-   * @param f
-   * @param opt
-   * @return
+   * @param f TODO: 調査中
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    */
   private int getBinaryField(AbstractCobolField f, int opt) {
     CobolDataStorage data = f.getDataStorage();
@@ -746,11 +694,11 @@ public class CobolDecimal {
   /**
    * libcob/numeric.cのnum_byte_memcpyの実装
    *
-   * @param s1
+   * @param s1 TODO: 調査中
    * @param s1StartIndex s1のコピー開始位置
-   * @param s2
+   * @param s2 TODO: 調査中
    * @param s2StartIndex s1のコピー開始位置
-   * @param size
+   * @param size TODO: 調査中
    */
   public static void numByteMemcpy(
       CobolDataStorage s1, int s1StartIndex, CobolDataStorage s2, int s2StartIndex, int size) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDecimal.java
@@ -217,7 +217,11 @@ public class CobolDecimal {
     this.scale = 0;
   }
 
-  /** libcob/numeric.cのcob_decimal_setの実装 */
+  /**
+   * libcob/numeric.cのcob_decimal_setの実装
+   *
+   * @param decimal TODO: 調査中
+   */
   public void set(CobolDecimal decimal) {
     // TODO よりよいコピーの方法を考える
     this.value = decimal.value.add(BigDecimal.ZERO);
@@ -319,6 +323,7 @@ public class CobolDecimal {
    * this.valueの値をthis.valueでotherを割った値にする
    *
    * @param decimal this.valueを割る数
+   * @throws CobolStopRunException TODO: 調査中
    */
   public void div(CobolDecimal decimal) throws CobolStopRunException {
     if (DECIMAL_CHECK(this, decimal)) {
@@ -406,6 +411,7 @@ public class CobolDecimal {
    * @param f TODO: 調査中
    * @param opt TODO: 調査中
    * @return TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int getField(AbstractCobolField f, int opt) throws CobolStopRunException {
     if (this.getScale() == CobolDecimal.DECIMAL_NAN) {
@@ -499,7 +505,12 @@ public class CobolDecimal {
     this.setScale(this.getScale() + n);
   }
 
-  /** libcob/numeric.cのalign_decimalの実装 */
+  /**
+   * libcob/numeric.cのalign_decimalの実装
+   *
+   * @param d1 TODO: 調査中
+   * @param d2 TODO: 調査中
+   */
   public void alignDecimal(CobolDecimal d1, CobolDecimal d2) {
     if (d1.getScale() < d2.getScale()) {
       d1.shiftDecimal(d2.getScale() - d1.getScale());
@@ -527,6 +538,7 @@ public class CobolDecimal {
    * @param f TODO: 調査中
    * @param opt TODO: 調査中
    * @return TODO: 調査中
+   * @throws CobolStopRunException TODO: 調査中
    */
   public int getDisplayField(AbstractCobolField f, int opt) throws CobolStopRunException {
     int sign = this.value.signum();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNationalField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNationalField.java
@@ -172,8 +172,8 @@ public class CobolNationalField extends AbstractCobolField {
   /**
    * libcob/move.cのjudge_hankakujpn_existの実装
    *
-   * @param src
-   * @return
+   * @param src TODO: 調査中
+   * @return TODO: 調査中
    */
   public static byte[] judge_hankakujpn_exist(AbstractCobolField src) {
     byte[] tmpZenJpnWord = null;
@@ -191,9 +191,9 @@ public class CobolNationalField extends AbstractCobolField {
   /**
    * libcob/move.c han2zenの実装
    *
-   * @param str
-   * @param size
-   * @return
+   * @param str TODO: 調査中
+   * @param size TODO: 調査中
+   * @return TODO: 調査中
    */
   public static byte[] han2zen(byte[] str, int size) {
     byte[] buf;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
@@ -216,7 +216,7 @@ public class CobolNumericBinaryField extends AbstractCobolField {
   /**
    * libcob/move.cのcob_binary_mset_int64の実装
    *
-   * @param n
+   * @param n TODO: 調査中
    */
   public void binaryMsetInt64(long n) {
     byte bytes[] = new byte[8];
@@ -310,7 +310,7 @@ public class CobolNumericBinaryField extends AbstractCobolField {
   /**
    * libcob/numeric.cのcob_binary_get_int64の実装
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   private long binaryGetInt64() {
     int fsiz = 8 - this.getSize();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -549,10 +549,10 @@ public class CobolNumericField extends AbstractCobolField {
   /**
    * libcob/move.cのstore_common_regionの実装
    *
-   * @param field
-   * @param data
-   * @param size
-   * @param scale
+   * @param field TODO: 調査中
+   * @param data TODO: 調査中
+   * @param size TODO: 調査中
+   * @param scale TODO: 調査中
    */
   public void storeCommonRegion(
       AbstractCobolField field, CobolDataStorage data, int size, int scale) {
@@ -562,10 +562,10 @@ public class CobolNumericField extends AbstractCobolField {
   /**
    * libcob/move.cのstore_common_regionの実装
    *
-   * @param field
-   * @param data
-   * @param size
-   * @param scale
+   * @param field TODO: 調査中
+   * @param data TODO: 調査中
+   * @param size TODO: 調査中
+   * @param scale TODO: 調査中
    */
   public void storeCommonRegion(
       AbstractCobolField field, CobolDataStorage data, int dataStartIndex, int size, int scale) {
@@ -729,11 +729,11 @@ public class CobolNumericField extends AbstractCobolField {
   /**
    * libcob/numeric.cのdisplay_add_intの実装
    *
-   * @param data
+   * @param data TODO: 調査中
    * @param firstDataIndex dataにアクセスするときの開始位置
-   * @param size
-   * @param n
-   * @return
+   * @param size TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private int displayAddInt(CobolDataStorage data, int firstDataIndex, int size, long n) {
     int carry = 0;
@@ -785,11 +785,11 @@ public class CobolNumericField extends AbstractCobolField {
   /**
    * libcob/numeric.cのdisplay_sub_intの実装
    *
-   * @param data
+   * @param data TODO: 調査中
    * @param firstDataIndex dataにアクセスするときの開始位置
-   * @param size
-   * @param n
-   * @return
+   * @param size TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int displaySubInt(CobolDataStorage data, int firstDataIndex, int size, long n) {
     int carry = 0;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -42,7 +42,11 @@ public class CobolNumericField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** TODO実装 */
+  /**
+   * TODO: 調査中
+   *
+   * @param s TODO: 調査中
+   */
   public void checkNumeric(String s) {}
 
   /** this.dataの保持するバイト配列のコピーを返す */
@@ -564,6 +568,7 @@ public class CobolNumericField extends AbstractCobolField {
    *
    * @param field TODO: 調査中
    * @param data TODO: 調査中
+   * @param dataStartIndex TODO: 調査中
    * @param size TODO: 調査中
    * @param scale TODO: 調査中
    */
@@ -660,6 +665,8 @@ public class CobolNumericField extends AbstractCobolField {
    * thisの保持する数値データに加算する
    *
    * @param in thisの保持する数値データに加算する値
+   * @param opt TODO: 調査中
+   * @return 0
    */
   public int addInt(int in, int opt) {
     if (in == 0) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -588,7 +588,7 @@ public class CobolNumericPackedField extends AbstractCobolField {
   /**
    * byte型データを右に4回シフトした値を返す CとJavaのビット演算の仕様に差異があるため実装した
    *
-   * @param b
+   * @param b TODO: 調査中
    * @return b>>4
    */
   private byte upper4bits(byte b) {
@@ -830,8 +830,8 @@ public class CobolNumericPackedField extends AbstractCobolField {
   /**
    * libcob/codegen.hのcob_cmp_packed_intの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private int cmpPackedInt(int n) {
     CobolDataStorage data = this.getDataStorage();
@@ -856,8 +856,8 @@ public class CobolNumericPackedField extends AbstractCobolField {
   /**
    * libcob/numeric.cのcob_cmp_packedの実装
    *
-   * @param n
-   * @return
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private int cmpPacked(int n) {
     int sign = this.getSign();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -139,7 +139,11 @@ public class CobolNumericPackedField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** TODO */
+  /**
+   * TODO: 調査中
+   *
+   * @param s TODO: 調査中
+   */
   public void checkNumeric(String s) {}
 
   /** this.dataの保持するバイト配列のコピーを返す */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -639,7 +639,7 @@ public class CobolNumericPackedField extends AbstractCobolField {
    * libcob/codegen.hのcob_add_packed_intの実装 thisの保持する数値データに加算する
    *
    * @param val thisの保持する数値データに加算する値
-   * @return
+   * @return TODO: 調査中
    */
   public int addPackedInt(int val) {
     if (val == 0) {
@@ -684,7 +684,7 @@ public class CobolNumericPackedField extends AbstractCobolField {
    * libcob/numeric.cのcob_add_intおよびcob_add_packedの実装
    *
    * @param ival thisに 加算する値
-   * @return
+   * @return TODO: 調査中
    */
   @Override
   public int addInt(int ival) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -23,7 +23,11 @@ public class CobolExceptionInfo {
   /* エラーコード。TODO: 調査中 */
   public static int code = 0;
 
-  /** エラーコードを設定する。TODO: 調査中 */
+  /**
+   * エラーコードを設定する。TODO: 調査中
+   *
+   * @param id TODO: 調査中
+   */
   public static void setException(int id) {
     CobolExceptionInfo.code = CobolExceptionTabCode.code[id];
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolGoBackException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolGoBackException.java
@@ -57,7 +57,7 @@ public final class CobolGoBackException extends Exception {
    * CobolGoBackExceptionを例外として投げる。
    *
    * @param returnCode GOBACKの返り値
-   * @throws CobolGoBackException
+   * @throws CobolGoBackException TODO: 調査中
    */
   public static void throwException(int returnCode) throws CobolGoBackException {
     throw new CobolGoBackException(returnCode);
@@ -67,7 +67,7 @@ public final class CobolGoBackException extends Exception {
    * CobolGoBackExceptionを例外として投げる。
    *
    * @param storage GOBACKの返り値
-   * @throws CobolGoBackException
+   * @throws CobolGoBackException TODO: 調査中
    */
   public static void throwException(CobolDataStorage storage) throws CobolGoBackException {
     throw new CobolGoBackException(storage);
@@ -77,7 +77,7 @@ public final class CobolGoBackException extends Exception {
    * javaコンパイラは、try節の中にthrowが発生しないと判断するとコンパイルエラーになる。 Javaコード生成時にこの問題を回避するため、このメソッドが挿入される。 throws
    * CobolGoBackExceptionが指定されているが、このメソッドは決して例外をスローせず、その他の処理も実行しない。
    *
-   * @throws CobolGoBackException
+   * @throws CobolGoBackException TODO: 調査中
    */
   public static void dummy() throws CobolGoBackException {
     if (false) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
@@ -91,6 +91,7 @@ public final class CobolStopRunException extends Exception {
    * デフォルトの終了処理では、COBOLプログラムによってオープンされたファイルのクローズが行われる。
    *
    * @param status STOP RUNの返り値
+   * @throws CobolStopRunException このメソッドでは必ずCobolStopRunExceptionがスローされる。
    */
   public static void stopRunAndThrow(int status) throws CobolStopRunException {
     stopRun();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
@@ -58,7 +58,7 @@ public final class CobolStopRunException extends Exception {
    * CobolStopRunExceptionを例外としてスローする。 COBOLプログラム終了時のデフォルトの終了処理は実行されない。
    *
    * @param returnCode STOP RUNの返り値
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void throwException(int returnCode) throws CobolStopRunException {
     throw new CobolStopRunException(returnCode);
@@ -68,7 +68,7 @@ public final class CobolStopRunException extends Exception {
    * CobolStopRunExceptionを例外としてスローする。 COBOLプログラム終了時のデフォルトの終了処理は実行されない。
    *
    * @param storage STOP RUNの返り値
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void throwException(CobolDataStorage storage) throws CobolStopRunException {
     throw new CobolStopRunException(storage);
@@ -78,7 +78,7 @@ public final class CobolStopRunException extends Exception {
    * javaコンパイラは、try節の中にthrowが発生しないと判断するとコンパイルエラーになる。 Javaコード生成時にこの問題を回避するため、このメソッドが挿入される。 throws
    * CobolRunExceptionが指定されているが、このメソッドは決して例外をスローせず、その他の処理も実行しない。
    *
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void dummy() throws CobolStopRunException {
     if (false) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -393,7 +393,7 @@ public class CobolFile {
    *
    * @param opt TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   protected int linage_write_opt(int opt) throws CobolStopRunException {
     int i, n;
@@ -1140,7 +1140,7 @@ public class CobolFile {
    *
    * @param opt TODO: 調査中
    * @return TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   protected int file_write_opt(int opt) throws CobolStopRunException {
     if ((this.flag_select_features & COB_SELECT_LINAGE) != 0) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -346,7 +346,7 @@ public class CobolFile {
   /**
    * libcob/fileio.cのcob_file_linage_checkの実装 TODO 実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   protected boolean file_linage_check() {
     Linage lingptr = getLinorkeyptr();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -291,8 +291,8 @@ public class CobolFile {
   /**
    * libcob/fileio.cのsave_statusの実装 RETURN_STATUSマクロは実装できないため,本メソッドの呼び出し後の次の文はreturn;を書くこと.
    *
-   * @param status
-   * @param fnstatus
+   * @param status TODO: 調査中
+   * @param fnstatus TODO: 調査中
    */
   protected void saveStatus(int status, AbstractCobolField fnstatus) {
     CobolFile.errorFile = this;
@@ -334,7 +334,7 @@ public class CobolFile {
   /**
    * libcob/cob_cache_fileのj実装
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   protected static void cacheFile(CobolFile f) {
     if (file_cache.contains(f)) {
@@ -391,8 +391,8 @@ public class CobolFile {
   /**
    * libcob/fileio.cのcob_linage_write_optの実装 TODO 実装
    *
-   * @param opt
-   * @return
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   protected int linage_write_opt(int opt) throws CobolStopRunException {
@@ -1138,8 +1138,8 @@ public class CobolFile {
   /**
    * libcob/fileio.cのcob_file_write_optの実装
    *
-   * @param opt
-   * @return
+   * @param opt TODO: 調査中
+   * @return TODO: 調査中
    * @throws CobolStopRunException
    */
   protected int file_write_opt(int opt) throws CobolStopRunException {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -318,7 +318,19 @@ public class CobolFile {
     }
   }
 
-  /** libcob/fileio.のcob_invoke_funの実装 */
+  /**
+   * libcob/fileio.のcob_invoke_funの実装
+   *
+   * @param operate TODO: 調査中
+   * @param f TODO: 調査中
+   * @param key TODO: 調査中
+   * @param rec TODO: 調査中
+   * @param fnstatus TODO: 調査中
+   * @param openMode TODO: 調査中
+   * @param startCond TODO: 調査中
+   * @param readOpts TODO: 調査中
+   * @return TODO: 調査中
+   */
   public static int invokeFun(
       int operate,
       Object f,
@@ -1284,7 +1296,12 @@ public class CobolFile {
     }
   }
 
-  /** libcob/fileio.cのcob_syncの実装 */
+  /**
+   * libcob/fileio.cのcob_syncの実装
+   *
+   * @param f TODO: 調査中
+   * @param mode TODO: 調査中
+   */
   protected void cob_sync(CobolFile f, int mode) {
     // TODO
     // INDEXEDファイル実装時にやる

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -163,7 +163,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_tmpfileの実装
    *
-   * @return
+   * @return TODO: 調査中
    */
   private static FileIO tmpfile() {
     FileIO fp = new FileIO();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -56,11 +56,11 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのsort_cmpsの実装
    *
-   * @param s1
-   * @param s2
-   * @param size
-   * @param col
-   * @return
+   * @param s1 TODO: 調査中
+   * @param s2 TODO: 調査中
+   * @param size TODO: 調査中
+   * @param col TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortCmps(
       CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
@@ -91,10 +91,10 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_compareの実装
    *
-   * @param k1
-   * @param k2
-   * @param pointer
-   * @return
+   * @param k1 TODO: 調査中
+   * @param k2 TODO: 調査中
+   * @param pointer TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortCompare(CobolItem k1, CobolItem k2, CobolFile pointer) {
     CobolFile f = pointer;
@@ -137,7 +137,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_free_listの実装
    *
-   * @param q
+   * @param q TODO: 調査中
    */
   private static void cob_free_list(CobolItem q) {
     // nothing to do
@@ -146,8 +146,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_new_itemの実装
    *
-   * @param hp
-   * @return
+   * @param hp TODO: 調査中
+   * @return TODO: 調査中
    */
   private static CobolItem newItem(CobolSort hp) {
     CobolItem q;
@@ -208,9 +208,9 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_get_temp_fileの実装
    *
-   * @param hp
-   * @param n
-   * @return
+   * @param hp TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private static boolean getTempFile(CobolSort hp, int n) {
     if (hp.getFile()[n].getFp() == null) {
@@ -230,8 +230,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_sort_queuesの実装
    *
-   * @param hp
-   * @return
+   * @param hp TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortQueues(CobolSort hp) {
     CobolItem q;
@@ -297,9 +297,9 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_read_itemの実装
    *
-   * @param hp
-   * @param n
-   * @return
+   * @param hp TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int readItem(CobolSort hp, int n) {
     FileIO fp = hp.getFile()[n].getFp();
@@ -324,9 +324,9 @@ public class CobolFileSort {
   /**
    * writeBlock内で使う補助メソッド
    *
-   * @param fp
-   * @param q
-   * @param hp
+   * @param fp TODO: 調査中
+   * @param q TODO: 調査中
+   * @param hp TODO: 調査中
    * @return 書き込み失敗時true,それ以外はfalse
    */
   private static boolean writeItem(FileIO fp, CobolItem q, CobolSort hp) {
@@ -344,9 +344,9 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_write_blockの実装
    *
-   * @param hp
-   * @param n
-   * @return
+   * @param hp TODO: 調査中
+   * @param n TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int writeBlock(CobolSort hp, int n) {
     FileIO fp = hp.getFile()[hp.getDestinationFile()].getFp();
@@ -374,7 +374,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_copy_checkの実装
    *
-   * @param from
+   * @param from TODO: 調査中
    */
   private static void copyCheck(CobolFile to, CobolFile from) {
     CobolDataStorage toptr = to.record.getDataStorage();
@@ -398,8 +398,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_processの実装
    *
-   * @param hp
-   * @return
+   * @param hp TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortProcess(CobolSort hp) {
     hp.setRetrieving(1);
@@ -489,8 +489,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_submitの実装
    *
-   * @param p
-   * @return
+   * @param p TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortSubmit(CobolFile f, CobolDataStorage p) {
 
@@ -559,8 +559,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_retrieveの実装
    *
-   * @param p
-   * @return
+   * @param p TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int sortRetrieve(CobolFile f, CobolDataStorage p) {
     CobolSort hp = f.filex;
@@ -673,10 +673,10 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_initの実装
    *
-   * @param nkeys
-   * @param collatingSequence
-   * @param sortReturn
-   * @param fnstatus
+   * @param nkeys TODO: 調査中
+   * @param collatingSequence TODO: 調査中
+   * @param sortReturn TODO: 調査中
+   * @param fnstatus TODO: 調査中
    */
   public static void sortInit(
       CobolFile f,
@@ -713,10 +713,10 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_initの実装
    *
-   * @param nkeys
-   * @param collatingSequence
-   * @param sortReturn
-   * @param fnstatus
+   * @param nkeys TODO: 調査中
+   * @param collatingSequence TODO: 調査中
+   * @param sortReturn TODO: 調査中
+   * @param fnstatus TODO: 調査中
    */
   public static void sortInit(
       CobolFile f,
@@ -730,9 +730,9 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_init_keyの実装
    *
-   * @param flag
-   * @param field
-   * @param offset
+   * @param flag TODO: 調査中
+   * @param field TODO: 調査中
+   * @param offset TODO: 調査中
    */
   public static void sortInitKey(CobolFile f, int flag, AbstractCobolField field, int offset) {
     f.keys[f.nkeys].setFlag(flag);
@@ -744,8 +744,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_usingの実装
    *
-   * @param sortFile
-   * @param dataFile
+   * @param sortFile TODO: 調査中
+   * @param dataFile TODO: 調査中
    */
   public static void sortUsing(CobolFile sortFile, CobolFile dataFile) {
     dataFile.open(CobolFile.COB_OPEN_INPUT, 0, null);
@@ -766,8 +766,8 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_givingの実装
    *
-   * @param varcnt
-   * @param fbase
+   * @param varcnt TODO: 調査中
+   * @param fbase TODO: 調査中
    * @throws CobolStopRunException
    */
   public static void sortGiving(CobolFile sortFile, int varcnt, CobolFile... fbase)

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -673,6 +673,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_initの実装
    *
+   * @param f TODO: 調査中
    * @param nkeys TODO: 調査中
    * @param collatingSequence TODO: 調査中
    * @param sortReturn TODO: 調査中
@@ -713,6 +714,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_initの実装
    *
+   * @param f TODO: 調査中
    * @param nkeys TODO: 調査中
    * @param collatingSequence TODO: 調査中
    * @param sortReturn TODO: 調査中
@@ -730,6 +732,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_init_keyの実装
    *
+   * @param f TODO: 調査中
    * @param flag TODO: 調査中
    * @param field TODO: 調査中
    * @param offset TODO: 調査中
@@ -766,6 +769,7 @@ public class CobolFileSort {
   /**
    * libcob/fileio.cのcob_file_sort_givingの実装
    *
+   * @param sortFile TODO: 調査中
    * @param varcnt TODO: 調査中
    * @param fbase TODO: 調査中
    * @throws CobolStopRunException TODO: 調査中
@@ -840,7 +844,11 @@ public class CobolFileSort {
     }
   }
 
-  /** libcob/fileio.cのcob_file_sort_closeの実装 */
+  /**
+   * libcob/fileio.cのcob_file_sort_closeの実装
+   *
+   * @param f TODO: 調査中
+   */
   public static void sortClose(CobolFile f) {
     AbstractCobolField fnstatus = null;
     CobolSort hp = f.filex;
@@ -859,7 +867,11 @@ public class CobolFileSort {
     f.saveStatus(CobolFile.COB_STATUS_00_SUCCESS, fnstatus);
   }
 
-  /** libcob/fileio.cのcob_file_releaseの実装 */
+  /**
+   * libcob/fileio.cのcob_file_releaseの実装
+   *
+   * @param f TODO: 調査中
+   */
   public static void performRelease(CobolFile f) {
     AbstractCobolField fnstatus = null;
     CobolSort hp = f.filex;
@@ -881,7 +893,11 @@ public class CobolFileSort {
     }
   }
 
-  /** libcob/fileio.cのcob_file_returnの実装 */
+  /**
+   * libcob/fileio.cのcob_file_returnの実装
+   *
+   * @param f TODO: 調査中
+   */
   public static void performReturn(CobolFile f) {
     AbstractCobolField fnstatus = null;
     CobolSort hp = f.filex;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -768,7 +768,7 @@ public class CobolFileSort {
    *
    * @param varcnt TODO: 調査中
    * @param fbase TODO: 調査中
-   * @throws CobolStopRunException
+   * @throws CobolStopRunException TODO: 調査中
    */
   public static void sortGiving(CobolFile sortFile, int varcnt, CobolFile... fbase)
       throws CobolStopRunException {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -281,7 +281,15 @@ public class CobolIndexedFile extends CobolFile {
     return COB_STATUS_00_SUCCESS;
   }
 
-  /** Equivalent to indexed_start_internal in libcob/fileio.c */
+  /**
+   * Equivalent to indexed_start_internal in libcob/fileio.c
+   *
+   * @param cond TODO: 調査中
+   * @param key TODO: 調査中
+   * @param readOpts TODO: 調査中
+   * @param testLock TODO: 調査中
+   * @return TODO: 調査中
+   */
   public int indexed_start_internal(
       int cond, AbstractCobolField key, int readOpts, boolean testLock) {
     IndexedFile p = this.filei;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -139,7 +139,11 @@ public final class IndexedCursor {
     }
   }
 
-  /** reload a cursor */
+  /**
+   * reload a cursor
+   *
+   * @return TODO: 調査中
+   */
   public Optional<IndexedCursor> reloadCursor() {
     if (this.firstFetch) {
       return createCursor(this.conn, this.key, this.tableIndex, this.isDuplicate, this.comparator);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -122,7 +122,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c job_or_current_localtime
    *
-   * @return
+   * @return TODO: 調査中
    */
   private static LocalDateTime jobOrCurrentLocalTime() {
     if (CobolUtil.cobLocalTm != null) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -38,7 +38,7 @@ public class CobolTerminal {
   /**
    * cob_displayの実装 TODO 暫定実装
    *
-   * @param dispStdout
+   * @param dispStdout TODO: 調査中
    * @param newline trueなら出力後に改行しない,それ以外の場合は改行する
    * @param fields 出力する変数(可変長)
    */
@@ -94,7 +94,7 @@ public class CobolTerminal {
   /**
    * cob_acceptの実装(暫定)
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void accept(AbstractCobolField f) {
     try {
@@ -135,7 +135,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_date
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptDate(AbstractCobolField f) {
     LocalDateTime date = jobOrCurrentLocalTime();
@@ -146,7 +146,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_date_yyyymmdd
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptDate_yyyymmdd(AbstractCobolField f) {
     LocalDateTime date = jobOrCurrentLocalTime();
@@ -157,7 +157,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_day
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptDay(AbstractCobolField f) {
     LocalDateTime date = jobOrCurrentLocalTime();
@@ -168,7 +168,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_date_yyyyddd
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptDay_yyyyddd(AbstractCobolField f) {
     LocalDateTime date = jobOrCurrentLocalTime();
@@ -179,7 +179,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_day_of_week
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptDayOfWeek(AbstractCobolField f) {
     LocalDateTime date = jobOrCurrentLocalTime();
@@ -189,7 +189,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_time
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptTime(AbstractCobolField f) {
     LocalDateTime date = LocalDateTime.now();
@@ -202,7 +202,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_display_environment
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void displayEnvironment(AbstractCobolField f) {
     CobolUtil.cobLocalEnv = f.fieldToString();
@@ -211,7 +211,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_display_env_value
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void displayEnvValue(AbstractCobolField f) {
     if (CobolUtil.cobLocalEnv == null || CobolUtil.cobLocalEnv.equals("")) {
@@ -224,7 +224,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_environment
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptEnvironment(AbstractCobolField f) {
     String p = null;
@@ -246,7 +246,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_display_command_line
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void displayCommandLine(AbstractCobolField f) {
     CobolUtil.commlnptr = new byte[f.getSize()];
@@ -259,7 +259,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_command_line
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptCommandLine(AbstractCobolField f) {
     if (CobolUtil.commlncnt != 0) {
@@ -273,7 +273,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_display_arg_number
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void displayArgNumber(AbstractCobolField f) {
     CobolFieldAttribute attr =
@@ -293,7 +293,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_arg_number
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptArgNumber(AbstractCobolField f) {
     CobolFieldAttribute attr =
@@ -308,7 +308,7 @@ public class CobolTerminal {
   /**
    * libcob/common.c cob_accept_arg_value
    *
-   * @param f
+   * @param f TODO: 調査中
    */
   public static void acceptArgValue(AbstractCobolField f) {
     if (CobolUtil.currentArgIndex > CobolUtil.commandLineArgs.length) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java
@@ -5,7 +5,7 @@ public class ErrorLib {
   /**
    * Error when indexed file does not exist
    *
-   * @param indexedFilePath
+   * @param indexedFilePath TODO: 調査中
    * @return 1
    */
   public static int errorFileDoesNotExist(String indexedFilePath) {
@@ -15,7 +15,7 @@ public class ErrorLib {
   /**
    * Error when indexed file is not a valid indexed file
    *
-   * @param indexedFilePath
+   * @param indexedFilePath TODO: 調査中
    * @return 1
    */
   public static int errorInvalidIndexedFile(String indexedFilePath) {
@@ -46,8 +46,8 @@ public class ErrorLib {
   /**
    * Error when some records in input data have invalid size
    *
-   * @param correctSize
-   * @return
+   * @param correctSize TODO: 調査中
+   * @return TODO: 調査中
    */
   public static int errorDataSizeMismatch(int correctSize) {
     System.err.println("error: all record must have the length of " + correctSize + " bytes.");

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -42,7 +42,7 @@ public class IndexedFileUtilMain {
   /**
    * Main method
    *
-   * @param args
+   * @param args TODO: 調査中
    */
   public static void main(String[] args) {
 
@@ -218,7 +218,7 @@ public class IndexedFileUtilMain {
   /**
    * Process info sub command, which shows information of the indexed file.
    *
-   * @param indexedFilePath
+   * @param indexedFilePath TODO: 調査中
    * @return 0 if success, otherwise non-zero. The return value is error code.
    */
   private static int processInfoCommand(String indexedFilePath) {
@@ -294,8 +294,8 @@ public class IndexedFileUtilMain {
   /**
    * Process load sub command, which loads data inputted from stdin to the indexed file.
    *
-   * @param indexedFilePath
-   * @return
+   * @param indexedFilePath TODO: 調査中
+   * @return TODO: 調査中
    */
   private static int processLoadCommand(
       String indexedFilePath,
@@ -451,7 +451,7 @@ public class IndexedFileUtilMain {
   /**
    * Create a CobolFile instance from the path of the indexed file.
    *
-   * @param indexedFilePath
+   * @param indexedFilePath TODO: 調査中
    * @return CobolFile instance if success, otherwise empty.
    */
   private static Optional<CobolFile> createCobolFileFromIndexedFilePath(String indexedFilePath) {


### PR DESCRIPTION
This pull request resolve all Javadoc warnings in libcobj/.
In addtion, this pull request changes javadoc.yml so that CI fails when Javadoc warnings are emitted.