### PR TITLE
Reduce redudant CI options

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -97,8 +97,6 @@ jobs:
 
   windows-build:
     needs: check-workflows
-    strategy:
-       fail-fast: false
     uses: ./.github/workflows/windows-build.yml
     with: 
       upload-artifacts: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -95,8 +95,6 @@ jobs:
 
   windows-build:
     needs: check-workflows
-    strategy:
-       fail-fast: false
     uses: ./.github/workflows/windows-build.yml
     with: 
       upload-artifacts: true

--- a/.github/workflows/test-nist.yml
+++ b/.github/workflows/test-nist.yml
@@ -21,9 +21,6 @@ env:
 
 jobs:
   test-other:
-    strategy:
-      matrix:
-        os: ["ubuntu:24.04", "almalinux:9"]
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.os }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to simplify the configurations by removing unnecessary strategy settings.

Workflow configuration simplifications:

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L100-L101): Removed the `strategy` settings from the `windows-build` job to streamline the workflow.
* [`.github/workflows/test-nist.yml`](diffhunk://#diff-17454dcdb6e47f30d18e44e4798c73103bf608c70e6071faed3b0dab40192859L24-L26): Removed the `strategy` settings and matrix configuration from the `test-other` job to simplify the workflow. **This change reduces the execution time of CI.**