### PR TITLE
Bump org.xerial:sqlite-jdbc from 3.30.1 to 3.46.0.0 in /libcobj

### DIFF
--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -32,12 +32,15 @@ tasks {
 
 dependencies {
     implementation("com.google.guava:guava:33.2.1-jre")
-    implementation("org.xerial:sqlite-jdbc:3.30.1")
+    implementation("org.xerial:sqlite-jdbc:3.46.0.0")
     implementation("commons-cli:commons-cli:1.8.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("org.json:json:20240303")
     spotbugs("com.github.spotbugs:spotbugs:4.8.6")
+
+    implementation("org.slf4j:slf4j-api:2.0.13")
+    implementation("org.slf4j:slf4j-simple:2.0.13")
 }
 
 java {


### PR DESCRIPTION
This pull request resolves the errors found in #417
* add sl4j to dependencies
* update the version of esqlite-jdbc