### PR TITLE
Refactor very slightly

### DIFF
--- a/cobj/tree.c
+++ b/cobj/tree.c
@@ -1724,7 +1724,6 @@ struct cb_file *build_file(cb_tree name) {
   p->cname = to_cname(p->name);
 
   p->organization = cb_default_organization;
-  ;
   p->access_mode = COB_ACCESS_SEQUENTIAL;
   p->handler = CB_LABEL(cb_standard_error_handler);
   p->handler_prog = current_program;


### PR DESCRIPTION
This pull request includes a small change to the `cobj/tree.c` file. The change removes an unnecessary semicolon from the `build_file` function.