### PR TITLE
update libcobj/.gitignore

### DIFF
--- a/libcobj/.gitignore
+++ b/libcobj/.gitignore
@@ -10,3 +10,4 @@ sqlite/sqlite.jar
 build
 
 app/src/main/java/javadoc.log
+app/bin


### PR DESCRIPTION
This pull request includes a small change to the `.gitignore` file in the `libcobj` directory. The change adds the `app/bin` directory to the list of ignored files.

* [`libcobj/.gitignore`](diffhunk://#diff-8f733745dd5177c55058f4eff8de4b79a7cb9101b6806ed4cb7e770bdfa7a7d2R13): Added `app/bin` to the list of ignored files.