### PR TITLE
Fix invalid constructors in record class generated by cobj-api

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/ApiFiles.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/ApiFiles.java
@@ -235,7 +235,7 @@ class ApiFiles {
 
     argPrint(rcdWriter, params, true, false);
 
-    rcdWriter.print(") {\n" + "    public LOANSUBRecord(){\n" + "        this(200, ");
+    rcdWriter.print(") {\n" + "    public " + programId + "Record(){\n" + "        this(200, ");
     for (i = 0; i < params.length(); ++i) {
       param = params.getJSONObject(i);
       type = param.getString("java_type");

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/testRecord.txt
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/testRecord.txt
@@ -1,6 +1,6 @@
 package com.example.restservice;
 public record testRecord(int statuscode, int param1, double param2, String param3) {
-    public LOANSUBRecord(){
+    public testRecord(){
         this(200, 0, 0, "");
     }
 }


### PR DESCRIPTION
This pull request includes changes to improve the naming consistency of record classes in the `libcobj` module.

### Naming Consistency Improvements:

* [`libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/ApiFiles.java`](diffhunk://#diff-fbaac7586955599ec3e6234a823f8cfad8a3983cc049e26a4663a2678f27a38fL238-R238): Updated the record class name to use `programId` for dynamic naming.
* [`libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/user_util/cobj_api/testRecord.txt`](diffhunk://#diff-4bb21df27d68e2d54f0a0700a87e0371800ddb7fc783cf18ac40d22d28d2f194L3-R3): Renamed the `LOANSUBRecord` to `testRecord` for consistency.