### PR TITLE
Disable cppcheck and clang-format

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -31,9 +31,9 @@ jobs:
           make
           sudo make install
 
-      - name: Check format with google-java-format and clang-format
-        run: |
-          ./check-format
+      #- name: Check format with google-java-format and clang-format
+      #  run: |
+      #    ./check-format
 
       - name: Run SpotBugs
         working-directory: libcobj
@@ -45,7 +45,7 @@ jobs:
         run: |
           ./gradlew pmdMain
 
-      - name: Run cppcheck
-        working-directory: cobj
-        run: |
-          ./cpp-check
+      #- name: Run cppcheck
+      #  working-directory: cobj
+      #  run: |
+      #    ./cpp-check


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/static-analysis.yml` file, specifically commenting out certain static analysis checks. The most important changes are:

Static analysis workflow adjustments:

* Commented out the step for checking format with `google-java-format` and `clang-format`. (`.github/workflows/static-analysis.yml`, [.github/workflows/static-analysis.ymlL34-R36](diffhunk://#diff-e9db86b6fd5f791eb849075b600b921e5e95b978e41f9d290c01027440076ec3L34-R36))
* Commented out the step for running `cppcheck` in the `cobj` directory. (`.github/workflows/static-analysis.yml`, [.github/workflows/static-analysis.ymlL48-R51](diffhunk://#diff-e9db86b6fd5f791eb849075b600b921e5e95b978e41f9d290c01027440076ec3L48-R51))