### PR TITLE
Handle SJIS hyphens in group item variable names correctly

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -807,7 +807,6 @@ static int is_call_parameter(const struct cb_field *f) {
 }
 
 static int joutput_field_storage(struct cb_field *f, struct cb_field *top) {
-  const char *p;
   int flag_call_parameter = is_call_parameter(top);
   if (flag_call_parameter ||
       (f->offset == 0 && strcmp(f->name, top->name) == 0)) {
@@ -815,37 +814,10 @@ static int joutput_field_storage(struct cb_field *f, struct cb_field *top) {
     joutput(base_name);
     free(base_name);
     return flag_call_parameter;
-  } else if (cb_flag_short_variable) {
-    joutput(CB_PREFIX_BASE);
-    for (p = f->name; *p != '\0'; ++p) {
-      if (*p == '-') {
-        joutput("_");
-      } else {
-        joutput("%c", *p);
-      }
-    }
-  } else if (cb_flag_serial_variable) {
+  } else {
+    //printf("dbg: base = %s\n", get_java_identifier_base(f));
     char *base_name = get_java_identifier_base(f);
     joutput(base_name);
-  } else {
-    joutput(CB_PREFIX_BASE);
-    struct cb_field *field = f;
-    int flag_first_iteration = 1;
-    while (field) {
-      if (flag_first_iteration) {
-        flag_first_iteration = 0;
-      } else {
-        joutput("__");
-      }
-      for (p = field->name; *p != '\0'; ++p) {
-        if (*p == '-') {
-          joutput("_");
-        } else {
-          joutput("%c", *p);
-        }
-      }
-      field = field->parent;
-    }
   }
   return 0;
 }

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -815,7 +815,6 @@ static int joutput_field_storage(struct cb_field *f, struct cb_field *top) {
     free(base_name);
     return flag_call_parameter;
   } else {
-    // printf("dbg: base = %s\n", get_java_identifier_base(f));
     char *base_name = get_java_identifier_base(f);
     joutput(base_name);
   }

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -815,7 +815,7 @@ static int joutput_field_storage(struct cb_field *f, struct cb_field *top) {
     free(base_name);
     return flag_call_parameter;
   } else {
-    //printf("dbg: base = %s\n", get_java_identifier_base(f));
+    // printf("dbg: base = %s\n", get_java_identifier_base(f));
     char *base_name = get_java_identifier_base(f);
     joutput(base_name);
   }

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -177,6 +177,77 @@ AT_CHECK([java prog], [0], [OK])
 
 AT_CLEANUP
 
+
+AT_SETUP([Nihongo field name with SJIS hyphens])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01  ‚s‚d‚r‚s|‚c‚`‚s‚`‚P     PIC X(10) VALUE "test-data1".
+       01  ‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚P.
+         03  ‚s‚d‚r‚s|‚c‚`‚s‚`‚Q   PIC X(10) VALUE "test-data2".
+         03  ‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚Q.
+           05  ‚s‚d‚r‚s|‚c‚`‚s‚`‚R PIC X(10) VALUE "test-data3".
+       PROCEDURE        DIVISION.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚P.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚Q.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚R.
+])
+
+AT_CHECK([cobj prog.cob])
+AT_CHECK([java prog], [0], 
+[test-data1
+test-data2
+test-data3
+])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚P' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚Q__‚s‚d‚r‚sQ‚q‚d‚b‚n‚q‚c‚P' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚R__‚s‚d‚r‚sQ‚q‚d‚b‚n‚q‚c‚Q__‚s‚d‚r‚sQ‚q‚d‚b‚n‚q‚c‚P' > /dev/null], [0])
+
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚P' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚Q__‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚P' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚R__‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚Q__‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚P' > /dev/null], [1])
+
+AT_CLEANUP
+
+
+AT_SETUP([Nihongo field name with SJIS hyphens using -fshort-variable ])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01  ‚s‚d‚r‚s|‚c‚`‚s‚`‚P     PIC X(10) VALUE "test-data1".
+       01  ‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚P.
+         03  ‚s‚d‚r‚s|‚c‚`‚s‚`‚Q   PIC X(10) VALUE "test-data2".
+         03  ‚s‚d‚r‚s|‚q‚d‚b‚n‚q‚c‚Q.
+           05  ‚s‚d‚r‚s|‚c‚`‚s‚`‚R PIC X(10) VALUE "test-data3".
+       PROCEDURE        DIVISION.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚P.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚Q.
+           DISPLAY ‚s‚d‚r‚s|‚c‚`‚s‚`‚R.
+])
+
+AT_CHECK([cobj -fshort-variable prog.cob])
+AT_CHECK([java prog], [0], 
+[test-data1
+test-data2
+test-data3
+])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚P' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚Q' > /dev/null], [0])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚sQ‚c‚`‚s‚`‚R' > /dev/null], [0])
+
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚P' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚Q' > /dev/null], [1])
+AT_CHECK([cat prog.java | grep 'f_‚s‚d‚r‚s|‚c‚`‚s‚`‚R' > /dev/null], [1])
+
+AT_CLEANUP
+
+
 AT_SETUP([Nihongo field name in numeric test msg.])
 
 AT_DATA([prog.cob], [


### PR DESCRIPTION
## Summary:
This pull request addresses a bug where SJIS hyphens in variable names within group items were not being correctly converted during Cobol to Java code generation, leading to incorrect variable names in the generated Java code.

## Details:
**Problem:**

When generating Java code from Cobol source, hyphens ('－', SJIS code 0x81 0x7C) in Cobol variable names are typically converted to underscores ('＿', SJIS code 0x81 0x51) for compatibility.  However, this conversion was failing when the variable containing the SJIS hyphen was part of a group item (a record within a larger record). This resulted in the hyphen remaining in the Java variable name for group item members, while other variables were correctly converted.

**Example:**
```cobol
       01  ＴＥＳＴ－ＲＥＣＯＲＤ１.
         03  ＴＥＳＴ－ＤＡＴＡ２   PIC X(10) VALUE "test-data2".
```
Before this fix, the generated Java code would look like this (incorrect):
```java
  private AbstractCobolField f_ＴＥＳＴ－ＤＡＴＡ１;	/* ＴＥＳＴ－ＤＡＴＡ１ */
  private AbstractCobolField f_ＴＥＳＴ－ＤＡＴＡ２__ＴＥＳＴ－ＲＥＣＯＲＤ１;	/* ＴＥＳＴ－ＤＡＴＡ２ */
```

After this fix, the generated Java code would look like this:
```java
  private AbstractCobolField f_ＴＥＳＴ＿ＤＡＴＡ１;	/* ＴＥＳＴ－ＤＡＴＡ１ */
  private AbstractCobolField f_ＴＥＳＴ＿ＤＡＴＡ２__ＴＥＳＴ＿ＲＥＣＯＲＤ１;	/* ＴＥＳＴ－ＤＡＴＡ２ */
```

## Code changes:
The cause of this error was that the function `joutput_field_storage` was not converting SJS hyphens when the variable name were items of a group item. Fixed to execute function `get_java_identifier_base` which indirectly executes function 'strcpy_identifier_cobol_to_java' to convert SJS hyphens.

Furthermore, the original `joutput_field_storage` function contained redundant code sections related to handling the `-fserial-variable` and `-fshort-variable` options. Since the `get_java_identifier_base` function already provides equivalent functionality for these options, these redundant sections have been removed.

## Adding tests
*   Variables with SJIS hyphens within group items.
*   Standalone variables with SJIS hyphens.
*   The above scenarios tested with and without the `-fshort-variable` option.


