### PR TITLE
Fix casting integers

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -1389,14 +1389,24 @@ static void joutput_integer(cb_tree x) {
       }
       if (f->size == 2 || f->size == 4 || f->size == 8) {
         if (f->flag_binary_swap) {
+          if (!integer_reference_flag) {
+            switch (f->size) {
+            case 2:
+              joutput("(short)(");
+              break;
+            case 4:
+              joutput("(int)(");
+              break;
+            }
+          }
           joutput_data(x);
           if (!integer_reference_flag) {
             switch (f->size) {
             case 2:
-              joutput(".bswap_16()");
+              joutput(".bswap_16())");
               break;
             case 4:
-              joutput(".bswap_32()");
+              joutput(".bswap_32())");
               break;
             case 8:
               joutput(".bswap_64()");

--- a/tests/data-rep.src/binary.at
+++ b/tests/data-rep.src/binary.at
@@ -1535,3 +1535,27 @@ AT_CHECK([${COMPILE} prog.cbl])
 AT_CHECK([java prog])
 
 AT_CLEANUP
+
+AT_SETUP([COMP: WRITE AFTER LINE])
+AT_DATA([prog.cbl], [
+       IDENTIFICATION  DIVISION.                                                
+       PROGRAM-ID.     prog.                                                  
+       ENVIRONMENT      DIVISION.
+       INPUT-OUTPUT      SECTION.                                               
+       FILE-CONTROL.                                                           
+           SELECT F ASSIGN  TO  "FILE".
+       DATA DIVISION.                                              
+       FILE SECTION.
+       FD  F.
+       01  F-REC PIC X(10).
+       WORKING-STORAGE SECTION.                                               
+       01  A PIC S9(6) COMP VALUE 0.
+       01  REC PIC X(10).
+       PROCEDURE DIVISION.
+           WRITE F-REC FROM REC AFTER A LINE.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} prog.cbl])
+
+AT_CLEANUP


### PR DESCRIPTION
With older versions, compiling the following code fails.
```cobol
       IDENTIFICATION  DIVISION.                                                
       PROGRAM-ID.     prog.                                                  
       ENVIRONMENT      DIVISION.
       INPUT-OUTPUT      SECTION.                                               
       FILE-CONTROL.                                                           
           SELECT F ASSIGN  TO  "FILE".
       DATA DIVISION.                                              
       FILE SECTION.
       FD  F.
       01  F-REC PIC X(10).
       WORKING-STORAGE SECTION.                                               
       01  A PIC S9(6) COMP VALUE 0.
       01  REC PIC X(10).
       PROCEDURE DIVISION.
           WRITE F-REC FROM REC AFTER A LINE.
           STOP RUN.
```
The following is an error message.
```java
./prog.java:153: error: incompatible types: possible lossy conversion from long to int
          h_F.write (f_F_REC, (1114112 + b_A.bswap_32()), null);
```

This pull request fixes the problem.

# files changes

* [`cobj/codegen.c`](diffhunk://#diff-92e09701bd613a805e09be47306909e3e3abb869c44ad69ad4695ba84bb0c421R1392-R1409): Added conditional checks and appropriate type casting for different integer sizes to ensure correct binary swapping and output formatting.

* [`tests/data-rep.src/binary.at`](diffhunk://#diff-2a86c892d66cbe7727aeba39d20f6b455d17f6b94576be9a10daeae14d051d01R1538-R1561): Introduced a new test setup `COMP: WRITE AFTER LINE`, which includes a COBOL program to test writing a record after a line.