### PR TITLE
Fix CI to upload files to Release page

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,15 @@ on:
       - v*.*.*
 
 jobs:
+  check-workflows:
+    uses: ./.github/workflows/check-workflows.yml
+
+  build-artifacts:
+    needs: check-workflows
+    uses: ./.github/workflows/windows-build.yml
+    with: 
+      upload-artifacts: true
+
   create-release:
     runs-on: windows-latest
     env:
@@ -16,3 +25,19 @@ jobs:
 
     - name: Create a Release
       run: gh release create ${{ github.ref }} -F ReleaseNote.md
+
+    - name: Download cobj.exe
+      uses: actions/download-artifact@v4
+      with:
+        name: cobj.exe
+
+    - name: Download libcobj.jar
+      uses: actions/download-artifact@v4
+      with:
+        name: libcobj.jar
+
+    - name: Publish artifacts
+      run: | 
+        gh release upload ${{ github.ref_name }} cobj.exe --clobber
+        gh release upload ${{ github.ref_name }} libcobj.jar --clobber
+        

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,4 +43,5 @@ jobs:
       run: | 
         gh release upload ${{ github.ref_name }} cobj.exe --clobber
         gh release upload ${{ github.ref_name }} libcobj.jar --clobber
+        gh release upload ${{ github.ref_name }} config/default.conf --clobber
         

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,10 @@ jobs:
       upload-artifacts: true
 
   create-release:
-    runs-on: windows-latest
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -103,6 +103,8 @@ jobs:
     strategy:
        fail-fast: false
     uses: ./.github/workflows/windows-build.yml
+    with: 
+      upload-artifacts: true
 
   windows-test:
     needs: windows-build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -101,6 +101,8 @@ jobs:
     strategy:
        fail-fast: false
     uses: ./.github/workflows/windows-build.yml
+    with: 
+      upload-artifacts: true
 
   windows-test:
     needs: windows-build

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,6 +2,11 @@ name: build opensource COBOL 4J on Windows
 
 on:
   workflow_call:
+    inputs:
+      upload-artifacts:
+        description: 'Upload artifacts'
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -32,12 +37,14 @@ jobs:
         run: msbuild /p:Configuration=Release /p:AdditionalIncludePaths=./:./cobj/:./win:./lib win/opensourcecobol4j.sln
       
       - name: Upload libcobj.jar
+        if: ${{inputs.upload-artifacts}}
         uses: actions/upload-artifact@v4
         with:
           name: libcobj.jar
           path: libcobj/app/build/libs/libcobj.jar 
       
       - name: Upload cobj.exe
+        if: ${{inputs.upload-artifacts}}
         uses: actions/upload-artifact@v4
         with:
           name: cobj.exe


### PR DESCRIPTION
Fixed CI to upload files (cobj.exe, libcobj.jar, default.conf) to Release page
These files were uploaded manually until now for the Widows environment.
Modified CI to reduce release effort.