### PR TITLE
Remove unnecessary settings

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,9 +17,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  CLASSPATH: ":/usr/lib/opensourcecobol4j/libcobj.jar"
-
 jobs:
   check-workflows:
     uses: ./.github/workflows/check-workflows.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,9 +16,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  CLASSPATH: ":/usr/lib/opensourcecobol4j/libcobj.jar"
-
 jobs:
   check-workflows:
     uses: ./.github/workflows/check-workflows.yml

--- a/cobj/pplex.c
+++ b/cobj/pplex.c
@@ -379,7 +379,7 @@ typedef unsigned int flex_uint32_t;
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start) - 1) / 2)
+#define YY_START (((yy_start)-1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
@@ -2632,8 +2632,8 @@ YY_DECL {
       default:
         YY_FATAL_ERROR("fatal flex scanner internal error--no action found");
       } /* end of action switch */
-    } /* end of scanning one token */
-  } /* end of user's declarations */
+    }   /* end of scanning one token */
+  }     /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows configuration files, specifically `.github/workflows/pull-request.yml` and `.github/workflows/push.yml`. The primary change involves the removal of the `env` section that sets the `CLASSPATH` environment variable.

Changes to GitHub workflows configuration:

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L20-L22): Removed the `env` section that sets the `CLASSPATH` environment variable.
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L19-L21): Removed the `env` section that sets the `CLASSPATH` environment variable.