### PR TITLE
Detect missing Javadoc comments

### DIFF
--- a/.github/workflows/check-missing-javadoc.yml
+++ b/.github/workflows/check-missing-javadoc.yml
@@ -1,0 +1,40 @@
+# This workflow detects missing Javadoc comments in the source code of the project.
+# Although it works correctly, the process should be improved to use gradle instead of javadoc directly.
+name: Javadoc
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CLASSPATH: ":/usr/lib/opensourcecobol4j/libcobj.jar"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies on Ubuntu
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-9 build-essential gettext autoconf
+
+      - name: Checkout opensource COBOL 4J
+        uses: actions/checkout@v4
+
+      - name: Install opensource COBOL 4J
+        run: |
+          ./configure --prefix=/usr/
+          make
+          sudo make install
+
+      - name: Check javadoc comments
+        working-directory: libcobj/
+        run: |
+          sh check-missing-javadoc.sh

--- a/.github/workflows/check-missing-javadoc.yml
+++ b/.github/workflows/check-missing-javadoc.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Check javadoc comments
         working-directory: libcobj/
         run: |
-          sh check-missing-javadoc.sh
+          sh check-missing-javadoc.sh || true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,6 +93,10 @@ jobs:
     needs: check-workflows
     uses: ./.github/workflows/javadoc.yml
 
+  check-missing-javadoc:
+    needs: check-workflows
+    uses: ./.github/workflows/check-missing-javadoc.yml
+
   build-libcobj:
     needs: check-workflows
     uses: ./.github/workflows/build-libcobj.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -92,6 +92,10 @@ jobs:
     needs: check-workflows
     uses: ./.github/workflows/javadoc.yml
 
+  check-missing-javadoc:
+    needs: check-workflows
+    uses: ./.github/workflows/check-missing-javadoc.yml
+
   build-libcobj:
     needs: check-workflows
     uses: ./.github/workflows/build-libcobj.yml

--- a/libcobj/.gitignore
+++ b/libcobj/.gitignore
@@ -8,3 +8,5 @@ sqlite/sqlite.jar
 
 # Ignore Gradle build output directory
 build
+
+app/src/main/java/javadoc.log

--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -18,9 +18,9 @@ tasks {
     javadoc {
         options.encoding = "UTF-8"
         options {
+            // It seems that the following line does not work.
             (this as CoreJavadocOptions).addStringOption("Xdoclint:missing")
         }
-        //options.addStringOption('Xdoclint:all,-missing')
     }
     compileJava {
         options.encoding = "UTF-8"

--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -18,8 +18,7 @@ tasks {
     javadoc {
         options.encoding = "UTF-8"
         options {
-            (this as CoreJavadocOptions).addStringOption("Xdoclint:none", "-quiet")
-            (this as CoreJavadocOptions).addStringOption("Xdoclint:all,-missing/private")
+            (this as CoreJavadocOptions).addStringOption("Xdoclint:missing")
         }
         //options.addStringOption('Xdoclint:all,-missing')
     }

--- a/libcobj/check-missing-javadoc.sh
+++ b/libcobj/check-missing-javadoc.sh
@@ -1,0 +1,4 @@
+cd app/src/main/java
+javadoc $(find . -name '*.java') -Xdoclint:missing 2> javadoc.log
+cat javadoc.log
+test "$(grep '[1-9][0-9]* warning' javadoc.log)" = ""


### PR DESCRIPTION
This pull request adds a workflow file check-missing-javadoc.yml which checks if there methods, constructors, classes and variables without Javadoc comments.
Currently the workflow check succeeds even if it detects missing Javadoc comments.
After this pull request is merged, I will add Javadoc comments and enable full checks of the workflow.