### PR TITLE
Remove COB_NON_ALIGNED and related code

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,8 @@ permissions:
 jobs:
   static_analysis:
     runs-on: ubuntu-latest
+    container:
+      image: "ubuntu:22.04"
     steps:
       # Checkout opensource COBOL
       - name: Checkout opensource COBOL 4J
@@ -21,15 +23,15 @@ jobs:
 
       - name: Install static analysis tools
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y clang-format cppcheck
+          apt-get update -y
+          apt-get install -y clang-format cppcheck
 
       - name: Install opensource COBOL 4J
         run: |
-          sudo apt-get install -y build-essential bison flex gettext texinfo autoconf
+          apt-get install -y build-essential bison flex gettext texinfo autoconf
           ./configure --prefix=/usr/
           make
-          sudo make install
+          make install
 
       - name: Check format with google-java-format and clang-format
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,9 +8,7 @@ permissions:
 
 jobs:
   static_analysis:
-    runs-on: ubuntu-latest
-    container:
-      image: "ubuntu:22.04"
+    runs-on: ubuntu-22.04
     steps:
       # Checkout opensource COBOL
       - name: Checkout opensource COBOL 4J
@@ -23,15 +21,15 @@ jobs:
 
       - name: Install static analysis tools
         run: |
-          apt-get update -y
-          apt-get install -y clang-format cppcheck
+          sudo apt-get update -y
+          sudo apt-get install -y clang-format cppcheck
 
       - name: Install opensource COBOL 4J
         run: |
-          apt-get install -y build-essential bison flex gettext texinfo autoconf
+          sudo apt-get install -y build-essential bison flex gettext texinfo autoconf
           ./configure --prefix=/usr/
           make
-          make install
+          sudo make install
 
       - name: Check format with google-java-format and clang-format
         run: |

--- a/cobj/cobj.h
+++ b/cobj/cobj.h
@@ -36,15 +36,6 @@
 #include "lib/gettext.h"
 #endif
 
-#if !defined(__i386__) && !defined(__x86_64__) && !defined(__powerpc__) &&     \
-    !defined(__powerpc64__) && !defined(__ppc__) && !defined(__amd64__)
-#define COB_NON_ALIGNED
-/* Some DEC Alphas can only directly load shorts at 4-byte aligned addresses */
-#ifdef __alpha
-#define COB_SHORT_BORK
-#endif
-#endif
-
 #define ABORT() cobc_abort(__FILE__, __LINE__)
 
 #define CB_FORMAT_FIXED 0

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2753,11 +2753,8 @@ static void joutput_search(struct cb_search *p) {
 static void joutput_call(struct cb_call *p) {
   cb_tree x;
   cb_tree l;
-  struct cb_literal *lp;
-  char *callp;
   struct cb_field *f;
   char *system_call = NULL;
-  struct system_table *psyst;
   size_t n;
   size_t retptr;
   int dynamic_link = 1;
@@ -2769,8 +2766,9 @@ static void joutput_call(struct cb_call *p) {
   }
   /* System routine entry points */
   if (p->is_system) {
-    lp = CB_LITERAL(p->name);
-    psyst = (struct system_table *)&system_tab[0];
+    struct cb_literal *lp = CB_LITERAL(p->name);
+
+    struct system_table *psyst = (struct system_table *)&system_tab[0];
     for (; psyst->syst_name; psyst++) {
       if (!strcmp((const char *)lp->data, (const char *)psyst->syst_name)) {
         system_call = (char *)psyst->syst_call;
@@ -2954,6 +2952,7 @@ static void joutput_call(struct cb_call *p) {
       }
     }
   } else {
+    char *callp;
     /* Dynamic link */
     if (CB_LITERAL_P(p->name)) {
       callp = cb_encode_program_id((char *)(CB_LITERAL(p->name)->data));

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -1974,13 +1974,6 @@ static void joutput_cond(cb_tree x, int save_flag) {
     if (save_flag) {
       joutput("(ret = ");
     }
-    //#ifdef __GNUC__
-    //		joutput_indent ("({");
-    //#else
-    //		inside_stack[inside_check] = 0;
-    //		++inside_check;
-    //		joutput ("(\n");
-    //#endif
     joutput_indent("(new GetInt() {");
     joutput_indent_level += 2;
     joutput_indent("public int run(){");
@@ -1992,12 +1985,6 @@ static void joutput_cond(cb_tree x, int save_flag) {
       }
       joutput_stmt(CB_VALUE(x), JOUTPUT_STMT_DEFAULT);
     }
-    //#ifdef __GNUC__
-    //		joutput_indent ("})");
-    //#else
-    //		--inside_check;
-    //		joutput (")");
-    //#endif
     joutput_indent_level -= 2;
     joutput_indent("}");
     joutput_indent_level -= 2;

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -2239,13 +2239,9 @@ static cb_tree build_cond_88(cb_tree x) {
 }
 
 static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
-  struct cb_field *f;
-  struct cb_field *fy;
-  const char *s;
-  size_t n;
 
   if (CB_REF_OR_FIELD_P(p->y)) {
-    fy = cb_field(p->y);
+    struct cb_field *fy = cb_field(p->y);
     if (!fy->pic->have_sign &&
         (fy->usage == CB_USAGE_BINARY || fy->usage == CB_USAGE_COMP_5 ||
          fy->usage == CB_USAGE_COMP_X)) {
@@ -2254,7 +2250,7 @@ static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
     }
   }
   if (CB_REF_OR_FIELD_P(p->x)) {
-    f = cb_field(p->x);
+    struct cb_field *f = cb_field(p->x);
     if (!f->pic->scale && f->usage == CB_USAGE_PACKED) {
       if (f->pic->digits < 10) {
         return cb_build_method_call_2("cmpInt", p->x,
@@ -2291,9 +2287,9 @@ static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
     if (!f->pic->scale &&
         (f->usage == CB_USAGE_BINARY || f->usage == CB_USAGE_COMP_5 ||
          f->usage == CB_USAGE_INDEX || f->usage == CB_USAGE_COMP_X)) {
-      n = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
-          (16 * (f->flag_binary_swap ? 1 : 0));
-      s = bin_compare_funcs[n];
+      size_t n = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
+                 (16 * (f->flag_binary_swap ? 1 : 0));
+      const char *s = bin_compare_funcs[n];
       if (s) {
         return cb_build_method_call_2(s, cb_build_cast_address(p->x),
                                       cb_build_cast_integer(p->y));
@@ -2540,17 +2536,13 @@ cb_tree cb_build_cond(cb_tree x) {
  */
 
 static cb_tree cb_build_optim_add(cb_tree v, cb_tree n) {
-  size_t z;
-  const char *s;
-  struct cb_field *f;
-
   if (CB_REF_OR_FIELD_P(v)) {
-    f = cb_field(v);
+    struct cb_field *f = cb_field(v);
     if (!f->pic->scale &&
         (f->usage == CB_USAGE_BINARY || f->usage == CB_USAGE_COMP_5 ||
          f->usage == CB_USAGE_COMP_X)) {
-      z = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
-          (16 * (f->flag_binary_swap ? 1 : 0));
+      size_t z = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
+                 (16 * (f->flag_binary_swap ? 1 : 0));
       if (f->usage == CB_USAGE_COMP_5) {
         switch (f->size) {
         case 1:
@@ -2560,7 +2552,7 @@ static cb_tree cb_build_optim_add(cb_tree v, cb_tree n) {
           return cb_build_assign(v, cb_build_binary_op(v, '+', n));
         }
       }
-      s = bin_add_funcs[z];
+      const char *s = bin_add_funcs[z];
       if (s) {
         return cb_build_method_call_2(s, cb_build_cast_address(v),
                                       cb_build_cast_integer(n));
@@ -2575,17 +2567,14 @@ static cb_tree cb_build_optim_add(cb_tree v, cb_tree n) {
 }
 
 static cb_tree cb_build_optim_sub(cb_tree v, cb_tree n) {
-  size_t z;
-  const char *s;
-  struct cb_field *f;
 
   if (CB_REF_OR_FIELD_P(v)) {
-    f = cb_field(v);
+    struct cb_field *f = cb_field(v);
     if (!f->pic->scale &&
         (f->usage == CB_USAGE_BINARY || f->usage == CB_USAGE_COMP_5 ||
          f->usage == CB_USAGE_COMP_X)) {
-      z = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
-          (16 * (f->flag_binary_swap ? 1 : 0));
+      size_t z = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
+                 (16 * (f->flag_binary_swap ? 1 : 0));
       if (f->usage == CB_USAGE_COMP_5) {
         switch (f->size) {
         case 1:
@@ -2595,7 +2584,7 @@ static cb_tree cb_build_optim_sub(cb_tree v, cb_tree n) {
           return cb_build_assign(v, cb_build_binary_op(v, '-', n));
         }
       }
-      s = bin_sub_funcs[z];
+      const char *s = bin_sub_funcs[z];
       if (s) {
         return cb_build_method_call_2(s, cb_build_cast_address(v),
                                       cb_build_cast_integer(n));


### PR DESCRIPTION
In order to to resolve the problem reported in #508, this pull request focuses on removing support for non-aligned memory access and simplifying the codebase by eliminating related conditional code. The most important changes involve the removal of `COB_NON_ALIGNED` and `COB_SHORT_BORK` preprocessor directives and the associated conditional code blocks.

The problem reported in #508 is caused by C macros changing some code due to differences in the CPU architecture of the machines that build opensource COBOL 4J.

While differences of CPU architecture are important in opensource COBOL, they do not need to be considered in opensource COBOL 4J, so the relevant code has been removed.