### PR TITLE
Add 'unzip' to the tools installed in Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,4 +9,4 @@ RUN echo 'export CLASSPATH=:/usr/lib/opensourcecobol4j/libcobj.jar' >> ~/.bashrc
 # install dependencies
 RUN dnf update -y
 RUN dnf install -y epel-release
-RUN dnf install -y gcc make bison flex automake autoconf diffutils gettext java-21-openjdk-devel git-clang-format cppcheck libtool gettext-devel
+RUN dnf install -y gcc make bison flex automake autoconf diffutils gettext java-21-openjdk-devel git-clang-format cppcheck libtool gettext-devel unzip

--- a/cobj/pplex.c
+++ b/cobj/pplex.c
@@ -379,7 +379,7 @@ typedef unsigned int flex_uint32_t;
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start)-1) / 2)
+#define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
@@ -2632,8 +2632,8 @@ YY_DECL {
       default:
         YY_FATAL_ERROR("fatal flex scanner internal error--no action found");
       } /* end of action switch */
-    }   /* end of scanning one token */
-  }     /* end of user's declarations */
+    } /* end of scanning one token */
+  } /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer


### PR DESCRIPTION
'-m' test of command-line options within the Dev Container environment failed due to the absence of 'unzip'. Therefore, I modified the Dockerfile to include the installation of 'unzip'.

test log:
```
#                             -*- compilation -*-
7. m.at:1: testing -m ...
./m.at:12: touch hello.txt
./m.at:14: ${COBJ} -m prog.cbl
./m.at:15: CLASSPATH=$CLASSPATH:./prog.jar java prog
./m.at:19: mkdir tmp && mv prog.jar tmp && cd tmp && unzip prog.jar > /dev/null
--- /dev/null	2024-11-19 00:53:10.830684202 +0000
+++ /workspaces/opensourcecobol4j/tests/command-line-options.dir/at-groups/7/stderr	2024-11-19 00:55:57.589857026 +0000
@@ -0,0 +1 @@
+/workspaces/opensourcecobol4j/tests/command-line-options.dir/at-groups/7/test-source: line 66: unzip: command not found
./m.at:19: exit code was 127, expected 0
7. m.at:1: 7. -m (m.at:1): FAILED (m.at:19)
```