### PR TITLE
Update the message of --version

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -850,6 +850,11 @@ static void cobc_print_version(void) {
   printf("cobj (%s) %s\n", PACKAGE_NAME, PACKAGE_VERSION);
   puts("Copyright (C) 2021-2023 TOKYO SYSTEM HOUSE CO.,LTD.");
   printf("Built    %s\n", cb_oc_build_stamp);
+  puts("----");
+  puts("cobc (opensource COBOL) 1.5.2.0");
+  puts("----");
+  puts("cobc (OpenCOBOL) 1.1");
+  puts("Copyright (C) 2001-2009 Keisuke Nishida / Roger While");
 }
 
 static void cobc_print_usage(void) {

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -848,7 +848,7 @@ static void cobc_print_version(void) {
 #endif /*I18N_UTF8*/
   puts("----");
   printf("cobj (%s) %s\n", PACKAGE_NAME, PACKAGE_VERSION);
-  puts("Copyright (C) 2021-2023 TOKYO SYSTEM HOUSE CO.,LTD.");
+  puts("Copyright (C) 2021-2025 TOKYO SYSTEM HOUSE CO.,LTD.");
   printf("Built    %s\n", cb_oc_build_stamp);
   puts("----");
   puts("cobc (opensource COBOL) 1.5.2.0");


### PR DESCRIPTION
This pull request updates the version information displayed by the `cobc_print_version` function in `cobj/cobj.c`. It adds details about multiple COBOL versions and their copyrights.

```
$ cobj --version
opensource COBOL 4J 1.1.8-hotfix1
----
cobj (opensource COBOL 4J) 1.1.8-hotfix1
Copyright (C) 2021-2025 TOKYO SYSTEM HOUSE CO.,LTD.
Built    Apr 25 2025 07:30:09
----
cobc (opensource COBOL) 1.5.2.0
----
cobc (OpenCOBOL) 1.1
Copyright (C) 2001-2009 Keisuke Nishida / Roger While
```