### PR TITLE
Fix  installaton commands of UTF-8 compatible compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In order to install a compiler for UTF-8 encoded COBOL source code, run the foll
 curl -L -o opensourcecobol4j-v1.1.6.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.1.6.tar.gz
 tar zxvf opensourcecobol4j-v1.1.6.tar.gz
 cd opensourcecobol4j-1.1.6
-./configure --prefix=/usr/
+./configure --prefix=/usr/ --enable-utf8
 touch cobj/*.m4
 make
 sudo make install

--- a/README_JP.md
+++ b/README_JP.md
@@ -60,7 +60,7 @@ UTF-8のCOBOLソースコード対応版コンパイラをインストールす�
 curl -L -o opensourcecobol4j-v1.1.6.tar.gz https://github.com/opensourcecobol/opensourcecobol4j/archive/refs/tags/v1.1.6.tar.gz
 tar zxvf opensourcecobol4j-v1.1.6.tar.gz
 cd opensourcecobol4j-1.1.6
-./configure --prefix=/usr/
+./configure --prefix=/usr/ --enable-utf8
 touch cobj/*.m4
 make
 sudo make install


### PR DESCRIPTION
This pull request updates the installation instructions for the Open Source COBOL compiler to include UTF-8 support. The changes are made in both the English and Japanese versions of the README files.

Installation instructions update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R69): Modified the `./configure` command to include the `--enable-utf8` flag for UTF-8 support.
* [`README_JP.md`](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L63-R63): Modified the `./configure` command to include the `--enable-utf8` flag for UTF-8 support.