### PR TITLE
Fix CI `update-github-pages.yml`

### DIFF
--- a/.github/workflows/update-github-pages.yml
+++ b/.github/workflows/update-github-pages.yml
@@ -26,6 +26,7 @@ jobs:
 
   # Single deploy job since we're just deploying
   deploy:
+    if: github.repository == 'opensourcecobol/opensourcecobol4j'
     needs: check-workflows
     environment:
       name: github-pages
@@ -39,7 +40,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-   
+
       - name: Build Javadoc
         working-directory: libcobj
         run: |

--- a/.github/workflows/update-github-pages.yml
+++ b/.github/workflows/update-github-pages.yml
@@ -26,12 +26,12 @@ jobs:
 
   # Single deploy job since we're just deploying
   deploy:
+    if: github.repository == 'opensourcecobol/opensourcecobol4j'
     needs: check-workflows
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: github.repository == 'opensourcecobol/opensourcecobol4j'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update-github-pages.yml
+++ b/.github/workflows/update-github-pages.yml
@@ -26,12 +26,12 @@ jobs:
 
   # Single deploy job since we're just deploying
   deploy:
-    if: github.repository == 'opensourcecobol/opensourcecobol4j'
     needs: check-workflows
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: github.repository == 'opensourcecobol/opensourcecobol4j'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Related to #522

This pull request includes a small but significant change to the GitHub Actions workflow file `.github/workflows/update-github-pages.yml`. The change ensures that the deploy job only runs for a specific repository.

* `.github/workflows/update-github-pages.yml`: Added a condition to the `deploy` job to check if the repository is `opensourcecobol/opensourcecobol4j`.

* I have confirmed that `deploy` job is skipped by running it manually on the browser.