### PR TITLE
Fix pre-commit

### DIFF
--- a/.devcontainer/term_settings/pre-commit
+++ b/.devcontainer/term_settings/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-git add -u
 ./format
+git add -u


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/term_settings/pre-commit` file. The change reorders the `git add -u` command to ensure it runs after the `./format` script.