### PR TITLE
Refactor Java classes in `jp.osscons.opensourcecobol.libcobj.data` except for `AbstractCobolField`

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolAlphanumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolAlphanumericField.java
@@ -37,17 +37,11 @@ public class CobolAlphanumericField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** this.dataの保持するバイト配列のコピーを返す */
   @Override
   public byte[] getBytes() {
     return dataStorage.getData();
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     try {
@@ -57,23 +51,12 @@ public class CobolAlphanumericField extends AbstractCobolField {
     }
   }
 
-  // @Override
-  // public int getInt() {
-  // throw new CobolRuntimeException(CobolRuntimeException.COBOL_FATAL_ERROR,
-  // "未対応");
-  // }
-
   @Override
   public void setDecimal(BigDecimal decimal) {
     // TODO 自動生成されたメソッド・スタブ
 
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
     AbstractCobolField src1 = this.preprocessOfMoving(src);
@@ -105,7 +88,7 @@ public class CobolAlphanumericField extends AbstractCobolField {
   }
 
   /**
-   * CobolNumericDisplayからCobolAlphanumericFieldへのMOVE
+   * CobolNumericDisplayからCobolAlphanumericFieldへのMOVEの処理
    *
    * @param field 転記元のCobolNumericDisplay型のフィールド
    */
@@ -145,7 +128,7 @@ public class CobolAlphanumericField extends AbstractCobolField {
   }
 
   /**
-   * CobolNumericDisplayからCobolAlphanumericFieldへのMOVE
+   * CobolNumericDisplayからCobolAlphanumericFieldへのMOVEの処理
    *
    * @param field 転記元のCobolNumericDisplay型のフィールド
    */
@@ -193,21 +176,11 @@ public class CobolAlphanumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {
     this.dataStorage.setData(bytes);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {
     try {
@@ -226,11 +199,6 @@ public class CobolAlphanumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
-   *
-   * @return thisからCobolNumericField型へ変換した値
-   */
   @Override
   public CobolNumericField getNumericField() {
     int size = 36;
@@ -248,50 +216,30 @@ public class CobolAlphanumericField extends AbstractCobolField {
     return field;
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int number) {
     // TODO 自動生成されたメソッド・スタブ
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(double型)
-   */
   @Override
   public void moveFrom(double number) {
     // TODO 自動生成されたメソッド・スタブ
     this.moveFrom((int) number);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(BigDecimal型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {
     // TODO 自動生成されたメソッド・スタブ
 
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param dataStorage 代入元のデータ(CobolDataStorage]型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {
     // TODO 自動生成されたメソッド・スタブ
 
   }
 
-  /** 実装しないメソッド */
+  @Override
   public int addPackedInt(int n) {
     throw new CobolRuntimeException(0, "実装しないコード");
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolGroupField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolGroupField.java
@@ -36,17 +36,11 @@ public class CobolGroupField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** this.dataの保持するバイト配列のコピーを返す */
   @Override
   public byte[] getBytes() {
     return dataStorage.getData(size);
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     try {
@@ -56,27 +50,19 @@ public class CobolGroupField extends AbstractCobolField {
     }
   }
 
-  /** TODO */
   @Override
   public int getInt() {
     return 0;
   }
 
-  /** TODO */
   @Override
   public CobolDecimal getDecimal() {
     return null;
   }
 
-  /** TODO */
   @Override
   public void setDecimal(BigDecimal decimal) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
     AbstractCobolField src1 = this.preprocessOfMoving(src);
@@ -87,19 +73,9 @@ public class CobolGroupField extends AbstractCobolField {
     CobolAlphanumericField.moveAlphanumToAlphanum(this, src1);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param dataStorage 代入元のデータ(CobolDataStorage型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {
     if (bytes.length >= this.size) {
@@ -110,11 +86,6 @@ public class CobolGroupField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {
     byte[] bytes;
@@ -127,31 +98,16 @@ public class CobolGroupField extends AbstractCobolField {
     this.moveFrom(bytes);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(double型)
-   */
   @Override
   public void moveFrom(double number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(BigDecimal型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {}
 
-  /** 実装しないメソッド */
+  @Override
   public int addPackedInt(int n) {
     throw new CobolRuntimeException(0, "実装しないコード");
   }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNationalField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNationalField.java
@@ -39,17 +39,11 @@ public class CobolNationalField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** this.dataの保持するバイト配列のコピーを返す */
   @Override
   public byte[] getBytes() {
     return dataStorage.getData(size);
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     try {
@@ -59,28 +53,21 @@ public class CobolNationalField extends AbstractCobolField {
     }
   }
 
-  /** TODO: 準備中 */
   @Override
   public int getInt() {
     return 0;
   }
 
-  /** TODO: 準備中 */
   @Override
   public CobolDecimal getDecimal() {
     return null;
   }
 
-  /** 実装しないメソッド */
+  @Override
   public int addPackedInt(int n) {
     throw new CobolRuntimeException(0, "実装しないコード");
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
 
@@ -173,7 +160,7 @@ public class CobolNationalField extends AbstractCobolField {
   }
 
   /**
-   * libcob/move.cのjudge_hankakujpn_existの実装
+   * TODO: 準備中
    *
    * @param src TODO: 準備中
    * @return TODO: 準備中
@@ -192,7 +179,7 @@ public class CobolNationalField extends AbstractCobolField {
   }
 
   /**
-   * libcob/move.c han2zenの実装
+   * TODO: 準備中
    *
    * @param str TODO: 準備中
    * @param size TODO: 準備中
@@ -1046,29 +1033,14 @@ public class CobolNationalField extends AbstractCobolField {
     return buf;
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param dataStorage 代入元のデータ(dataStorage型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {
     dataStorage.setBytes(bytes);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {
     try {
@@ -1083,43 +1055,18 @@ public class CobolNationalField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(double number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param decimal 代入元のデータ(int型)
-   */
   @Override
   public void setDecimal(BigDecimal decimal) {}
 
-  /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
-   *
-   * @return thisからCobolNumericField型へ変換した値
-   */
   @Override
   public CobolNumericField getNumericField() {
     int size = this.getSize() / 2;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
@@ -222,11 +222,7 @@ public class CobolNumericBinaryField extends AbstractCobolField {
   @Override
   public void moveFrom(BigDecimal number) {}
 
-  /**
-   * このオブジェクトの示す数値と同等の値を保持するCobolNumericFieldを計算する
-   *
-   * @return このオブジェクトの示す数値と同等の値を保持するCobolNumericFieldのインスタンス
-   */
+  @Override
   public CobolNumericField getNumericField() {
     int size = this.getAttribute().getDigits();
     int scale = this.getAttribute().getScale();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
@@ -39,13 +39,12 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     super(size, dataStorage, attribute);
   }
 
-  /** TODO */
   @Override
   public byte[] getBytes() {
     return new byte[0];
   }
 
-  /** 実装しないメソッド */
+  @Override
   public int addPackedInt(int n) {
     throw new CobolRuntimeException(0, "実装しないコード");
   }
@@ -90,11 +89,6 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     this.setBinaryValue(n);
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     CobolFieldAttribute thisAttr = this.getAttribute();
@@ -112,11 +106,6 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     return numericField.getString();
   }
 
-  /**
-   * thisの保持する数値データの符号を返す
-   *
-   * @return thisの保持する数値データが負ならば負数,0なら0,正なら正数を返す
-   */
   @Override
   public int getSign() {
     long n = this.getBinaryValue();
@@ -130,15 +119,9 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     }
   }
 
-  /** TODO */
   @Override
   public void setDecimal(BigDecimal decimal) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
     AbstractCobolField src1 = this.preprocessOfMoving(src);
@@ -219,74 +202,30 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     field.putSign(sign);
   }
 
-  /**
-   * libcob/move.cのcob_binary_mset_int64の実装
-   *
-   * @param n TODO: 準備中
-   */
-  public void binaryMsetInt64(long n) {
-    byte bytes[] = new byte[8];
-    for (int i = 0; i < 8; ++i) {
-      bytes[i] = (byte) ((byte) (n >> ((7 - i) * 8)) & 0x00000000000000FFL);
-    }
-    CobolDataStorage nData = new CobolDataStorage(bytes, 0);
-    this.ownByteMemcpy(this.getDataStorage(), 0, nData, 8 - this.size, this.size);
-  }
-
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param dataStorage 代入元のデータ(CobolDataStorage型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {}
 
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {}
 
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {}
 
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int number) {
     this.getDataStorage().setSwpU32Binary(number);
   }
 
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param number 代入元のデータ(double型)
-   */
   @Override
   public void moveFrom(double number) {}
 
-  /**
-   * CobolNumericFieldからからthisへの代入
-   *
-   * @param number 代入元のデータ(BigDecimal型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {}
 
   /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
+   * このオブジェクトの示す数値と同等の値を保持するCobolNumericFieldを計算する
    *
-   * @return thisからCobolNumericField型へ変換した値
+   * @return このオブジェクトの示す数値と同等の値を保持するCobolNumericFieldのインスタンス
    */
   public CobolNumericField getNumericField() {
     int size = this.getAttribute().getDigits();
@@ -304,7 +243,6 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     return field;
   }
 
-  /** libcob/numeric.cのcob_decimal_set_binaryの実装 */
   @Override
   public CobolDecimal getDecimal() {
     CobolDecimal decimal = new CobolDecimal();
@@ -334,7 +272,6 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     return n;
   }
 
-  /** libcob/common.cのcob_get_long_longの実装 */
   @Override
   public long getLong() {
     return this.binaryGetInt64();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericBinaryField.java
@@ -247,11 +247,7 @@ public class CobolNumericBinaryField extends AbstractCobolField {
     return decimal;
   }
 
-  /**
-   * libcob/numeric.cのcob_binary_get_int64の実装
-   *
-   * @param f TODO: 準備中
-   */
+  // libcob/numeric.cのcob_binary_get_int64の実装
   private long binaryGetInt64() {
     int fsiz = 8 - this.getSize();
     long n = 0;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericEditedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericEditedField.java
@@ -364,11 +364,7 @@ public class CobolNumericEditedField extends AbstractCobolField {
   @Override
   public void moveFrom(BigDecimal number) {}
 
-  /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
-   *
-   * @return thisからCobolNumericField型へ変換した値
-   */
+  @Override
   public CobolNumericField getNumericField() {
     int size = 36;
     int scale = 18;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -49,17 +49,11 @@ public class CobolNumericField extends AbstractCobolField {
    */
   public void checkNumeric(String s) {}
 
-  /** this.dataの保持するバイト配列のコピーを返す */
   @Override
   public byte[] getBytes() {
     return dataStorage.getData();
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     CobolDataStorage data = this.getDataStorage();
@@ -123,11 +117,6 @@ public class CobolNumericField extends AbstractCobolField {
     return sb.toString();
   }
 
-  /**
-   * thisの保持する数値データをint型で返す
-   *
-   * @return thisの保持する数値データをintに変換した値
-   */
   @Override
   public int getInt() {
     int size = this.getFieldSize();
@@ -178,11 +167,6 @@ public class CobolNumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
     AbstractCobolField src1 = this.preprocessOfMoving(src);
@@ -468,11 +452,6 @@ public class CobolNumericField extends AbstractCobolField {
     this.putSign(sign);
   }
 
-  /**
-   * thisの保持する数値データの符号を返す
-   *
-   * @return thisの保持する数値データが負ならば負数,0なら0,正なら正数を返す
-   */
   @Override
   public int getSign() {
     CobolFieldAttribute attr = this.getAttribute();
@@ -512,11 +491,6 @@ public class CobolNumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * thisの保持する数値データの符号を設定する
-   *
-   * @param sign 正符号を設定するときは正数,負符号を設定するときは負数,それ以外は0
-   */
   @Override
   public void putSign(int sign) {
     CobolFieldAttribute attr = this.getAttribute();
@@ -558,7 +532,7 @@ public class CobolNumericField extends AbstractCobolField {
    * @param size TODO: 準備中
    * @param scale TODO: 準備中
    */
-  public void storeCommonRegion(
+  private void storeCommonRegion(
       AbstractCobolField field, CobolDataStorage data, int size, int scale) {
     this.storeCommonRegion(field, data, 0, size, scale);
   }
@@ -572,7 +546,7 @@ public class CobolNumericField extends AbstractCobolField {
    * @param size TODO: 準備中
    * @param scale TODO: 準備中
    */
-  public void storeCommonRegion(
+  private void storeCommonRegion(
       AbstractCobolField field, CobolDataStorage data, int dataStartIndex, int size, int scale) {
     int lf1 = -scale;
     int lf2 = -field.getAttribute().getScale();
@@ -601,21 +575,11 @@ public class CobolNumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {
     this.dataStorage.setData(bytes);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {
     try {
@@ -625,11 +589,6 @@ public class CobolNumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int number) {
     int n = Math.abs(number);
@@ -652,14 +611,7 @@ public class CobolNumericField extends AbstractCobolField {
     return this.addInt(-in, CobolDecimal.COB_STORE_KEEP_ON_OVERFLOW);
   }
 
-  /**
-   * TODO: 準備中
-   *
-   * @param in TODO: 準備中
-   * @param opt TODO: 準備中
-   * @return TODO: 準備中
-   */
-  public int subInt(int in, int opt) {
+  private int subInt(int in, int opt) {
     return this.addInt(-in, opt);
   }
 
@@ -668,14 +620,7 @@ public class CobolNumericField extends AbstractCobolField {
     return this.addInt(in, CobolDecimal.COB_STORE_KEEP_ON_OVERFLOW);
   }
 
-  /**
-   * thisの保持する数値データに加算する
-   *
-   * @param in thisの保持する数値データに加算する値
-   * @param opt TODO: 準備中
-   * @return 0
-   */
-  public int addInt(int in, int opt) {
+  private int addInt(int in, int opt) {
     if (in == 0) {
       return 0;
     }
@@ -796,16 +741,7 @@ public class CobolNumericField extends AbstractCobolField {
     return 1;
   }
 
-  /**
-   * libcob/numeric.cのdisplay_sub_intの実装
-   *
-   * @param data TODO: 準備中
-   * @param firstDataIndex dataにアクセスするときの開始位置
-   * @param size TODO: 準備中
-   * @param n TODO: 準備中
-   * @return TODO: 準備中
-   */
-  public static int displaySubInt(CobolDataStorage data, int firstDataIndex, int size, long n) {
+  private static int displaySubInt(CobolDataStorage data, int firstDataIndex, int size, long n) {
     int carry = 0;
     int sp = firstDataIndex + size;
     int i;
@@ -876,11 +812,6 @@ public class CobolNumericField extends AbstractCobolField {
     return this;
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param field 代入元のデータ(double型)
-   */
   /*
    * @Override
    * public void moveFrom(double number) {
@@ -888,28 +819,17 @@ public class CobolNumericField extends AbstractCobolField {
    * }
    */
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(BigDecimal型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {}
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param dataStorage 代入元のデータ(CobolDataStorage型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {}
 
-  /** 実装しないメソッド */
+  @Override
   public int addPackedInt(int n) {
     throw new CobolRuntimeException(0, "実装しないコード");
   }
 
-  /** libcob/move.cのcob_display_get_long_longの実装 */
   @Override
   public long getLong() {
     int size = this.getSize();
@@ -943,6 +863,7 @@ public class CobolNumericField extends AbstractCobolField {
     return val;
   }
 
+  @Override
   public int numericCompareTo(AbstractCobolField field) {
     CobolFieldAttribute attr1 = this.getAttribute();
     CobolFieldAttribute attr2 = field.getAttribute();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -871,11 +871,6 @@ public class CobolNumericField extends AbstractCobolField {
     }
   }
 
-  /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
-   *
-   * @return thisからCobolNumericField型へ変換した値
-   */
   @Override
   public CobolNumericField getNumericField() {
     return this;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -146,17 +146,11 @@ public class CobolNumericPackedField extends AbstractCobolField {
    */
   public void checkNumeric(String s) {}
 
-  /** this.dataの保持するバイト配列のコピーを返す */
   @Override
   public byte[] getBytes() {
     return dataStorage.getData();
   }
 
-  /**
-   * thisの文字列表現をかえす.(toStringだけで十分か?)
-   *
-   * @return thisの文字列表現
-   */
   @Override
   public String getString() {
     StringBuilder sb = new StringBuilder();
@@ -200,11 +194,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param src 代入元のデータ(AbstractCobolField型)
-   */
   @Override
   public void moveFrom(AbstractCobolField src) {
     AbstractCobolField src1 = this.preprocessOfMoving(src);
@@ -312,21 +301,11 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param bytes 代入元のデータ(byte[]型)
-   */
   @Override
   public void moveFrom(byte[] bytes) {
     this.dataStorage.setData(bytes);
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param string 代入元のデータ(String型)
-   */
   @Override
   public void moveFrom(String string) {
     try {
@@ -336,11 +315,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * libcob/numeric.cのcob_set_packed_intの実装 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param val 代入元のデータ(int型)
-   */
   @Override
   public void moveFrom(int val) {
     int n;
@@ -466,31 +440,16 @@ public class CobolNumericPackedField extends AbstractCobolField {
     return field;
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param number 代入元のデータ(BigDecimal型)
-   */
   @Override
   public void moveFrom(BigDecimal number) {
     // TODO 自動生成されたメソッド・スタブ
   }
 
-  /**
-   * 引数で与えらえられたデータからthisへの代入を行う
-   *
-   * @param dataStorage 代入元のデータ(CobolDataStorage型)
-   */
   @Override
   public void moveFrom(CobolDataStorage dataStorage) {
     // TODO 自動生成されたメソッド・スタブ
   }
 
-  /**
-   * libcob/numeric.cのcob_packed_get_signの実装 thisの保持する数値データの符号を返す
-   *
-   * @return thisの保持する数値データが負ならば負数,0なら0,正なら正数を返す
-   */
   @Override
   public int getSign() {
     if (!this.getAttribute().isFlagHaveSign()) {
@@ -500,11 +459,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     return (this.dataStorage.getByte(index) & 0x0f) == 0x0d ? -1 : 1;
   }
 
-  /**
-   * thisの保持する数値データの符号を設定する
-   *
-   * @param sign 正符号を設定するときは正数,負符号を設定するときは負数,それ以外は0
-   */
   @Override
   public void putSign(int sign) {
     int index = this.getSize() - 1;
@@ -516,11 +470,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * 数値を表すデータが実装すべきメソッド. 保持する数値データをCobolDecimal型に変換する.
-   *
-   * @return 保持する数値データをCobolDecimal型に変換した値
-   */
   @Override
   public CobolDecimal getDecimal() {
     CobolDataStorage data = this.getDataStorage();
@@ -594,11 +543,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     return (byte) ((b >>> 4) & 0x0F);
   }
 
-  /**
-   * thisの保持する数値データをint型で返す
-   *
-   * @return thisの保持する数値データをintに変換した値
-   */
   @Override
   public int getInt() {
     int p = 0;
@@ -634,12 +578,7 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * libcob/codegen.hのcob_add_packed_intの実装 thisの保持する数値データに加算する
-   *
-   * @param val thisの保持する数値データに加算する値
-   * @return TODO: 準備中
-   */
+  @Override
   public int addPackedInt(int val) {
     if (val == 0) {
       return 0;
@@ -679,12 +618,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     return 0;
   }
 
-  /**
-   * libcob/numeric.cのcob_add_intおよびcob_add_packedの実装
-   *
-   * @param ival thisに 加算する値
-   * @return TODO: 準備中
-   */
   @Override
   public int addInt(int ival) {
     if (ival == 0) {
@@ -816,7 +749,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /** */
   @Override
   public int cmpInt(int n) {
     if (this.getAttribute().getDigits() < 10) {
@@ -918,7 +850,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     return 0;
   }
 
-  /** libcob/move.cのcob_packed_get_long_longの実装 */
   @Override
   public long getLong() {
     int digits = this.getAttribute().getDigits();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericPackedField.java
@@ -449,11 +449,6 @@ public class CobolNumericPackedField extends AbstractCobolField {
     }
   }
 
-  /**
-   * thisをCobolNumericFieldに変換する. indirect moveをするときに使用されることを想定している.
-   *
-   * @return thisからCobolNumericField型へ変換した値
-   */
   @Override
   public CobolNumericField getNumericField() {
     int size = this.getAttribute().getDigits();


### PR DESCRIPTION
This pull request improve improve Java classes of `jp.osscons.opensourcecobol.libcobj.data` except for `AbstractCobolField`

* Add missing `@Override`
* remove Javadoc comments of overrided methods
* Change public methods to private ones