### PR TITLE
Upgrade the JVM version in the static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '21'
 
       - name: Install static analysis tools
         run: |


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/static-analysis.yml` file, updating the Java version used in the static analysis workflow.

* [`.github/workflows/static-analysis.yml`](diffhunk://#diff-e9db86b6fd5f791eb849075b600b921e5e95b978e41f9d290c01027440076ec3L21-R21): Updated the `java-version` from '11' to '21' under `jobs:`.