### PR TITLE
Fix numericCompareTo()

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolNumericField.java
@@ -911,7 +911,7 @@ public class CobolNumericField extends AbstractCobolField {
         final int i1 = firstIndex1 + i + pointIndex1;
         final int i2 = firstIndex2 + i + pointIndex2;
         byte b1;
-        if (i1 < 0 || i1 > lastIndex1) {
+        if (i1 < firstIndex1 || i1 > lastIndex1) {
           b1 = (byte) '0';
         } else {
           b1 = d1.getByte(i1);
@@ -920,7 +920,7 @@ public class CobolNumericField extends AbstractCobolField {
           }
         }
         byte b2;
-        if (i2 < 0 || i2 > lastIndex2) {
+        if (i2 < firstIndex2 || i2 > lastIndex2) {
           b2 = (byte) '0';
         } else {
           b2 = d2.getByte(i2);

--- a/tests/misc.src/compare-9.at
+++ b/tests/misc.src/compare-9.at
@@ -57,3 +57,34 @@ AT_CHECK([${COBJ} prog.cbl])
 AT_CHECK([java prog])
 
 AT_CLEANUP
+
+AT_SETUP([compare 9(n), S9(n) SEPARATE])
+
+AT_DATA([prog.cbl], [
+	   IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE SECTION.
+       01  N10 PIC 9(10).
+       01  S9-L PIC S9(9) SIGN LEADING SEPARATE.
+       01  S9-T PIC S9(9) SIGN TRAILING SEPARATE.
+       PROCEDURE        DIVISION.
+       MAIN-PROC.
+      *************************************************************
+          MOVE 800 TO N10.
+          MOVE 900 TO S9-L.
+          MOVE 900 TO S9-T.
+
+          IF N10 >= S9-L
+              DISPLAY "NG (N10 >= S9-L)"
+          END-IF.
+
+          IF N10 >= S9-T
+              DISPLAY "NG (N10 >= S9-T)"
+          END-IF.
+])
+
+AT_CHECK([${COBJ} prog.cbl])
+AT_CHECK([java prog])
+
+AT_CLEANUP


### PR DESCRIPTION
Fixed the problem that sign and numeric values are compared when comparing `PIC9(n) SIGN LEADING SEPARATE` and `PIC9(n - 1)` values. (n > 10)
For example, in a test case I added, 
before the modification, when N10 and S9-L were compared, the first digit '0' of N10 was compared with the first digit '+' of S9-L.
Therefore, the result was that N10 was larger than S9-L even though a smaller value was assigned to N10.
The correction I made improved the comparison to start with the digit containing the S9-L value.