### PR TITLE
Convert string literals containing SJIS characters to Java string literals

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -505,7 +505,8 @@ static void joutput_string_write(const unsigned char *s, int size,
                                  enum cb_string_category category) {
   int i;
 
-  if (category == CB_STRING_CATEGORY_ALL_ASCII) {
+  if (category == CB_STRING_CATEGORY_ALL_ASCII ||
+      category == CB_STRING_CATEGORY_ALL_SJIS) {
     if (param_wrap_string_flag) {
       joutput("new CobolDataStorage(");
     } else {

--- a/tests/i18n_sjis.src/pic-x.at
+++ b/tests/i18n_sjis.src/pic-x.at
@@ -483,3 +483,62 @@ AT_CHECK([cobj prog.cob], [0])
 AT_CHECK([java prog], [0], [02])
 
 AT_CLEANUP
+
+AT_SETUP([Readable string literals])
+# Older compilers converts string literals "日本語" in COBOL source code
+# to `CobolUtil.toBytes((byte)0x93, (byte)0xfa, (byte)0x96, (byte)0x7b, (byte)0x8c, (byte)0xea)` in Java source code.
+# The following tests check that the compiler converts the string literals to readable ones.
+
+AT_DATA([prog1.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog1.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 F0 PIC X(30)  VALUE "東京1".
+       PROCEDURE        DIVISION.
+            MOVE "東京2" TO F0.
+            DISPLAY "東京3".
+])
+
+AT_CHECK([cobj prog1.cob])
+AT_CHECK([grep '東京1' < prog1.java > /dev/null])
+AT_CHECK([grep '東京2' < prog1.java > /dev/null])
+AT_CHECK([grep '東京3' < prog1.java > /dev/null])
+
+# '　' is the first multi-byte Shift-JIS character with respect to the byte order
+# see http://charset.7jp.net/sjis.html
+AT_DATA([prog2.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog2.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 F0 PIC X(30)  VALUE "　1".
+       PROCEDURE        DIVISION.
+            MOVE "　2" TO F0.
+            DISPLAY "　3".
+])
+
+AT_CHECK([cobj prog2.cob])
+AT_CHECK([grep '　1' < prog2.java > /dev/null])
+AT_CHECK([grep '　2' < prog2.java > /dev/null])
+AT_CHECK([grep '　3' < prog2.java > /dev/null])
+
+# '熙' is the last printable Shift-JIS character with respect to the byte order.
+# See http://charset.7jp.net/sjis.html
+AT_DATA([prog3.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog3.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 F0 PIC X(30)  VALUE "熙1".
+       PROCEDURE        DIVISION.
+            MOVE "熙2" TO F0.
+            DISPLAY "熙3".
+])
+
+AT_CHECK([cobj prog3.cob])
+AT_CHECK([grep '熙1' < prog3.java > /dev/null])
+AT_CHECK([grep '熙2' < prog3.java > /dev/null])
+AT_CHECK([grep '熙3' < prog3.java > /dev/null])
+
+AT_CLEANUP


### PR DESCRIPTION
In order to improve the readability of generated Java code, this pull request modifies codegen.c so that `cobj` converts string literals containing no non-SJIS character to ordinary Java string literals.

For example, the older compiler converts `"日本語"` in COBOL source code to `CobolUtil.toBytes((byte)0x93, (byte)0xfa, (byte)0x96, (byte)0x7b, (byte)0x8c, (byte)0xea)` in Java source code.
This pull request causes the compiler to converts "日本語" in COBOL source code to `CobolUtil.stringToBytes("日本語")`