### PR TITLE
fix comparison of COMP data

### DIFF
--- a/cobj/pplex.c
+++ b/cobj/pplex.c
@@ -379,7 +379,7 @@ typedef unsigned int flex_uint32_t;
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start)-1) / 2)
+#define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
@@ -2632,8 +2632,8 @@ YY_DECL {
       default:
         YY_FATAL_ERROR("fatal flex scanner internal error--no action found");
       } /* end of action switch */
-    }   /* end of scanning one token */
-  }     /* end of user's declarations */
+    } /* end of scanning one token */
+  } /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer

--- a/cobj/pplex.c
+++ b/cobj/pplex.c
@@ -379,7 +379,7 @@ typedef unsigned int flex_uint32_t;
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
-#define YY_START (((yy_start) - 1) / 2)
+#define YY_START (((yy_start)-1) / 2)
 #define YYSTATE YY_START
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
@@ -2632,8 +2632,8 @@ YY_DECL {
       default:
         YY_FATAL_ERROR("fatal flex scanner internal error--no action found");
       } /* end of action switch */
-    } /* end of scanning one token */
-  } /* end of user's declarations */
+    }   /* end of scanning one token */
+  }     /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -114,16 +114,6 @@ static const char *const bin_set_funcs[] = {NULL,
                                             "setSwpS56Binary",
                                             "setSwpS64Binary"};
 
-static const char *const bin_compare_funcs[] = {
-    "cmpU8Binary",     "cmpU16Binary",    "cmpU24Binary",    "cmpU32Binary",
-    "cmpU40Binary",    "cmpU48Binary",    "cmpU56Binary",    "cmpU64Binary",
-    "cmpS8Binary",     "cmpS16Binary",    "cmpS24Binary",    "cmpS32Binary",
-    "cmpS40Binary",    "cmpS48Binary",    "cmpS56Binary",    "cmpS64Binary",
-    "cmpU8Binary",     "cmpSwpU16Binary", "cmpSwpU24Binary", "cmpSwpU32Binary",
-    "cmpSwpU40Binary", "cmpSwpU48Binary", "cmpSwpU56Binary", "cmpSwpU64Binary",
-    "cmpS8Binary",     "cmpSwpS16Binary", "cmpSwpS24Binary", "cmpSwpS32Binary",
-    "cmpSwpS40Binary", "cmpSwpS48Binary", "cmpSwpS56Binary", "cmpSwpS64Binary"};
-
 static const char *const bin_add_funcs[] = {
     "addU8Binary",     "addU16Binary",    "addU24Binary",    "addU32Binary",
     "addU40Binary",    "addU48Binary",    "addU56Binary",    "addU64Binary",
@@ -2245,7 +2235,7 @@ static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
     if (!fy->pic->have_sign &&
         (fy->usage == CB_USAGE_BINARY || fy->usage == CB_USAGE_COMP_5 ||
          fy->usage == CB_USAGE_COMP_X)) {
-      return cb_build_method_call_2("cmpUint", p->x,
+      return cb_build_method_call_2("cmpInteger", p->x,
                                     cb_build_cast_integer(p->y));
     }
   }
@@ -2253,10 +2243,10 @@ static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
     struct cb_field *f = cb_field(p->x);
     if (!f->pic->scale && f->usage == CB_USAGE_PACKED) {
       if (f->pic->digits < 10) {
-        return cb_build_method_call_2("cmpInt", p->x,
+        return cb_build_method_call_2("cmpInteger", p->x,
                                       cb_build_cast_integer(p->y));
       } else {
-        return cb_build_method_call_2("cmpInt", p->x,
+        return cb_build_method_call_2("cmpInteger", p->x,
                                       cb_build_cast_integer(p->y));
       }
     }
@@ -2287,16 +2277,12 @@ static cb_tree cb_build_optim_cond(struct cb_binary_op *p) {
     if (!f->pic->scale &&
         (f->usage == CB_USAGE_BINARY || f->usage == CB_USAGE_COMP_5 ||
          f->usage == CB_USAGE_INDEX || f->usage == CB_USAGE_COMP_X)) {
-      size_t n = (f->size - 1) + (8 * (f->pic->have_sign ? 1 : 0)) +
-                 (16 * (f->flag_binary_swap ? 1 : 0));
-      const char *s = bin_compare_funcs[n];
-      if (s) {
-        return cb_build_method_call_2(s, cb_build_cast_address(p->x),
-                                      cb_build_cast_integer(p->y));
-      }
+      return cb_build_method_call_2("cmpInteger", p->x,
+                                    cb_build_cast_integer(p->y));
     }
   }
-  return cb_build_method_call_2("cmpInt", p->x, cb_build_cast_integer(p->y));
+  return cb_build_method_call_2("cmpInteger", p->x,
+                                cb_build_cast_integer(p->y));
 }
 
 static int cb_chk_num_cond(cb_tree x, cb_tree y) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -414,10 +414,10 @@ public abstract class AbstractCobolField {
     }
 
     /**
-     * TODO: 準備中
-     *
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * 整数値との比較を行う
+     * @deprecated 代わりにcmpIntegerを使用してください
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
      */
     public int cmpInt(int n) {
         CobolDecimal d1 = this.getDecimal();
@@ -427,10 +427,10 @@ public abstract class AbstractCobolField {
     }
 
     /**
-     * TODO: 準備中
-     *
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * 整数値との比較を行う
+     * @deprecated 代わりにcmpIntegerを使用してください
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
      */
     public int cmpInt(long n) {
         return this.cmpInt((int) n);
@@ -458,20 +458,20 @@ public abstract class AbstractCobolField {
     }
 
     /**
-     * TODO: 準備中
-     *
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * 整数値との比較を行う
+     * @deprecated 代わりにcmpIntegerを使用してください
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
      */
     public int cmpUint(int n) {
         return this.cmpInt(n);
     }
 
     /**
-     * TODO: 準備中
-     *
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * 整数値との比較を行う
+     * @deprecated 代わりにcmpIntegerを使用してください
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
      */
     public int cmpUint(long n) {
         return this.cmpUint((int) n);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -437,6 +437,27 @@ public abstract class AbstractCobolField {
     }
 
     /**
+     * 整数値との比較を行う
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
+     */
+    public int cmpInteger(long n) {
+        CobolDecimal d1 = this.getDecimal();
+        CobolDecimal d2 = new CobolDecimal(n);
+        d2.setScale(0);
+        return d1.compareTo(d2);
+    }
+
+    /**
+     * 整数値との比較を行う
+     * @param n 比較対象の整数値
+     * @return 保持する数値データの比較を行い,this&lt;nなら負の値,this==nなら0,this&gt;nなら正の値
+     */
+    public int cmpInteger(int n) {
+        return this.cmpInteger((long) n);
+    }
+
+    /**
      * TODO: 準備中
      *
      * @param n TODO: 準備中

--- a/tests/data-rep.src/binary.at
+++ b/tests/data-rep.src/binary.at
@@ -1277,3 +1277,261 @@ AT_CHECK([java prog], [0],
 ])
 
 AT_CLEANUP
+
+# compare COMP data
+
+AT_SETUP([compare COMP])
+
+AT_DATA([prog.cbl],[
+       identification division.
+       program-id. prog.
+       data division.
+       working-storage section.
+       01 u9 pic 9(9) comp.
+       01 u18 pic 9(18) comp.
+       01 s4 pic s9(4) comp.
+       01 s9 pic s9(9) comp.
+       01 s18 pic s9(18) comp.
+       procedure division.
+       move 2 to u9. move -1 to s4.
+       if u9 <= s4 then display "ng 00-00" end-if.
+       move 2 to u9. move -3 to s4.
+       if u9 <= s4 then display "ng 00-01" end-if.
+       move 2 to u9. move -9999 to s4.
+       if u9 <= s4 then display "ng 00-02" end-if.
+       move 2 to u9. move 0 to s4.
+       if u9 <= s4 then display "ng 00-03" end-if.
+       move 2 to u9. move 1 to s4.
+       if u9 <= s4 then display "ng 00-04" end-if.
+       move 2 to u9. move 2 to s4.
+       if u9 <> s4 then display "ng 00-05" end-if.
+       move 2 to u9. move 3 to s4.
+       if u9 >= s4 then display "ng 00-06" end-if.
+       move 2 to u9. move 9999 to s4.
+       if u9 >= s4 then display "ng 00-06" end-if.
+       move 0 to u9. move -1 to s4.
+       if u9 <= s4 then display "ng 00-07" end-if.
+       move 0 to u9. move -3 to s4.
+       if u9 <= s4 then display "ng 00-08" end-if.
+       move 0 to u9. move -9999 to s4.
+       if u9 <= s4 then display "ng 00-09" end-if.
+       move 0 to u9. move 0 to s4.
+       if u9 <> s4 then display "ng 00-10" end-if.
+       move 0 to u9. move 1 to s4.
+       if u9 >= s4 then display "ng 00-11" end-if.
+       move 0 to u9. move 2 to s4.
+       if u9 >= s4 then display "ng 00-12" end-if.
+       move 0 to u9. move 3 to s4.
+       if u9 >= s4 then display "ng 00-13" end-if.
+       move 0 to u9. move 9999 to s4.
+       if u9 >= s4 then display "ng 00-14" end-if.
+       move 999999999 to u9. move -1 to s4.
+       if u9 <= s4 then display "ng 00-15" end-if.
+       move 999999999 to u9. move -3 to s4.
+       if u9 <= s4 then display "ng 00-16" end-if.
+       move 999999999 to u9. move -9999 to s4.
+       if u9 <= s4 then display "ng 00-17" end-if.
+       move 999999999 to u9. move 0 to s4.
+       if u9 <= s4 then display "ng 00-18" end-if.
+       move 999999999 to u9. move 1 to s4.
+       if u9 <= s4 then display "ng 00-19" end-if.
+       move 999999999 to u9. move 2 to s4.
+       if u9 <= s4 then display "ng 00-20" end-if.
+       move 999999999 to u9. move 9999 to s4.
+       if u9 <= s4 then display "ng 00-21" end-if.
+      ******************************************************************
+       move 2 to u9. move -1 to s9.
+       if u9 <= s9 then display "ng 01-00" end-if.
+       move 2 to u9. move -3 to s9.
+       if u9 <= s9 then display "ng 01-01" end-if.
+       move 2 to u9. move -999999999 to s9.
+       if u9 <= s9 then display "ng 01-02" end-if.
+       move 2 to u9. move 0 to s9.
+       if u9 <= s9 then display "ng 01-03" end-if.
+       move 2 to u9. move 1 to s9.
+       if u9 <= s9 then display "ng 01-04" end-if.
+       move 2 to u9. move 2 to s9.
+       if u9 <> s9 then display "ng 01-05" end-if.
+       move 2 to u9. move 3 to s9.
+       if u9 >= s9 then display "ng 01-06" end-if.
+       move 2 to u9. move 999999999 to s9.
+       if u9 >= s9 then display "ng 01-06" end-if.
+       move 0 to u9. move -1 to s9.
+       if u9 <= s9 then display "ng 01-07" end-if.
+       move 0 to u9. move -3 to s9.
+       if u9 <= s9 then display "ng 01-08" end-if.
+       move 0 to u9. move -999999999 to s9.
+       if u9 <= s9 then display "ng 01-09" end-if.
+       move 0 to u9. move 0 to s9.
+       if u9 <> s9 then display "ng 01-10" end-if.
+       move 0 to u9. move 1 to s9.
+       if u9 >= s9 then display "ng 01-11" end-if.
+       move 0 to u9. move 2 to s9.
+       if u9 >= s9 then display "ng 01-12" end-if.
+       move 0 to u9. move 3 to s9.
+       if u9 >= s9 then display "ng 01-13" end-if.
+       move 0 to u9. move 999999999 to s9.
+       if u9 >= s9 then display "ng 01-14" end-if.
+       move 999999999 to u9. move -1 to s9.
+       if u9 <= s9 then display "ng 01-15" end-if.
+       move 999999999 to u9. move -3 to s9.
+       if u9 <= s9 then display "ng 01-16" end-if.
+       move 999999999 to u9. move -999999999 to s9.
+       if u9 <= s9 then display "ng 01-17" end-if.
+       move 999999999 to u9. move 0 to s9.
+       if u9 <= s9 then display "ng 01-18" end-if.
+       move 999999999 to u9. move 1 to s9.
+       if u9 <= s9 then display "ng 01-19" end-if.
+       move 999999999 to u9. move 2 to s9.
+       if u9 <= s9 then display "ng 01-20" end-if.
+       move 999999999 to u9. move 999999999 to s9.
+       if u9 <> s9 then display "ng 01-21" end-if.
+      ******************************************************************
+       move 2 to u9. move -1 to s18.
+       if u9 <= s18 then display "ng 02-00" end-if.
+       move 2 to u9. move -3 to s18.
+       if u9 <= s18 then display "ng 02-01" end-if.
+       move 2 to u9. move -999999999999999999 to s18.
+       if u9 <= s18 then display "ng 02-02" end-if.
+       move 2 to u9. move 0 to s18.
+       if u9 <= s18 then display "ng 02-03" end-if.
+       move 2 to u9. move 1 to s18.
+       if u9 <= s18 then display "ng 02-04" end-if.
+       move 2 to u9. move 2 to s18.
+       if u9 <> s18 then display "ng 02-05" end-if.
+       move 2 to u9. move 3 to s18.
+       if u9 >= s18 then display "ng 02-06" end-if.
+       move 2 to u9. move 999999999999999999 to s18.
+       if u9 >= s18 then display "ng 02-06" end-if.
+       move 0 to u9. move -1 to s18.
+       if u9 <= s18 then display "ng 02-07" end-if.
+       move 0 to u9. move -3 to s18.
+       if u9 <= s18 then display "ng 02-08" end-if.
+       move 0 to u9. move -999999999999999999 to s18.
+       if u9 <= s18 then display "ng 02-09" end-if.
+       move 0 to u9. move 0 to s18.
+       if u9 <> s18 then display "ng 02-10" end-if.
+       move 0 to u9. move 1 to s18.
+       if u9 >= s18 then display "ng 02-11" end-if.
+       move 0 to u9. move 2 to s18.
+       if u9 >= s18 then display "ng 02-12" end-if.
+       move 0 to u9. move 3 to s18.
+       if u9 >= s18 then display "ng 02-13" end-if.
+       move 0 to u9. move 999999999999999999 to s18.
+       if u9 >= s18 then display "ng 02-14" end-if.
+       move 999999999 to u9. move -1 to s18.
+       if u9 <= s18 then display "ng 02-15" end-if.
+       move 999999999 to u9. move -3 to s18.
+       if u9 <= s18 then display "ng 02-16" end-if.
+       move 999999999 to u9. move -999999999999999999 to s18.
+       if u9 <= s18 then display "ng 02-17" end-if.
+       move 999999999 to u9. move 0 to s18.
+       if u9 <= s18 then display "ng 02-18" end-if.
+       move 999999999 to u9. move 1 to s18.
+       if u9 <= s18 then display "ng 02-19" end-if.
+       move 999999999 to u9. move 2 to s18.
+       if u9 <= s18 then display "ng 02-20" end-if.
+       move 999999999 to u9. move 999999999999999999 to s18.
+       if u9 >= s18 then display "ng 02-21" end-if.
+      ******************************************************************
+       move 2 to u18. move -1 to s9.
+       if u18 <= s9 then display "ng 03-00" end-if.
+       move 2 to u18. move -3 to s9.
+       if u18 <= s9 then display "ng 03-01" end-if.
+       move 2 to u18. move -999999999 to s9.
+       if u18 <= s9 then display "ng 03-02" end-if.
+       move 2 to u18. move 0 to s9.
+       if u18 <= s9 then display "ng 03-03" end-if.
+       move 2 to u18. move 1 to s9.
+       if u18 <= s9 then display "ng 03-04" end-if.
+       move 2 to u18. move 2 to s9.
+       if u18 <> s9 then display "ng 03-05" end-if.
+       move 2 to u18. move 3 to s9.
+       if u18 >= s9 then display "ng 03-06" end-if.
+       move 2 to u18. move 999999999 to s9.
+       if u18 >= s9 then display "ng 03-06" end-if.
+       move 0 to u18. move -1 to s9.
+       if u18 <= s9 then display "ng 03-07" end-if.
+       move 0 to u18. move -3 to s9.
+       if u18 <= s9 then display "ng 03-08" end-if.
+       move 0 to u18. move -999999999 to s9.
+       if u18 <= s9 then display "ng 03-09" end-if.
+       move 0 to u18. move 0 to s9.
+       if u18 <> s9 then display "ng 03-10" end-if.
+       move 0 to u18. move 1 to s9.
+       if u18 >= s9 then display "ng 03-11" end-if.
+       move 0 to u18. move 2 to s9.
+       if u18 >= s9 then display "ng 03-12" end-if.
+       move 0 to u18. move 3 to s9.
+       if u18 >= s9 then display "ng 03-13" end-if.
+       move 0 to u18. move 999999999 to s9.
+       if u18 >= s9 then display "ng 03-14" end-if.
+       move 999999999999999999 to u18. move -1 to s9.
+       if u18 <= s9 then display "ng 03-15" end-if.
+       move 999999999999999999 to u18. move -3 to s9.
+       if u18 <= s9 then display "ng 03-16" end-if.
+       move 999999999999999999 to u18. move -999999999 to s9.
+       if u18 <= s9 then display "ng 03-17" end-if.
+       move 999999999999999999 to u18. move 0 to s9.
+       if u18 <= s9 then display "ng 03-18" end-if.
+       move 999999999999999999 to u18. move 1 to s9.
+       if u18 <= s9 then display "ng 03-19" end-if.
+       move 999999999999999999 to u18. move 2 to s9.
+       if u18 <= s9 then display "ng 03-20" end-if.
+       move 999999999999999999 to u18. move 999999999 to s9.
+       if u18 <= s9 then display "ng 03-21" end-if.
+      ******************************************************************
+       move 2 to u18. move -1 to s18.
+       if u18 <= s18 then display "ng 04-00" end-if.
+       move 2 to u18. move -3 to s18.
+       if u18 <= s18 then display "ng 04-01" end-if.
+       move 2 to u18. move -999999999999999999 to s18.
+       if u18 <= s18 then display "ng 04-02" end-if.
+       move 2 to u18. move 0 to s18.
+       if u18 <= s18 then display "ng 04-03" end-if.
+       move 2 to u18. move 1 to s18.
+       if u18 <= s18 then display "ng 04-04" end-if.
+       move 2 to u18. move 2 to s18.
+       if u18 <> s18 then display "ng 04-05" end-if.
+       move 2 to u18. move 3 to s18.
+       if u18 >= s18 then display "ng 04-06" end-if.
+       move 2 to u18. move 999999999999999999 to s18.
+       if u18 >= s18 then display "ng 04-06" end-if.
+       move 0 to u18. move -1 to s18.
+       if u18 <= s18 then display "ng 04-07" end-if.
+       move 0 to u18. move -3 to s18.
+       if u18 <= s18 then display "ng 04-08" end-if.
+       move 0 to u18. move -999999999999999999 to s18.
+       if u18 <= s18 then display "ng 04-09" end-if.
+       move 0 to u18. move 0 to s18.
+       if u18 <> s18 then display "ng 04-10" end-if.
+       move 0 to u18. move 1 to s18.
+       if u18 >= s18 then display "ng 04-11" end-if.
+       move 0 to u18. move 2 to s18.
+       if u18 >= s18 then display "ng 04-12" end-if.
+       move 0 to u18. move 3 to s18.
+       if u18 >= s18 then display "ng 04-13" end-if.
+       move 0 to u18. move 999999999999999999 to s18.
+       if u18 >= s18 then display "ng 04-14" end-if.
+       move 999999999999999999 to u18. move -1 to s18.
+       if u18 <= s18 then display "ng 04-15" end-if.
+       move 999999999999999999 to u18. move -3 to s18.
+       if u18 <= s18 then display "ng 04-16" end-if.
+       move 999999999999999999 to u18. move -999999999999999999 to s18.
+       if u18 <= s18 then display "ng 04-17" end-if.
+       move 999999999999999999 to u18. move 0 to s18.
+       if u18 <= s18 then display "ng 04-18" end-if.
+       move 999999999999999999 to u18. move 1 to s18.
+       if u18 <= s18 then display "ng 04-19" end-if.
+       move 999999999999999999 to u18. move 2 to s18.
+       if u18 <= s18 then display "ng 04-20" end-if.
+       move 999999999999999999 to u18. move 999999999999999999 to s18.
+       if u18 <> s18 then display "ng 04-21" end-if.
+      ******************************************************************
+           stop run.
+])
+
+AT_CHECK([${COMPILE} prog.cbl])
+AT_CHECK([java prog])
+
+AT_CLEANUP


### PR DESCRIPTION
This pull request fixes the comparison process of COMP data.
With older versions, comparisons of COMP data are invalid in some cases.

```cobol
       identification division.
       program-id. prog.
       data division.
       working-storage section.
       01 u9 pic 9(9) comp.
       01 s4 pic s9(4) comp.
       procedure division.
       move 2 to u9. move -3 to s4.
       if u9 <= s4 then display "ng" end-if.
```

# Changes

* Add a new method `cmpInteger` in AbstractCobolField
* Modify cobj/ to use `cmpInteger` when comparing COMP data
* add test suite in tests/data-rep.src/binary.at
* Add `@deprecatred` cmpInt and cmpUint because these functions should be cmpInteger.