### PR TITLE
Simplify configure.ac slightly

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -60,9 +60,6 @@
    the CoreFoundation framework. */
 #undef HAVE_CFPREFERENCESCOPYAPPVALUE
 
-/* curses has color_set function */
-#undef HAVE_COLOR_SET
-
 /* Define if the GNU dcgettext() function is already present or preinstalled.
    */
 #undef HAVE_DCGETTEXT

--- a/config.h.in
+++ b/config.h.in
@@ -82,9 +82,6 @@
 /* Define if the GNU gettext() function is already present or preinstalled. */
 #undef HAVE_GETTEXT
 
-/* Define to 1 if you have the `gettimeofday' function. */
-#undef HAVE_GETTIMEOFDAY
-
 /* Define if you have the iconv() function and it works. */
 #undef HAVE_ICONV
 

--- a/configure
+++ b/configure
@@ -20250,12 +20250,6 @@ then :
   printf "%s\n" "#define HAVE_STRTOL 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "gettimeofday" "ac_cv_func_gettimeofday"
-if test "x$ac_cv_func_gettimeofday" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETTIMEOFDAY 1" >>confdefs.h
-
-fi
 
 
 # Check for timezone

--- a/configure
+++ b/configure
@@ -3549,7 +3549,6 @@ fi
 
 
 
-
 printf "%s\n" "#define __USE_STRING_INLINES 1" >>confdefs.h
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ fi
 AC_FUNC_ALLOCA
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([memmove memset setlocale fcntl strerror \
-		strcasecmp strchr strrchr strdup strstr strtol gettimeofday])
+		strcasecmp strchr strrchr strdup strstr strtol])
 
 # Check for timezone
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <time.h>]], [[timezone = 3600;]])],

--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,6 @@ AH_TEMPLATE([COB_HAS_INLINE], [Can use inline keyword])
 AH_TEMPLATE([COB_NO_SELFOPEN], [Can not dlopen self])
 AH_TEMPLATE([COB_STRFTIME], [Can use strftime for timezone])
 AH_TEMPLATE([COB_LI_IS_LL], [long int is long long])
-AH_TEMPLATE([HAVE_COLOR_SET], [curses has color_set function])
 
 AC_DEFINE(__USE_STRING_INLINES)
 


### PR DESCRIPTION
This pull request cleans up unused macros and functions. The most important changes include removing checks for the `gettimeofday` function and the `color_set` function from the `curses` library.
This pull request resolves #505 partially.

Configuration cleanup:

* [`configure.ac`](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L74): Removed the `AH_TEMPLATE` entry for `HAVE_COLOR_SET` and the function check for `gettimeofday`. [[1]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L74) [[2]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L182-R181)