### PR TITLE
Fix a bug of duplicate record keys of indexed files.

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -545,8 +545,12 @@ public class CobolIndexedFile extends CobolFile {
         return returnCode;
     }
 
-    /** Equivalent to indexed_write_internal in libcob/fileio.c */
     private int indexed_write_internal(boolean rewrite, int opt) {
+        return this.indexed_write_internal(rewrite, -1, opt);
+    }
+
+    /** Equivalent to indexed_write_internal in libcob/fileio.c */
+    private int indexed_write_internal(boolean rewrite, int dupNo, int opt) {
         IndexedFile p = this.filei;
 
         boolean closeCursor;
@@ -592,7 +596,9 @@ public class CobolIndexedFile extends CobolFile {
 
                 PreparedStatement insertStatement;
                 if (isDuplicateColumn(i)) {
-                    int dupNo = getNextKeyDupNo(p.connection, i, p.key);
+                    if (dupNo < 0) {
+                        dupNo = getNextKeyDupNo(p.connection, i, p.key);
+                    }
                     insertStatement =
                             p.connection.prepareStatement(
                                     String.format(

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -546,11 +546,11 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     private int indexed_write_internal(boolean rewrite, int opt) {
-        return this.indexed_write_internal(rewrite, -1, opt);
+        return this.indexed_write_internal(rewrite, null, opt);
     }
 
     /** Equivalent to indexed_write_internal in libcob/fileio.c */
-    private int indexed_write_internal(boolean rewrite, int dupNo, int opt) {
+    private int indexed_write_internal(boolean rewrite, int[] dupNumbers, int opt) {
         IndexedFile p = this.filei;
 
         boolean closeCursor;
@@ -596,8 +596,11 @@ public class CobolIndexedFile extends CobolFile {
 
                 PreparedStatement insertStatement;
                 if (isDuplicateColumn(i)) {
-                    if (dupNo < 0) {
+                    int dupNo;
+                    if (dupNumbers == null) {
                         dupNo = getNextKeyDupNo(p.connection, i, p.key);
+                    } else {
+                        dupNo = dupNumbers[i];
                     }
                     insertStatement =
                             p.connection.prepareStatement(
@@ -686,6 +689,30 @@ public class CobolIndexedFile extends CobolFile {
         }
     }
 
+    private static void showTable(IndexedFile p, int index) {
+        String query =
+                String.format(
+                        "select key, value, dupNo from %s " + "order by key, dupNo",
+                        getTableName(index));
+        System.out.println("[dbg] ---------");
+        try (PreparedStatement selectStatement = p.connection.prepareStatement(query)) {
+            ResultSet rs = selectStatement.executeQuery();
+            while (rs.next()) {
+                byte[] keyBytes = rs.getBytes(1);
+                byte[] primaryKeyBytes = rs.getBytes(2);
+                int dupNo = rs.getInt(3);
+                System.out.println(
+                        String.format(
+                                "[dbg] key: %s, value: %s, dupNo: %d",
+                                new String(keyBytes), new String(primaryKeyBytes), dupNo));
+            }
+        } catch (SQLException e) {
+            System.out.println("[dbg] read tables error");
+        } finally {
+            System.out.println("[dbg] ---------");
+        }
+    }
+
     @Override
     /** Equivalent to indexed_rewrite in libcob/fileio.c */
     public int rewrite_(int opt) {
@@ -699,19 +726,37 @@ public class CobolIndexedFile extends CobolFile {
         }
 
         p.key = DBT_SET(this.keys[0].getField());
+        int[] dupNumbers = new int[this.nkeys];
 
-        int ret = this.indexed_delete_internal(true);
+        // System.out.println("[dbg] before delete, table 0 =============");
+        // showTable(p, 0);
+        // System.out.println("[dbg] before delete, table 1 =============");
+        // showTable(p, 1);
+        int ret = this.indexed_delete_internal(true, dupNumbers);
+        // System.out.println("[dbg] after delete, table 0 =============");
+        // showTable(p, 0);
+        // System.out.println("[dbg] after delete, table 1 =============");
+        // showTable(p, 1);
 
         if (ret != COB_STATUS_00_SUCCESS) {
             p.write_cursor_open = false;
             return ret;
         }
 
-        return this.indexed_write_internal(true, opt);
+        int retCode = this.indexed_write_internal(true, dupNumbers, opt);
+        // System.out.println("[dbg] after write, table 0 =============");
+        // showTable(p, 0);
+        // System.out.println("[dbg] after write, table 1 =============");
+        // showTable(p, 1);
+        return retCode;
+    }
+
+    private int indexed_delete_internal(boolean rewrite) {
+        return this.indexed_delete_internal(rewrite, null);
     }
 
     /** Equivalent to indexed_delete_internal in libcob/fileio.c */
-    private int indexed_delete_internal(boolean rewrite) {
+    private int indexed_delete_internal(boolean rewrite, int[] dupNumbers) {
         IndexedFile p = this.filei;
         boolean closeCursor;
 
@@ -737,6 +782,25 @@ public class CobolIndexedFile extends CobolFile {
 
         // delete data from sub tables
         for (int i = 1; i < this.nkeys; ++i) {
+            // save the duplicate number of the record to be deleted
+            if (isDuplicateColumn(i)) {
+                try (PreparedStatement statement =
+                        p.connection.prepareStatement(
+                                String.format(
+                                        "select dupNo from %s where value = ?", getTableName(i)))) {
+                    statement.setBytes(1, p.key);
+                    ResultSet rs = statement.executeQuery();
+                    if (rs.next()) {
+                        int dupNo = rs.getInt(1);
+                        if (dupNumbers != null) {
+                            dupNumbers[i] = dupNo;
+                        }
+                    }
+                } catch (SQLException e) {
+                    return returnWith(p, closeCursor, 0, COB_STATUS_30_PERMANENT_ERROR);
+                }
+            }
+            // delete the record
             try (PreparedStatement statement =
                     p.connection.prepareStatement(
                             String.format("delete from %s where value = ?", getTableName(i)))) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -41,6 +41,7 @@ public class CobolIndexedFile extends CobolFile {
     private boolean indexedFirstRead = true;
     private boolean callStart = false;
     private boolean commitOnModification = true;
+    private int fetchKeyIndex = -1;
 
     /** TODO: 準備中 */
     public static final int COB_EQ = 1;
@@ -295,6 +296,7 @@ public class CobolIndexedFile extends CobolFile {
         this.indexedFirstRead = true;
         this.callStart = false;
 
+        this.fetchKeyIndex = -1;
         return 0;
     }
 
@@ -345,6 +347,7 @@ public class CobolIndexedFile extends CobolFile {
         } catch (SQLException e) {
             return COB_STATUS_30_PERMANENT_ERROR;
         }
+        this.fetchKeyIndex = -1;
         return COB_STATUS_00_SUCCESS;
     }
 
@@ -366,6 +369,7 @@ public class CobolIndexedFile extends CobolFile {
                 break;
             }
         }
+        this.fetchKeyIndex = p.key_index;
 
         p.key = DBT_SET(key);
 
@@ -597,7 +601,7 @@ public class CobolIndexedFile extends CobolFile {
                 PreparedStatement insertStatement;
                 if (isDuplicateColumn(i)) {
                     int dupNo;
-                    if (dupNumbers == null) {
+                    if (dupNumbers == null || dupNumbers[i] < 0 || i != this.fetchKeyIndex) {
                         dupNo = getNextKeyDupNo(p.connection, i, p.key);
                     } else {
                         dupNo = dupNumbers[i];
@@ -689,30 +693,6 @@ public class CobolIndexedFile extends CobolFile {
         }
     }
 
-    private static void showTable(IndexedFile p, int index) {
-        String query =
-                String.format(
-                        "select key, value, dupNo from %s " + "order by key, dupNo",
-                        getTableName(index));
-        System.out.println("[dbg] ---------");
-        try (PreparedStatement selectStatement = p.connection.prepareStatement(query)) {
-            ResultSet rs = selectStatement.executeQuery();
-            while (rs.next()) {
-                byte[] keyBytes = rs.getBytes(1);
-                byte[] primaryKeyBytes = rs.getBytes(2);
-                int dupNo = rs.getInt(3);
-                System.out.println(
-                        String.format(
-                                "[dbg] key: %s, value: %s, dupNo: %d",
-                                new String(keyBytes), new String(primaryKeyBytes), dupNo));
-            }
-        } catch (SQLException e) {
-            System.out.println("[dbg] read tables error");
-        } finally {
-            System.out.println("[dbg] ---------");
-        }
-    }
-
     @Override
     /** Equivalent to indexed_rewrite in libcob/fileio.c */
     public int rewrite_(int opt) {
@@ -727,28 +707,16 @@ public class CobolIndexedFile extends CobolFile {
 
         p.key = DBT_SET(this.keys[0].getField());
         int[] dupNumbers = new int[this.nkeys];
+        java.util.Arrays.fill(dupNumbers, -1);
 
-        // System.out.println("[dbg] before delete, table 0 =============");
-        // showTable(p, 0);
-        // System.out.println("[dbg] before delete, table 1 =============");
-        // showTable(p, 1);
         int ret = this.indexed_delete_internal(true, dupNumbers);
-        // System.out.println("[dbg] after delete, table 0 =============");
-        // showTable(p, 0);
-        // System.out.println("[dbg] after delete, table 1 =============");
-        // showTable(p, 1);
 
         if (ret != COB_STATUS_00_SUCCESS) {
             p.write_cursor_open = false;
             return ret;
         }
 
-        int retCode = this.indexed_write_internal(true, dupNumbers, opt);
-        // System.out.println("[dbg] after write, table 0 =============");
-        // showTable(p, 0);
-        // System.out.println("[dbg] after write, table 1 =============");
-        // showTable(p, 1);
-        return retCode;
+        return this.indexed_write_internal(true, dupNumbers, opt);
     }
 
     private int indexed_delete_internal(boolean rewrite) {

--- a/tests/misc.src/record-key-duplicates-error.at
+++ b/tests/misc.src/record-key-duplicates-error.at
@@ -26,3 +26,80 @@ AT_CHECK([${COBJ} prog.cbl], [1], [],
 [prog.cbl:8: Error: Record keys with duplicates are not yet supported
 ])
 AT_CLEANUP
+
+AT_SETUP([Error on rewriting record keys with duplicates])
+
+AT_DATA([prog.cbl],
+[       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT DUP-FILE ASSIGN TO "dupfile.dat"
+               ORGANIZATION IS INDEXED
+               ACCESS MODE IS DYNAMIC
+               RECORD KEY IS DUP-KEY 
+               ALTERNATE RECORD KEY IS DUP-KEY2 WITH DUPLICATES
+               FILE STATUS IS FILE-STATUS.
+
+       DATA DIVISION.
+       FILE SECTION.
+       FD  DUP-FILE.
+       01  DUP-RECORD.
+           05  DUP-KEY      PIC X(5).
+           05  DUP-KEY2     PIC X(5).
+           05  DUP-DATA     PIC X(10).
+
+       WORKING-STORAGE SECTION.
+       01  FILE-STATUS      PIC XX.
+       01  WS-END-OF-FILE   PIC X VALUE 'N'.
+
+       PROCEDURE DIVISION.
+       MAIN-PROCEDURE.
+           OPEN OUTPUT DUP-FILE.
+           MOVE "11111AAAAAaaaaaaaaaa" TO DUP-RECORD.
+           WRITE DUP-RECORD.
+           MOVE "22222BBBBBbbbbbbbbbb" TO DUP-RECORD.
+           WRITE DUP-RECORD.
+           MOVE "33333BBBBBcccccccccc" TO DUP-RECORD.
+           WRITE DUP-RECORD.
+           MOVE "44444AAAAAdddddddddd" TO DUP-RECORD.
+           WRITE DUP-RECORD.
+           MOVE "55555CCCCCeeeeeeeeee" TO DUP-RECORD.
+           WRITE DUP-RECORD.
+           CLOSE DUP-FILE.
+
+           OPEN I-O DUP-FILE
+           IF FILE-STATUS NOT = "00"
+              DISPLAY "Error opening file: " FILE-STATUS
+              STOP RUN
+           END-IF.
+
+           MOVE "BBBBB" TO DUP-KEY2.
+           START DUP-FILE KEY IS >= DUP-KEY2.
+           IF FILE-STATUS = "00"
+               MOVE 'N' TO WS-END-OF-FILE
+               PERFORM UNTIL WS-END-OF-FILE = 'Y'
+                   READ DUP-FILE NEXT
+                       AT END
+                           MOVE 'Y' TO WS-END-OF-FILE
+                       NOT AT END
+                           REWRITE DUP-RECORD
+                           DISPLAY DUP-RECORD
+               END-PERFORM
+           ELSE
+               DISPLAY "Key not found"
+           END-IF.
+           CLOSE DUP-FILE.
+           STOP RUN.
+])
+
+AT_CHECK([${COBJ} prog.cbl])
+AT_CHECK([java prog], [0],
+[22222BBBBBbbbbbbbbbb
+33333BBBBBcccccccccc
+55555CCCCCeeeeeeeeee
+])
+
+AT_CLEANUP


### PR DESCRIPTION
This pull request includes several changes to the `CobolIndexedFile` class in order to fix a bug of duplicate record keys. 
With previous version, executing the program in a new test causes an infinite loop.