### PR TITLE
Fix config file setting for "binary-byteorder"

### DIFF
--- a/cobj/cobj.h
+++ b/cobj/cobj.h
@@ -244,7 +244,10 @@ enum cb_assign_clause {
   CB_ASSIGN_JPH1       /* JP compatibility */
 };
 
-enum cb_binary_byteorder { CB_BYTEORDER_LITTLE_ENDIAN, CB_BYTEORDER_BIG_ENDIAN };
+enum cb_binary_byteorder {
+  CB_BYTEORDER_LITTLE_ENDIAN,
+  CB_BYTEORDER_BIG_ENDIAN
+};
 
 enum cb_binary_size {
   CB_BINARY_SIZE_2_4_8,   /* 2,4,8 bytes */

--- a/cobj/cobj.h
+++ b/cobj/cobj.h
@@ -244,7 +244,7 @@ enum cb_assign_clause {
   CB_ASSIGN_JPH1       /* JP compatibility */
 };
 
-enum cb_binary_byteorder { CB_BYTEORDER_NATIVE, CB_BYTEORDER_BIG_ENDIAN };
+enum cb_binary_byteorder { CB_BYTEORDER_LITTLE_ENDIAN, CB_BYTEORDER_BIG_ENDIAN };
 
 enum cb_binary_size {
   CB_BINARY_SIZE_2_4_8,   /* 2,4,8 bytes */

--- a/cobj/config.c
+++ b/cobj/config.c
@@ -229,8 +229,8 @@ int cb_load_conf(const char *fname, const int check_nodef,
           ret = -1;
         }
       } else if (strcmp(name, "binary-byteorder") == 0) {
-        if (strcmp(val, "native") == 0) {
-          cb_binary_byteorder = CB_BYTEORDER_NATIVE;
+        if (strcmp(val, "little-endian") == 0) {
+          cb_binary_byteorder = CB_BYTEORDER_LITTLE_ENDIAN;
         } else if (strcmp(val, "big-endian") == 0) {
           cb_binary_byteorder = CB_BYTEORDER_BIG_ENDIAN;
         } else {

--- a/cobj/field.c
+++ b/cobj/field.c
@@ -709,7 +709,7 @@ static void setup_parameters(struct cb_field *f) {
     switch (f->usage) {
     case CB_USAGE_BINARY:
 #ifndef WORDS_BIGENDIAN
-      if (cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
+      if (cb_binary_byteorder == CB_BYTEORDER_LITTLE_ENDIAN) {
         f->flag_binary_swap = 1;
       }
 #endif
@@ -746,7 +746,7 @@ static void setup_parameters(struct cb_field *f) {
       }
 #ifndef WORDS_BIGENDIAN
       if (f->usage == CB_USAGE_COMP_X) {
-        if (cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
+        if (cb_binary_byteorder == CB_BYTEORDER_LITTLE_ENDIAN) {
           f->flag_binary_swap = 1;
         }
       }

--- a/cobj/field.c
+++ b/cobj/field.c
@@ -709,7 +709,7 @@ static void setup_parameters(struct cb_field *f) {
     switch (f->usage) {
     case CB_USAGE_BINARY:
 #ifndef WORDS_BIGENDIAN
-      if (cb_binary_byteorder == CB_BYTEORDER_LITTLE_ENDIAN) {
+      if (cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
         f->flag_binary_swap = 1;
       }
 #endif
@@ -746,7 +746,7 @@ static void setup_parameters(struct cb_field *f) {
       }
 #ifndef WORDS_BIGENDIAN
       if (f->usage == CB_USAGE_COMP_X) {
-        if (cb_binary_byteorder == CB_BYTEORDER_LITTLE_ENDIAN) {
+        if (cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
           f->flag_binary_swap = 1;
         }
       }

--- a/tests/data-rep.src/binary.at
+++ b/tests/data-rep.src/binary.at
@@ -215,9 +215,9 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 
-# 2-4-8 native
+# 2-4-8 little-endian
 
-AT_SETUP([BINARY: 2-4-8 native])
+AT_SETUP([BINARY: 2-4-8 little-endian])
 AT_CHECK([${SKIP_TEST}])
 
 if test "x$COB_BIGENDIAN" = "xyes"; then
@@ -227,7 +227,7 @@ else
 AT_DATA([test.conf], [
 include "cobol2002.conf"
 binary-size: 2-4-8
-binary-byteorder: native
+binary-byteorder: little-endian
 ])
 
 AT_DATA([dump.java], [
@@ -616,9 +616,9 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 
-# 1-2-4-8 native
+# 1-2-4-8 little-endian
 
-AT_SETUP([BINARY: 1-2-4-8 native])
+AT_SETUP([BINARY: 1-2-4-8 little-endian])
 AT_CHECK([${SKIP_TEST}])
 
 if test "x$COB_BIGENDIAN" = "xyes"; then
@@ -628,7 +628,7 @@ else
 AT_DATA([test.conf], [
 include "cobol2002.conf"
 binary-size: 1-2-4-8
-binary-byteorder: native
+binary-byteorder: little-endian
 ])
 
 AT_DATA([dump.java], [
@@ -1019,9 +1019,9 @@ AT_CHECK([java prog], [0],
 AT_CLEANUP
 
 
-# 1--8 native
+# 1--8 little-endian
 
-AT_SETUP([BINARY: 1--8 native])
+AT_SETUP([BINARY: 1--8 little-endian])
 AT_CHECK([${SKIP_TEST}])
 
 if test "x$COB_BIGENDIAN" = "xyes"; then
@@ -1031,7 +1031,7 @@ else
 AT_DATA([test.conf], [
 include "cobol2002.conf"
 binary-size: 1--8
-binary-byteorder: native
+binary-byteorder: little-endian
 ])
 
 AT_DATA([dump.java], [

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -602,7 +602,7 @@ AT_CHECK([test $SHREXT != "dll" || exit 77])
 
 AT_DATA([test.conf], [
 include "default.conf"
-binary-byteorder: native
+binary-byteorder: little-endian
 ])
 
 AT_DATA([dump.c], [
@@ -656,7 +656,7 @@ AT_CHECK([test $SHREXT = "dll" || exit 77])
 
 AT_DATA([test.conf], [
 include "default.conf"
-binary-byteorder: native
+binary-byteorder: little-endian
 ])
 
 AT_DATA([dump.c], [


### PR DESCRIPTION
Because big-endian is the default byte order in Java, the value that can be set for "binary-byteorder" in the config file was changed from "`native` or `big-endian`" to "`little-endian` or `big-endian`".