### PR TITLE
Add error message if unimplemented subroutines are used

### DIFF
--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -222,6 +222,56 @@ enum cb_usage {
 
 enum cb_operand_type { CB_SENDING_OPERAND, CB_RECEIVING_OPERAND };
 
+enum cb_system_routine {
+  SYSTEM,
+  CBL_AND,
+  CBL_CHANGE_DIR,
+  CBL_CHECK_FILE_EXIST,
+  CBL_CLOSE_FILE,
+  CBL_COPY_FILE,
+  CBL_CREATE_DIR,
+  CBL_CREATE_FILE,
+  CBL_DELETE_DIR,
+  CBL_DELETE_FILE,
+  CBL_EQ,
+  CBL_ERROR_PROC,
+  CBL_EXIT_PROC,
+  CBL_FLUSH_FILE,
+  CBL_GET_CURRENT_DIR,
+  CBL_IMP,
+  CBL_NIMP,
+  CBL_NOR,
+  CBL_NOT,
+  CBL_OC_NANOSLEEP,
+  CBL_OPEN_FILE,
+  CBL_OR,
+  CBL_READ_FILE,
+  CBL_RENAME_FILE,
+  CBL_TOLOWER,
+  CBL_TOUPPER,
+  CBL_WRITE_FILE,
+  CBL_XOR,
+  CBL_OC_KEISEN,
+  CBL_OC_ATTRIBUTE,
+  C$CHDIR,
+  C$COPY,
+  C$DELETE,
+  C$FILEINFO,
+  C$LIST_DIRECTORY,
+  C$GETPID,
+  C$JUSTIFY,
+  C$CALLEDBY,
+  C$MAKEDIR,
+  C$NARG,
+  C$SLEEP,
+  C$PARAMSIZE,
+  C$TOUPPER,
+  C$TOLOWER,
+  CBL_X91,
+  CBL_XF4,
+  CBL_XF5
+};
+
 /*
  * Tree
  */
@@ -516,7 +566,7 @@ struct cb_field {
     cb_tree key; /* KEY */
     cb_tree ref; /* reference used in SEARCH ALL */
     cb_tree val; /* value to be compared in SEARCH ALL */
-  } *keys;
+  } * keys;
   int nkeys;              /* the number of keys */
   int param_num;          /* CHAINING param number */
   struct cb_picture *pic; /* PICTURE */

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -566,7 +566,7 @@ struct cb_field {
     cb_tree key; /* KEY */
     cb_tree ref; /* reference used in SEARCH ALL */
     cb_tree val; /* value to be compared in SEARCH ALL */
-  } * keys;
+  } *keys;
   int nkeys;              /* the number of keys */
   int param_num;          /* CHAINING param number */
   struct cb_picture *pic; /* PICTURE */

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3100,39 +3100,40 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
     for (psyst = (const struct system_table *)&system_tab[0]; psyst->syst_name;
          psyst++) {
       const char *data = (const char *)CB_LITERAL(prog)->data;
+      // error if the subroutine is not implemented
       if (!strcmp(data, (const char *)psyst->syst_name)) {
         int i = psyst - &system_tab[0];
         switch (i) {
-        case 2:
-        case 3:
-        case 4:
-        case 6:
-        case 7:
-        case 8:
-        case 9:
-        case 10:
-        case 11:
-        case 12:
-        case 13:
-        case 14:
-        case 15:
-        case 20:
-        case 22:
-        case 23:
-        case 26:
-        case 28:
-        case 29:
-        case 30:
-        case 31:
-        case 32:
-        case 33:
-        case 35:
-        case 36:
-        case 37:
-        case 38:
-        case 39:
-        case 40:
-        case 41:
+        case 2:  // CBL_CHANGE_DIR
+        case 3:  // CBL_CHECK_FILE_EXIST
+        case 4:  // CBL_CLOSE_FILE
+        case 6:  // CBL_CREATE_DIR
+        case 7:  // CBL_CREATE_FILE
+        case 8:  // CBL_DELETE_DIR
+        case 9:  // CBL_DELETE_FILE
+        case 10: // CBL_EQ
+        case 11: // CBL_ERROR_PROC
+        case 12: // CBL_EXIT_PROC
+        case 13: // CBL_FLUSH_FILE
+        case 14: // CBL_GET_CURRENT_DIR
+        case 15: // CBL_IMP
+        case 20: // CBL_OPEN_FILE
+        case 22: // CBL_READ_FILE
+        case 23: // CBL_RENAME_FILE
+        case 26: // CBL_WRITE_FILE
+        case 28: // CBL_OC_KEISEN
+        case 29: // CBL_OC_ATTRIBUTE
+        case 30: // C$CHDIR
+        case 31: // C$COPY
+        case 32: // C$DELETE
+        case 33: // C$FILEINFO
+        case 35: // C$GETPID
+        case 36: // C$JUSTIFY
+        case 37: // C$CALLEDBY
+        case 38: // C$MAKEDIR
+        case 39: // C$NARG
+        case 40: // C$SLEEP
+        case 41: // C$PARAMSIZE
           cb_error(_("%s not implemented"), data);
         }
         if (psyst->syst_params > cb_list_length(cb_using)) {

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3100,10 +3100,9 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
     for (psyst = (const struct system_table *)&system_tab[0]; psyst->syst_name;
          psyst++) {
       const char *data = (const char *)CB_LITERAL(prog)->data;
-      // error if the subroutine is not implemented
       if (!strcmp(data, (const char *)psyst->syst_name)) {
-        int i = psyst - &system_tab[0];
-        switch (i) {
+        // error if the subroutine is not implemented
+        switch (psyst - &system_tab[0]) {
         case 2:  // CBL_CHANGE_DIR
         case 3:  // CBL_CHECK_FILE_EXIST
         case 4:  // CBL_CLOSE_FILE

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3099,13 +3099,48 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
     const struct system_table *psyst;
     for (psyst = (const struct system_table *)&system_tab[0]; psyst->syst_name;
          psyst++) {
-      if (!strcmp((const char *)CB_LITERAL(prog)->data,
-                  (const char *)psyst->syst_name)) {
+      const char *data = (const char *)CB_LITERAL(prog)->data;
+      if (!strcmp(data, (const char *)psyst->syst_name)) {
+        int i = psyst - &system_tab[0];
+        switch (i) {
+        case 2:
+        case 3:
+        case 4:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+        case 12:
+        case 13:
+        case 14:
+        case 15:
+        case 20:
+        case 22:
+        case 23:
+        case 26:
+        case 28:
+        case 29:
+        case 30:
+        case 31:
+        case 32:
+        case 33:
+        case 35:
+        case 36:
+        case 37:
+        case 38:
+        case 39:
+        case 40:
+        case 41:
+          cb_error(_("%s not implemented"), data);
+        }
         if (psyst->syst_params > cb_list_length(cb_using)) {
           cb_error(_("Wrong number of CALL parameters for '%s'"),
                    (char *)psyst->syst_name);
           return;
         }
+
         is_sys_call = 1;
         break;
       }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3103,35 +3103,35 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
       if (!strcmp(data, (const char *)psyst->syst_name)) {
         // error if the subroutine is not implemented
         switch (psyst - &system_tab[0]) {
-        case 2:  // CBL_CHANGE_DIR
-        case 3:  // CBL_CHECK_FILE_EXIST
-        case 4:  // CBL_CLOSE_FILE
-        case 5:  // CBL_COPY_FILE
-        case 6:  // CBL_CREATE_DIR
-        case 7:  // CBL_CREATE_FILE
-        case 8:  // CBL_DELETE_DIR
-        case 9:  // CBL_DELETE_FILE
-        case 11: // CBL_ERROR_PROC
-        case 12: // CBL_EXIT_PROC
-        case 13: // CBL_FLUSH_FILE
-        case 14: // CBL_GET_CURRENT_DIR
-        case 15: // CBL_IMP
-        case 20: // CBL_OPEN_FILE
-        case 22: // CBL_READ_FILE
-        case 23: // CBL_RENAME_FILE
-        case 26: // CBL_WRITE_FILE
-        case 28: // CBL_OC_KEISEN
-        case 29: // CBL_OC_ATTRIBUTE
-        case 30: // C$CHDIR
-        case 31: // C$COPY
-        case 32: // C$DELETE
-        case 33: // C$FILEINFO
-        case 35: // C$GETPID
-        case 36: // C$JUSTIFY
-        case 38: // C$MAKEDIR
-        case 39: // C$NARG
-        case 40: // C$SLEEP
-        case 41: // C$PARAMSIZE
+          case CBL_CHANGE_DIR:
+          case CBL_CHECK_FILE_EXIST:
+          case CBL_CLOSE_FILE:
+          case CBL_COPY_FILE:
+          case CBL_CREATE_DIR:
+          case CBL_CREATE_FILE:
+          case CBL_DELETE_DIR:
+          case CBL_DELETE_FILE:
+          case CBL_ERROR_PROC:
+          case CBL_EXIT_PROC:
+          case CBL_FLUSH_FILE:
+          case CBL_GET_CURRENT_DIR:
+          case CBL_IMP:
+          case CBL_OPEN_FILE:
+          case CBL_READ_FILE:
+          case CBL_RENAME_FILE:
+          case CBL_WRITE_FILE:
+          case CBL_OC_KEISEN:
+          case CBL_OC_ATTRIBUTE:
+          case C$CHDIR:
+          case C$COPY:
+          case C$DELETE:
+          case C$FILEINFO:
+          case C$GETPID:
+          case C$JUSTIFY:
+          case C$MAKEDIR:
+          case C$NARG:
+          case C$SLEEP: 
+          case C$PARAMSIZE:
           cb_error(_("%s not implemented"), data);
           return;
         }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3103,35 +3103,35 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
       if (!strcmp(data, (const char *)psyst->syst_name)) {
         // error if the subroutine is not implemented
         switch (psyst - &system_tab[0]) {
-          case CBL_CHANGE_DIR:
-          case CBL_CHECK_FILE_EXIST:
-          case CBL_CLOSE_FILE:
-          case CBL_COPY_FILE:
-          case CBL_CREATE_DIR:
-          case CBL_CREATE_FILE:
-          case CBL_DELETE_DIR:
-          case CBL_DELETE_FILE:
-          case CBL_ERROR_PROC:
-          case CBL_EXIT_PROC:
-          case CBL_FLUSH_FILE:
-          case CBL_GET_CURRENT_DIR:
-          case CBL_IMP:
-          case CBL_OPEN_FILE:
-          case CBL_READ_FILE:
-          case CBL_RENAME_FILE:
-          case CBL_WRITE_FILE:
-          case CBL_OC_KEISEN:
-          case CBL_OC_ATTRIBUTE:
-          case C$CHDIR:
-          case C$COPY:
-          case C$DELETE:
-          case C$FILEINFO:
-          case C$GETPID:
-          case C$JUSTIFY:
-          case C$MAKEDIR:
-          case C$NARG:
-          case C$SLEEP: 
-          case C$PARAMSIZE:
+        case CBL_CHANGE_DIR:
+        case CBL_CHECK_FILE_EXIST:
+        case CBL_CLOSE_FILE:
+        case CBL_COPY_FILE:
+        case CBL_CREATE_DIR:
+        case CBL_CREATE_FILE:
+        case CBL_DELETE_DIR:
+        case CBL_DELETE_FILE:
+        case CBL_ERROR_PROC:
+        case CBL_EXIT_PROC:
+        case CBL_FLUSH_FILE:
+        case CBL_GET_CURRENT_DIR:
+        case CBL_IMP:
+        case CBL_OPEN_FILE:
+        case CBL_READ_FILE:
+        case CBL_RENAME_FILE:
+        case CBL_WRITE_FILE:
+        case CBL_OC_KEISEN:
+        case CBL_OC_ATTRIBUTE:
+        case C$CHDIR:
+        case C$COPY:
+        case C$DELETE:
+        case C$FILEINFO:
+        case C$GETPID:
+        case C$JUSTIFY:
+        case C$MAKEDIR:
+        case C$NARG:
+        case C$SLEEP:
+        case C$PARAMSIZE:
           cb_error(_("%s not implemented"), data);
           return;
         }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -3107,11 +3107,11 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
         case 2:  // CBL_CHANGE_DIR
         case 3:  // CBL_CHECK_FILE_EXIST
         case 4:  // CBL_CLOSE_FILE
+        case 5:  // CBL_COPY_FILE
         case 6:  // CBL_CREATE_DIR
         case 7:  // CBL_CREATE_FILE
         case 8:  // CBL_DELETE_DIR
         case 9:  // CBL_DELETE_FILE
-        case 10: // CBL_EQ
         case 11: // CBL_ERROR_PROC
         case 12: // CBL_EXIT_PROC
         case 13: // CBL_FLUSH_FILE
@@ -3129,12 +3129,12 @@ void cb_emit_call(cb_tree prog, cb_tree cb_using, cb_tree returning,
         case 33: // C$FILEINFO
         case 35: // C$GETPID
         case 36: // C$JUSTIFY
-        case 37: // C$CALLEDBY
         case 38: // C$MAKEDIR
         case 39: // C$NARG
         case 40: // C$SLEEP
         case 41: // C$PARAMSIZE
           cb_error(_("%s not implemented"), data);
+          return;
         }
         if (psyst->syst_params > cb_list_length(cb_using)) {
           cb_error(_("Wrong number of CALL parameters for '%s'"),


### PR DESCRIPTION
## Summary
Fixed that if an unimplemented subroutine is called, an error message is output and a precompile error occurs.

## Example
COBOL:
```COBOL
           CALL "CBL_CHANGE_DIR" USING "sample".
```
error message:
```
prog.cbl:5: Error: CBL_CHANGE_DIR not implemented
```