### PR TITLE
Fix doc/cobj-api_SpringBoot.md

### DIFF
--- a/doc/cobj-api_SpringBoot.md
+++ b/doc/cobj-api_SpringBoot.md
@@ -99,7 +99,7 @@ The project will be created according to the above steps.
    ```
     cobj-api -java-package=com.example.cobj_api_test info_sample.json
     ```
-   * `-java-package`：生成されるJavaファイルのパッケージ名を指定するオプション。
+   * `-java-package`: An option to specify the package name of the generated Java file.
 
     This will generate sampleController.java and sampleRecord.java.
 4. Place sample.java, sampleController.java, and sampleRecord.java in the created Spring Boot project.   


### PR DESCRIPTION
This pull request includes a minor change to the `doc/cobj-api_SpringBoot.md` file to translate the Japanese description of the `-java-package` option to the English one.