### PR TITLE
Change GetTempPath2A to GetTempPathA

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1359,7 +1359,7 @@ static char *cobc_temp_name(const char *ext) {
 #ifdef _WIN32
   char temp[MAX_PATH];
 
-  GetTempPath2A(MAX_PATH, temp);
+  GetTempPathA(MAX_PATH, temp);
   GetTempFileNameA(temp, "cob", 0, buff);
   DeleteFile(buff);
   strcpy(buff + strlen(buff) - 4, ext); /* replace ".tmp" by EXT */


### PR DESCRIPTION
We found that "GetTempPath2A" is not available in Windwos 10, which causes a build error,
changed "GetTempPath2A" to "GetTempPathA" in cobj.c.
