### PR TITLE
feat: Add create command of cobj-idx

### DIFF
--- a/libcobj/Makefile.am
+++ b/libcobj/Makefile.am
@@ -69,6 +69,7 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \ 
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/CobolFileKeyInfo.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \

--- a/libcobj/Makefile.in
+++ b/libcobj/Makefile.in
@@ -346,6 +346,7 @@ SRC_FILES = \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java \
+	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/CobolFileKeyInfo.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/ErrorLib.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/LoadResult.java \
 	./app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/UserDataFormat.java \

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/CobolFileKeyInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/CobolFileKeyInfo.java
@@ -1,0 +1,13 @@
+package jp.osscons.opensourcecobol.libcobj.user_util.indexed_file;
+
+class CobolFileKeyInfo {
+    public int offset;
+    public int size;
+    public boolean duplicate;
+
+    public CobolFileKeyInfo(int offset, int size, boolean duplicate) {
+        this.offset = offset;
+        this.size = size;
+        this.duplicate = duplicate;
+    }
+}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -270,6 +270,13 @@ class IndexedFileUtilMain {
             Matcher matcher = pattern.matcher(keyOption);
 
             if (!matcher.matches()) {
+                Pattern patternPrimaryKeyDup =
+                        Pattern.compile("d[1-9][0-9]*,[1-9][0-9]*(:d?[1-9][0-9]*,[1-9][0-9]*)*");
+                Matcher matcherPrimaryKeyDup = patternPrimaryKeyDup.matcher(keyOption);
+                if (matcherPrimaryKeyDup.matches()) {
+                    throw new IllegalArgumentException(
+                            "the first key (primary key) must not be a duplicate key.");
+                }
                 throw new IllegalArgumentException(
                         String.format("invalid key information: %s", keyOption));
             }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -571,7 +571,8 @@ class IndexedFileUtilMain {
         // Retrive key information
         List<CobolFileKey> keyList = new ArrayList<>();
         for (CobolFileKeyInfo key : keyInfoList) {
-            addCobolFileKeyToList(keyList, recordDataStorage, key.offset, key.size, key.duplicate);
+            addCobolFileKeyToList(
+                    keyList, recordDataStorage, key.offset - 1, key.size, key.duplicate);
         }
 
         // Return a CobolFile instance
@@ -594,12 +595,12 @@ class IndexedFileUtilMain {
             boolean duplicate) {
 
         CobolFileKey cobolFileKey = new CobolFileKey();
-        cobolFileKey.setOffset(offset - 1);
+        cobolFileKey.setOffset(offset);
         cobolFileKey.setFlag(duplicate ? 1 : 0);
         AbstractCobolField keyField =
                 CobolFieldFactory.makeCobolField(
                         size,
-                        recordStorage.getSubDataStorage(offset - 1),
+                        recordStorage.getSubDataStorage(offset),
                         new CobolFieldAttribute(33, 0, 0, 0, null));
         cobolFileKey.setField(keyField);
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -53,7 +53,7 @@ class IndexedFileUtilMain {
         options.addOption("v", "version", false, "Print the version");
         options.addOption("n", "new", false, "Delete all data before loading");
         options.addOption("f", "format", true, "Specify the format of the input and output data");
-        options.addOption("r", "record-size", true, "Specify the record size of the indexed file.");
+        options.addOption("s", "size", true, "Specify the record size of the indexed file.");
         options.addOption("k", "key", true, "Specify the key information of the indexed file.");
         options.addOption(
                 "d", "dup-key", true, "Specify the duplicate key information of the indexed file.");
@@ -200,7 +200,7 @@ class IndexedFileUtilMain {
         System.out.println("    Show information of the indexed file.");
         System.out.println();
         System.out.println(
-                "cobj-idx create <indexed file> --record-size=<record size> --key=<start"
+                "cobj-idx create <indexed file> --size=<record size> --key=<start"
                         + " index>,<size> --dup-key=<start index>,<size>");
         System.out.println("    Create a new indexed file.");
         System.out.println("    The record size and key information are specified by the options.");
@@ -212,7 +212,7 @@ class IndexedFileUtilMain {
                 "    The alternate key can be specified as a duplicate key by using the --dup-key"
                         + " option.");
         System.out.println(
-                "    Example) cobj-idx create test.idx --record-size=100 --key=1,10 --key=20,5"
+                "    Example) cobj-idx create test.idx --size=100 --key=1,10 --key=20,5"
                         + " --dup-key=30,3");
         System.out.println("             File name: test.idx");
         System.out.println("             Record size: 100");

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -270,8 +270,7 @@ class IndexedFileUtilMain {
                     String keyType = "k".equals(option.getOpt()) ? "key" : "duplicate key";
                     throw new IllegalArgumentException(
                             String.format(
-                                    "error: invalid %s information: %s",
-                                    keyType, option.getValue()));
+                                    "invalid %s information: %s", keyType, option.getValue()));
                 }
                 int offset = Integer.parseInt(keyInfo[0]);
                 int size = Integer.parseInt(keyInfo[1]);
@@ -595,12 +594,12 @@ class IndexedFileUtilMain {
             boolean duplicate) {
 
         CobolFileKey cobolFileKey = new CobolFileKey();
-        cobolFileKey.setOffset(offset);
+        cobolFileKey.setOffset(offset - 1);
         cobolFileKey.setFlag(duplicate ? 1 : 0);
         AbstractCobolField keyField =
                 CobolFieldFactory.makeCobolField(
                         size,
-                        recordStorage.getSubDataStorage(offset),
+                        recordStorage.getSubDataStorage(offset - 1),
                         new CobolFieldAttribute(33, 0, 0, 0, null));
         cobolFileKey.setField(keyField);
 
@@ -682,13 +681,9 @@ class IndexedFileUtilMain {
                     "the first key (primary key) must not be a duplicate key.");
         }
         for (CobolFileKeyInfo keyInfo : keyInfoList) {
-            if (keyInfo.offset <= 0 || keyInfo.size <= 0) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "invalid key information: offset=%d, size=%d",
-                                keyInfo.offset, keyInfo.size));
-            }
-            if (keyInfo.offset + keyInfo.size > recordSize + 1) {
+            if (keyInfo.offset <= 0
+                    || keyInfo.size <= 0
+                    || keyInfo.offset + keyInfo.size > recordSize + 1) {
                 throw new IllegalArgumentException(
                         String.format(
                                 "invalid key information: offset=%d, size=%d, record size=%d",
@@ -741,6 +736,11 @@ class IndexedFileUtilMain {
                 throw new IllegalArgumentException("failed to open the indexed file.");
             }
             cobolIndexedFile.close(0, null);
+        } else {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s is already exists. Use -o or --overwrite option to overwrite it.",
+                            indexedFilePath));
         }
     }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -13,6 +13,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import jp.osscons.opensourcecobol.libcobj.common.CobolModule;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
@@ -27,7 +29,6 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolIndexedFile;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.sqlite.SQLiteConfig;
@@ -55,8 +56,6 @@ class IndexedFileUtilMain {
         options.addOption("f", "format", true, "Specify the format of the input and output data");
         options.addOption("s", "size", true, "Specify the record size of the indexed file.");
         options.addOption("k", "key", true, "Specify the key information of the indexed file.");
-        options.addOption(
-                "d", "dup-key", true, "Specify the duplicate key information of the indexed file.");
         options.addOption("o", "overwrite", false, "Overwrite the indexed file if it exists.");
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd;
@@ -131,7 +130,7 @@ class IndexedFileUtilMain {
                 validateCreateCommandArgs(unrecognizedArgs, cmd);
                 String indexedFilePath = unrecognizedArgs[1];
                 int recordSize = parseRecordSize(cmd);
-                List<CobolFileKeyInfo> keyInfoList = parseKeyOptions(cmd.getOptions());
+                List<CobolFileKeyInfo> keyInfoList = parseKeyOptions(cmd);
                 validateKeyInfoList(keyInfoList, recordSize);
                 processCreateIndexedFile(indexedFilePath, recordSize, keyInfoList, cmd);
                 System.exit(0);
@@ -200,25 +199,17 @@ class IndexedFileUtilMain {
         System.out.println("    Show information of the indexed file.");
         System.out.println();
         System.out.println(
-                "cobj-idx create <indexed file> --size=<record size> --key=<start"
-                        + " index>,<size> --dup-key=<start index>,<size>");
+                "cobj-idx create <indexed file> --size=<record size> --key=<key information>");
         System.out.println("    Create a new indexed file.");
         System.out.println("    The record size and key information are specified by the options.");
         System.out.println("    By default, this command does not overwrite the indexed file.");
         System.out.println("    To overwrite the indexed file, use the --overwrite option.");
-        System.out.println(
-                "    The first key is the primary key and the others are alternate keys.");
-        System.out.println(
-                "    The alternate key can be specified as a duplicate key by using the --dup-key"
-                        + " option.");
-        System.out.println(
-                "    Example) cobj-idx create test.idx --size=100 --key=1,10 --key=20,5"
-                        + " --dup-key=30,3");
+        System.out.println("    Example) cobj-idx create test.idx --size=100 --key=2,2:5,4:d15,5");
         System.out.println("             File name: test.idx");
         System.out.println("             Record size: 100");
-        System.out.println("             Primary key: 1-10");
-        System.out.println("             Alternate key (No Duplicates): 20-24");
-        System.out.println("             Alternate key (Duplicates): 30-32");
+        System.out.println("             Primary key: 2-3");
+        System.out.println("             Alternate key (No Duplicates):5-8");
+        System.out.println("             Alternate key (Duplicates): 15-19");
         System.out.println();
         System.out.println("cobj-idx load <indexed file>");
         System.out.println("    Load the data from stdin into the indexed file.");
@@ -269,26 +260,50 @@ class IndexedFileUtilMain {
      * @param options TODO: 準備中
      * @return TODO: 準備中
      */
-    private static List<CobolFileKeyInfo> parseKeyOptions(Option[] options) throws Exception {
-        ArrayList<CobolFileKeyInfo> keyInfoList = new ArrayList<>();
-        for (Option option : options) {
-            if ("k".equals(option.getOpt()) || "d".equals(option.getOpt())) {
-                String[] keyInfo = option.getValue().split(",");
-                if (keyInfo.length != 2) {
-                    String keyType = "k".equals(option.getOpt()) ? "key" : "duplicate key";
-                    throw new IllegalArgumentException(
-                            String.format(
-                                    "invalid %s information: %s", keyType, option.getValue()));
-                }
-                int offset = Integer.parseInt(keyInfo[0]);
-                int size = Integer.parseInt(keyInfo[1]);
-                boolean duplicate = "d".equals(option.getOpt());
+    private static List<CobolFileKeyInfo> parseKeyOptions(CommandLine cmd) throws Exception {
+        if (cmd.hasOption("k")) {
+            ArrayList<CobolFileKeyInfo> keyInfoList = new ArrayList<>();
 
-                CobolFileKeyInfo cobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
-                keyInfoList.add(cobolFileKeyInfo);
+            String keyOption = cmd.getOptionValue("k");
+            Pattern pattern =
+                    Pattern.compile("[1-9][0-9]*,[1-9][0-9]*(:d?[1-9][0-9]*,[1-9][0-9]*)*");
+            Matcher matcher = pattern.matcher(keyOption);
+
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException(
+                        String.format("invalid key information: %s", keyOption));
             }
+            String[] keys = keyOption.split(":");
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+                boolean isFirstKey = (i == 0);
+                String[] keyInfo = key.split(",");
+                if (keyInfo.length != 2) {
+                    throw new IllegalArgumentException(
+                            String.format("invalid key information: %s", keyOption));
+                }
+                String offsetString = keyInfo[0];
+                boolean duplicate = false;
+                if (keyInfo[0].startsWith("d")) {
+                    if (isFirstKey) {
+                        throw new IllegalArgumentException(
+                                String.format(
+                                        "the first key (primary key) must not be a duplicate"
+                                                + " key."));
+                    }
+                    offsetString = keyInfo[0].substring(1);
+                    duplicate = true;
+                }
+                int offset = Integer.parseInt(offsetString);
+                int size = Integer.parseInt(keyInfo[1]);
+
+                CobolFileKeyInfo keyInfoObj = new CobolFileKeyInfo(offset, size, duplicate);
+                keyInfoList.add(keyInfoObj);
+            }
+            return keyInfoList;
+        } else {
+            throw new IllegalArgumentException("no key information is specified.");
         }
-        return keyInfoList;
     }
 
     /**
@@ -661,13 +676,13 @@ class IndexedFileUtilMain {
         if (unrecognizedArgs.length < 2) {
             throw new IllegalArgumentException("no indexed file is specified.");
         }
-        if (!cmd.hasOption("r")) {
+        if (!cmd.hasOption("s")) {
             throw new IllegalArgumentException("no record size is specified.");
         }
     }
 
     private static int parseRecordSize(CommandLine cmd) {
-        String recordSizeString = cmd.getOptionValue("r");
+        String recordSizeString = cmd.getOptionValue("s");
         int recordSize;
         try {
             recordSize = Integer.parseInt(recordSizeString);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -180,8 +180,7 @@ class IndexedFileUtilMain {
                     keyInfo.offset--;
                 }
                 Optional<CobolFile> cobolFile =
-                        createCobolFile(
-                                indexedFilePath, Optional.of(recordSize), Optional.of(keyInfoList));
+                        createCobolFile(indexedFilePath, recordSize, keyInfoList);
                 if (!cobolFile.isPresent()) {
                     System.err.println(
                             String.format(
@@ -586,7 +585,46 @@ class IndexedFileUtilMain {
     }
 
     private static Optional<CobolFile> createCobolFileFromIndexedFilePath(String indexedFilePath) {
-        return createCobolFile(indexedFilePath, Optional.empty(), Optional.empty());
+        SQLiteConfig config = new SQLiteConfig();
+        config.setReadOnly(true);
+
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                "jdbc:sqlite:" + indexedFilePath, config.toProperties());
+                Statement stmt = conn.createStatement(); ) {
+
+            ResultSet rs =
+                    stmt.executeQuery(
+                            "select value from metadata_string_int where key = 'record_size'");
+            if (!rs.next()) {
+                return Optional.empty();
+            }
+
+            int recordSize = rs.getInt("value");
+
+            // Create a record field and data storage
+            AbstractCobolField recordField = createIndexedRecordField(recordSize);
+            CobolDataStorage recordDataStorage = recordField.getDataStorage();
+
+            // Retrive key information
+            List<CobolFileKey> keyList = new ArrayList<>();
+            rs =
+                    stmt.executeQuery(
+                            "select idx, offset, size, duplicate from metadata_key order by"
+                                    + " idx");
+            while (rs.next()) {
+                int offset = rs.getInt("offset");
+                int size = rs.getInt("size");
+                boolean duplicate = rs.getBoolean("duplicate");
+                addCobolFileKeyToList(keyList, recordDataStorage, offset, size, duplicate);
+            }
+
+            // Return a CobolFile instance
+            return Optional.of(
+                    createCobolFileInstance(indexedFilePath, recordSize, recordField, keyList));
+        } catch (SQLException e) {
+            return Optional.empty();
+        }
     }
 
     /**
@@ -596,125 +634,30 @@ class IndexedFileUtilMain {
      * @return CobolFile instance if success, otherwise empty.
      */
     private static Optional<CobolFile> createCobolFile(
-            String indexedFilePath,
-            Optional<Integer> optionRecordSize,
-            Optional<List<CobolFileKeyInfo>> optionKeyInfoList) {
+            String indexedFilePath, Integer recordSize, List<CobolFileKeyInfo> keyInfoList) {
         SQLiteConfig config = new SQLiteConfig();
         config.setReadOnly(true);
 
-        Connection conn = null;
-        Statement stmt = null;
-        if (!optionRecordSize.isPresent() || !optionKeyInfoList.isPresent()) {
-            try {
-                conn =
-                        DriverManager.getConnection(
-                                "jdbc:sqlite:" + indexedFilePath, config.toProperties());
-                stmt = conn.createStatement();
-            } catch (SQLException e) {
-                System.err.println("[dbg] 1 error: " + e.getMessage());
-                return Optional.empty();
-            }
-        }
-
-        int recordSize = 0;
-        if (optionRecordSize.isPresent()) {
-            recordSize = optionRecordSize.get();
-        } else {
-            // Retrieve the record size
-            try {
-                ResultSet rs =
-                        stmt.executeQuery(
-                                "select value from metadata_string_int where key = 'record_size'");
-                if (!rs.next()) {
-                    return Optional.empty();
-                }
-                recordSize = rs.getInt("value");
-            } catch (SQLException e) {
-                System.err.println("[dbg] 2 error: " + e.getMessage());
-                return Optional.empty();
-            }
-        }
-
         // Create a record field
-        byte[] recordByteArray = new byte[recordSize];
-        CobolDataStorage recordDataStorage = new CobolDataStorage(recordByteArray);
-        AbstractCobolField recordField =
-                CobolFieldFactory.makeCobolField(
-                        recordSize, recordDataStorage, new CobolFieldAttribute(1, 0, 0, 0, null));
+        AbstractCobolField recordField = createIndexedRecordField(recordSize);
+        CobolDataStorage recordDataStorage = recordField.getDataStorage();
 
         // Retrive key information
         List<CobolFileKey> keyList = new ArrayList<>();
-        if (optionKeyInfoList.isPresent()) {
-            List<CobolFileKeyInfo> keys = optionKeyInfoList.get();
-            for (CobolFileKeyInfo key : keys) {
-                addCobolFileKeyToList(
-                        keyList, recordDataStorage, key.offset, key.size, key.duplicate);
-            }
-        } else {
-            try {
-                ResultSet rs =
-                        stmt.executeQuery(
-                                "select idx, offset, size, duplicate from metadata_key order by"
-                                        + " idx");
-                while (rs.next()) {
-                    int offset = rs.getInt("offset");
-                    int size = rs.getInt("size");
-                    boolean duplicate = rs.getBoolean("duplicate");
-                    addCobolFileKeyToList(keyList, recordDataStorage, offset, size, duplicate);
-                }
-            } catch (SQLException e) {
-                System.err.println("[dbg] 3 error: " + e.getMessage());
-                return Optional.empty();
-            }
+        for (CobolFileKeyInfo key : keyInfoList) {
+            addCobolFileKeyToList(keyList, recordDataStorage, key.offset, key.size, key.duplicate);
         }
 
-        if (conn != null) {
-            try {
-                conn.close();
-            } catch (SQLException e) {
-                System.err.println("[dbg] 4 error: " + e.getMessage());
-                return Optional.empty();
-            }
-        }
+        // Return a CobolFile instance
+        return Optional.of(
+                createCobolFileInstance(indexedFilePath, recordSize, recordField, keyList));
+    }
 
-        // Construct a CobolFile instance
-        byte[] fileStatus = new byte[4];
-        byte[] indxedFilePathBytes = indexedFilePath.getBytes(AbstractCobolField.charSetSJIS);
-        AbstractCobolField assignField =
-                CobolFieldFactory.makeCobolField(
-                        indxedFilePathBytes.length,
-                        new CobolDataStorage(indxedFilePathBytes),
-                        new CobolFieldAttribute(33, 0, 0, 0, null));
-        CobolFileKey[] keyArray = new CobolFileKey[keyList.size()];
-        keyList.toArray(keyArray);
-        CobolFile cobolFile =
-                CobolFileFactory.makeCobolFileInstance(
-                        "f",
-                        fileStatus,
-                        assignField,
-                        recordField,
-                        null,
-                        recordSize,
-                        recordSize,
-                        keyArray.length,
-                        keyArray,
-                        (char) 3,
-                        (char) 1,
-                        (char) 0,
-                        (char) 0,
-                        false,
-                        (char) 0,
-                        (char) 0,
-                        false,
-                        false,
-                        false,
-                        (char) 0,
-                        false,
-                        (char) 2,
-                        false,
-                        false,
-                        (char) 0);
-        return Optional.of(cobolFile);
+    private static AbstractCobolField createIndexedRecordField(int recordSize) {
+        byte[] recordByteArray = new byte[recordSize];
+        CobolDataStorage recordDataStorage = new CobolDataStorage(recordByteArray);
+        return CobolFieldFactory.makeCobolField(
+                recordSize, recordDataStorage, new CobolFieldAttribute(1, 0, 0, 0, null));
     }
 
     private static void addCobolFileKeyToList(
@@ -735,6 +678,48 @@ class IndexedFileUtilMain {
         cobolFileKey.setField(keyField);
 
         keyList.add(cobolFileKey);
+    }
+
+    private static CobolFile createCobolFileInstance(
+            String indexedFilePath,
+            int recordSize,
+            AbstractCobolField recordField,
+            List<CobolFileKey> keyList) {
+        byte[] fileStatus = new byte[4];
+        byte[] indxedFilePathBytes = indexedFilePath.getBytes(AbstractCobolField.charSetSJIS);
+        AbstractCobolField assignField =
+                CobolFieldFactory.makeCobolField(
+                        indxedFilePathBytes.length,
+                        new CobolDataStorage(indxedFilePathBytes),
+                        new CobolFieldAttribute(33, 0, 0, 0, null));
+        CobolFileKey[] keyArray = new CobolFileKey[keyList.size()];
+        keyList.toArray(keyArray);
+        return CobolFileFactory.makeCobolFileInstance(
+                "f",
+                fileStatus,
+                assignField,
+                recordField,
+                null,
+                recordSize,
+                recordSize,
+                keyArray.length,
+                keyArray,
+                (char) 3,
+                (char) 1,
+                (char) 0,
+                (char) 0,
+                false,
+                (char) 0,
+                (char) 0,
+                false,
+                false,
+                false,
+                (char) 0,
+                false,
+                (char) 2,
+                false,
+                false,
+                (char) 0);
     }
 }
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -180,6 +180,17 @@ class IndexedFileUtilMain {
         System.out.println("cobj-idx info <indexed-file>");
         System.out.println("    Show information of the indexed file.");
         System.out.println();
+        System.out.println(
+                "cobj-idx create <indexed file> --record-size=<record size> --key=<start"
+                        + " index>,<size> --dup-key=<start index>,<size>");
+        System.out.println("    Create a new indexed file.");
+        System.out.println("    The record size and key information are specified by the options.");
+        System.out.println(
+                "    The first key is the primary key and the others are alternate keys.");
+        System.out.println(
+                "    The alternate key can be specified as a duplicate key by using the --dup-key"
+                        + " option.");
+        System.out.println();
         System.out.println("cobj-idx load <indexed file>");
         System.out.println("    Load the data from stdin into the indexed file.");
         System.out.println("    The default format of the input data is SEQUENTIAL of COBOL.");

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -175,10 +175,6 @@ class IndexedFileUtilMain {
                                         keyInfo.offset, keyInfo.size, recordSize));
                     }
                 }
-                for (CobolFileKeyInfo keyInfo : keyInfoList) {
-                    // Convert to 0-based index
-                    keyInfo.offset--;
-                }
                 Optional<CobolFile> cobolFile =
                         createCobolFile(indexedFilePath, recordSize, keyInfoList);
                 if (!cobolFile.isPresent()) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -254,10 +254,10 @@ class IndexedFileUtilMain {
     }
 
     /**
-     * Parse the key options and return a list of CobolFileKey.
+     * Parse the key options and return a list of CobolFileKeyInfo.
      *
-     * @param options TODO: 準備中
-     * @return TODO: 準備中
+     * @param cmd the CommandLine object containing the parsed command line arguments
+     * @return a list of CobolFileKeyInfo objects parsed from the key options in the provided CommandLine argument
      */
     private static List<CobolFileKeyInfo> parseKeyOptions(CommandLine cmd) throws Exception {
         if (cmd.hasOption("k")) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -277,6 +277,40 @@ class IndexedFileUtilMain {
                     throw new IllegalArgumentException(
                             "the first key (primary key) must not be a duplicate key.");
                 }
+
+                Pattern patternContains0 = Pattern.compile("[0-9]+,[0-9]+(:d?[0-9]+,[0-9]+)*");
+                matcher = patternContains0.matcher(keyOption);
+                if (matcher.matches()) {
+                    String[] keys = keyOption.split(":");
+                    for (int i = 0; i < keys.length; i++) {
+                        String key = keys[i];
+                        String[] keyInfo = key.split(",");
+                        String offsetString = keyInfo[0];
+                        if (offsetString.startsWith("d")) {
+                            offsetString = offsetString.substring(1);
+                        }
+
+                        if ("0".equals(offsetString)) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "key offsets must be greater than 0: %s", keyOption));
+                        } else if (offsetString.startsWith("0")) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "key offsets must not start with 0: %s", keyOption));
+                        }
+                        String sizeString = keyInfo[1];
+                        if ("0".equals(sizeString)) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "key sizes must be greater than 0: %s", keyOption));
+                        } else if (sizeString.startsWith("0")) {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "key sizes must not start with 0: %s", keyOption));
+                        }
+                    }
+                }
                 throw new IllegalArgumentException(
                         String.format("invalid key information: %s", keyOption));
             }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -27,6 +27,7 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolIndexedFile;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.sqlite.SQLiteConfig;
@@ -52,6 +53,10 @@ class IndexedFileUtilMain {
         options.addOption("v", "version", false, "Print the version");
         options.addOption("n", "new", false, "Delete all data before loading");
         options.addOption("f", "format", true, "Specify the format of the input and output data");
+        options.addOption("r", "record-size", true, "Specify the record size of the indexed file.");
+        options.addOption("k", "key", true, "Specify the key information of the indexed file.");
+        options.addOption(
+                "d", "dup-key", true, "Specify the duplicate key information of the indexed file.");
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd;
 
@@ -120,7 +125,46 @@ class IndexedFileUtilMain {
             String indexedFilePath = args[1];
             int exitCode = processInfoCommand(indexedFilePath);
             System.exit(exitCode);
-
+        } else if ("create".equals(subCommand)) {
+            if (unrecognizedArgs.length < 2) {
+                System.err.println("error: no indexed file is specified.");
+                System.exit(1);
+            }
+            String indexedFilePath = unrecognizedArgs[1];
+            List<CobolFileKeyInfo> keyInfoList;
+            try {
+                keyInfoList = parseKeyOptions(cmd.getOptions());
+                String recordSizeString = cmd.getOptionValue("r");
+                int recordSize = 0;
+                try {
+                    recordSize = Integer.parseInt(recordSizeString);
+                } catch (NumberFormatException e) {
+                    System.err.println(
+                            String.format("error: invalid record size: %s", recordSizeString));
+                    System.exit(1);
+                }
+                if (recordSize <= 0) {
+                    throw new IllegalArgumentException(
+                            String.format("error: invalid record size: %d", recordSize));
+                }
+                Optional<CobolFile> cobolFile =
+                        createCobolFile(
+                                indexedFilePath, Optional.of(recordSize), Optional.of(keyInfoList));
+                if (!cobolFile.isPresent()) {
+                    System.err.println(
+                            String.format(
+                                    "error: failed to create a cobol file from the indexed file:"
+                                            + " %s",
+                                    indexedFilePath));
+                    System.exit(1);
+                }
+                CobolIndexedFile cobolIndexedFile = (CobolIndexedFile) cobolFile.get();
+                cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
+            } catch (Exception e) {
+                System.err.println("error: " + e.getMessage());
+                System.exit(1);
+            }
+            System.exit(0);
         } else if ("load".equals(subCommand)) {
             if (unrecognizedArgs.length < 2 || unrecognizedArgs.length > 3) {
                 if (unrecognizedArgs.length < 2) {
@@ -232,6 +276,35 @@ class IndexedFileUtilMain {
         System.out.println();
         System.out.println("-v, --version");
         System.out.println("    Print the version of cobj-idx.");
+    }
+
+    /**
+     * Parse the key options and return a list of CobolFileKey.
+     *
+     * @param options TODO: 準備中
+     * @return TODO: 準備中
+     */
+    private static List<CobolFileKeyInfo> parseKeyOptions(Option[] options) throws Exception {
+        ArrayList<CobolFileKeyInfo> keyInfoList = new ArrayList<>();
+        for (Option option : options) {
+            if ("k".equals(option.getOpt()) || "d".equals(option.getOpt())) {
+                String[] keyInfo = option.getValue().split(",");
+                if (keyInfo.length != 2) {
+                    String keyType = "k".equals(option.getOpt()) ? "key" : "duplicate key";
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "error: invalid %s information: %s",
+                                    keyType, option.getValue()));
+                }
+                int offset = Integer.parseInt(keyInfo[0]);
+                int size = Integer.parseInt(keyInfo[1]);
+                boolean duplicate = "d".equals(option.getOpt());
+
+                CobolFileKeyInfo cobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
+                keyInfoList.add(cobolFileKeyInfo);
+            }
+        }
+        return keyInfoList;
     }
 
     /**
@@ -474,7 +547,7 @@ class IndexedFileUtilMain {
     private static Optional<CobolFile> createCobolFile(
             String indexedFilePath,
             Optional<Integer> optionRecordSize,
-            Optional<ArrayList<CobolFileKey>> optionKeyList) {
+            Optional<List<CobolFileKeyInfo>> optionKeyInfoList) {
         SQLiteConfig config = new SQLiteConfig();
         config.setReadOnly(true);
 
@@ -507,11 +580,14 @@ class IndexedFileUtilMain {
                             new CobolFieldAttribute(1, 0, 0, 0, null));
 
             // Retrive key information
-            List<CobolFileKey> keyList;
-            if (optionKeyList.isPresent()) {
-                keyList = optionKeyList.get();
+            List<CobolFileKey> keyList = new ArrayList<>();
+            if (optionKeyInfoList.isPresent()) {
+                List<CobolFileKeyInfo> keys = optionKeyInfoList.get();
+                for (CobolFileKeyInfo key : keys) {
+                    addCobolFileKeyToList(
+                            keyList, recordDataStorage, key.offset, key.size, key.duplicate);
+                }
             } else {
-                keyList = new ArrayList<>();
                 ResultSet rs =
                         stmt.executeQuery(
                                 "select idx, offset, size, duplicate from metadata_key order by"
@@ -520,18 +596,7 @@ class IndexedFileUtilMain {
                     int offset = rs.getInt("offset");
                     int size = rs.getInt("size");
                     boolean duplicate = rs.getBoolean("duplicate");
-
-                    CobolFileKey cobolFileKey = new CobolFileKey();
-                    cobolFileKey.setOffset(offset);
-                    cobolFileKey.setFlag(duplicate ? 1 : 0);
-                    AbstractCobolField keyField =
-                            CobolFieldFactory.makeCobolField(
-                                    size,
-                                    recordDataStorage.getSubDataStorage(offset),
-                                    new CobolFieldAttribute(33, 0, 0, 0, null));
-                    cobolFileKey.setField(keyField);
-
-                    keyList.add(cobolFileKey);
+                    addCobolFileKeyToList(keyList, recordDataStorage, offset, size, duplicate);
                 }
             }
 
@@ -577,5 +642,37 @@ class IndexedFileUtilMain {
         } catch (SQLException e) {
             return Optional.empty();
         }
+    }
+
+    private static void addCobolFileKeyToList(
+            List<CobolFileKey> keyList,
+            CobolDataStorage recordStorage,
+            int offset,
+            int size,
+            boolean duplicate) {
+
+        CobolFileKey cobolFileKey = new CobolFileKey();
+        cobolFileKey.setOffset(offset);
+        cobolFileKey.setFlag(duplicate ? 1 : 0);
+        AbstractCobolField keyField =
+                CobolFieldFactory.makeCobolField(
+                        size,
+                        recordStorage.getSubDataStorage(offset),
+                        new CobolFieldAttribute(33, 0, 0, 0, null));
+        cobolFileKey.setField(keyField);
+
+        keyList.add(cobolFileKey);
+    }
+}
+
+class CobolFileKeyInfo {
+    public int offset;
+    public int size;
+    public boolean duplicate;
+
+    public CobolFileKeyInfo(int offset, int size, boolean duplicate) {
+        this.offset = offset;
+        this.size = size;
+        this.duplicate = duplicate;
     }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -130,10 +130,22 @@ class IndexedFileUtilMain {
                 System.err.println("error: no indexed file is specified.");
                 System.exit(1);
             }
+            if (!cmd.hasOption("r")) {
+                System.err.println("error: no record size is specified.");
+                System.exit(1);
+            }
             String indexedFilePath = unrecognizedArgs[1];
             List<CobolFileKeyInfo> keyInfoList;
             try {
                 keyInfoList = parseKeyOptions(cmd.getOptions());
+                if (keyInfoList.isEmpty()) {
+                    System.err.println("error: no key information is specified.");
+                    System.exit(1);
+                } else if (keyInforList.get(0).duplicate) {
+                    System.err.println(
+                            "error: the first key (primary key) must not be a duplicate key.");
+                    System.exit(1);
+                }
                 String recordSizeString = cmd.getOptionValue("r");
                 int recordSize = 0;
                 try {
@@ -146,6 +158,25 @@ class IndexedFileUtilMain {
                 if (recordSize <= 0) {
                     throw new IllegalArgumentException(
                             String.format("error: invalid record size: %d", recordSize));
+                }
+                for (CobolFileKeyInfo keyInfo : keyInfoList) {
+                    if (keyInfo.offset <= 0 || keyInfo.size <= 0) {
+                        throw new IllegalArgumentException(
+                                String.format(
+                                        "error: invalid key information: offset=%d, size=%d",
+                                        keyInfo.offset, keyInfo.size));
+                    }
+                    if (keyInfo.offset + keyInfo.size > recordSize + 1) {
+                        throw new IllegalArgumentException(
+                                String.format(
+                                        "error: invalid key information: offset=%d, size=%d, record"
+                                                + " size=%d",
+                                        keyInfo.offset, keyInfo.size, recordSize));
+                    }
+                }
+                for (CobolFileKeyInfo keyInfo : keyInfoList) {
+                    // Convert to 0-based index
+                    keyInfo.offset--;
                 }
                 Optional<CobolFile> cobolFile =
                         createCobolFile(

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -196,6 +196,11 @@ class IndexedFileUtilMain {
                 boolean indexedFileAlreadyExists = new File(indexedFilePath).exists();
 
                 if (enableOverwriteOption || !indexedFileAlreadyExists) {
+                    // Set the module
+                    CobolModule module =
+                            new CobolModule(
+                                    null, null, null, null, 0, '.', '$', ',', 1, 1, 1, 0, null);
+                    CobolModule.push(module);
                     cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
                     if (CobolRuntimeException.code != 0) {
                         System.err.println("error: failed to open the indexed file.");
@@ -273,6 +278,8 @@ class IndexedFileUtilMain {
                         + " index>,<size> --dup-key=<start index>,<size>");
         System.out.println("    Create a new indexed file.");
         System.out.println("    The record size and key information are specified by the options.");
+        System.out.println("    By default, this command does not overwrite the indexed file.");
+        System.out.println("    To overwrite the indexed file, use the --overwrite option.");
         System.out.println(
                 "    The first key is the primary key and the others are alternate keys.");
         System.out.println(
@@ -595,16 +602,26 @@ class IndexedFileUtilMain {
         SQLiteConfig config = new SQLiteConfig();
         config.setReadOnly(true);
 
-        try (Connection conn =
+        Connection conn = null;
+        Statement stmt = null;
+        if (!optionRecordSize.isPresent() || !optionKeyInfoList.isPresent()) {
+            try {
+                conn =
                         DriverManager.getConnection(
                                 "jdbc:sqlite:" + indexedFilePath, config.toProperties());
-                Statement stmt = conn.createStatement(); ) {
+                stmt = conn.createStatement();
+            } catch (SQLException e) {
+                System.err.println("[dbg] 1 error: " + e.getMessage());
+                return Optional.empty();
+            }
+        }
 
-            int recordSize;
-            if (optionRecordSize.isPresent()) {
-                recordSize = optionRecordSize.get();
-            } else {
-                // Retrieve the record size
+        int recordSize = 0;
+        if (optionRecordSize.isPresent()) {
+            recordSize = optionRecordSize.get();
+        } else {
+            // Retrieve the record size
+            try {
                 ResultSet rs =
                         stmt.executeQuery(
                                 "select value from metadata_string_int where key = 'record_size'");
@@ -612,26 +629,29 @@ class IndexedFileUtilMain {
                     return Optional.empty();
                 }
                 recordSize = rs.getInt("value");
+            } catch (SQLException e) {
+                System.err.println("[dbg] 2 error: " + e.getMessage());
+                return Optional.empty();
             }
+        }
 
-            // Create a record field
-            byte[] recordByteArray = new byte[recordSize];
-            CobolDataStorage recordDataStorage = new CobolDataStorage(recordByteArray);
-            AbstractCobolField recordField =
-                    CobolFieldFactory.makeCobolField(
-                            recordSize,
-                            recordDataStorage,
-                            new CobolFieldAttribute(1, 0, 0, 0, null));
+        // Create a record field
+        byte[] recordByteArray = new byte[recordSize];
+        CobolDataStorage recordDataStorage = new CobolDataStorage(recordByteArray);
+        AbstractCobolField recordField =
+                CobolFieldFactory.makeCobolField(
+                        recordSize, recordDataStorage, new CobolFieldAttribute(1, 0, 0, 0, null));
 
-            // Retrive key information
-            List<CobolFileKey> keyList = new ArrayList<>();
-            if (optionKeyInfoList.isPresent()) {
-                List<CobolFileKeyInfo> keys = optionKeyInfoList.get();
-                for (CobolFileKeyInfo key : keys) {
-                    addCobolFileKeyToList(
-                            keyList, recordDataStorage, key.offset, key.size, key.duplicate);
-                }
-            } else {
+        // Retrive key information
+        List<CobolFileKey> keyList = new ArrayList<>();
+        if (optionKeyInfoList.isPresent()) {
+            List<CobolFileKeyInfo> keys = optionKeyInfoList.get();
+            for (CobolFileKeyInfo key : keys) {
+                addCobolFileKeyToList(
+                        keyList, recordDataStorage, key.offset, key.size, key.duplicate);
+            }
+        } else {
+            try {
                 ResultSet rs =
                         stmt.executeQuery(
                                 "select idx, offset, size, duplicate from metadata_key order by"
@@ -642,50 +662,59 @@ class IndexedFileUtilMain {
                     boolean duplicate = rs.getBoolean("duplicate");
                     addCobolFileKeyToList(keyList, recordDataStorage, offset, size, duplicate);
                 }
+            } catch (SQLException e) {
+                System.err.println("[dbg] 3 error: " + e.getMessage());
+                return Optional.empty();
             }
-
-            // Construct a CobolFile instance
-            byte[] fileStatus = new byte[4];
-            byte[] indxedFilePathBytes = indexedFilePath.getBytes(AbstractCobolField.charSetSJIS);
-            AbstractCobolField assignField =
-                    CobolFieldFactory.makeCobolField(
-                            indxedFilePathBytes.length,
-                            new CobolDataStorage(indxedFilePathBytes),
-                            new CobolFieldAttribute(33, 0, 0, 0, null));
-            CobolFileKey[] keyArray = new CobolFileKey[keyList.size()];
-            keyList.toArray(keyArray);
-            CobolFile cobolFile =
-                    CobolFileFactory.makeCobolFileInstance(
-                            "f",
-                            fileStatus,
-                            assignField,
-                            recordField,
-                            null,
-                            recordSize,
-                            recordSize,
-                            keyArray.length,
-                            keyArray,
-                            (char) 3,
-                            (char) 1,
-                            (char) 0,
-                            (char) 0,
-                            false,
-                            (char) 0,
-                            (char) 0,
-                            false,
-                            false,
-                            false,
-                            (char) 0,
-                            false,
-                            (char) 2,
-                            false,
-                            false,
-                            (char) 0);
-            conn.close();
-            return Optional.of(cobolFile);
-        } catch (SQLException e) {
-            return Optional.empty();
         }
+
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                System.err.println("[dbg] 4 error: " + e.getMessage());
+                return Optional.empty();
+            }
+        }
+
+        // Construct a CobolFile instance
+        byte[] fileStatus = new byte[4];
+        byte[] indxedFilePathBytes = indexedFilePath.getBytes(AbstractCobolField.charSetSJIS);
+        AbstractCobolField assignField =
+                CobolFieldFactory.makeCobolField(
+                        indxedFilePathBytes.length,
+                        new CobolDataStorage(indxedFilePathBytes),
+                        new CobolFieldAttribute(33, 0, 0, 0, null));
+        CobolFileKey[] keyArray = new CobolFileKey[keyList.size()];
+        keyList.toArray(keyArray);
+        CobolFile cobolFile =
+                CobolFileFactory.makeCobolFileInstance(
+                        "f",
+                        fileStatus,
+                        assignField,
+                        recordField,
+                        null,
+                        recordSize,
+                        recordSize,
+                        keyArray.length,
+                        keyArray,
+                        (char) 3,
+                        (char) 1,
+                        (char) 0,
+                        (char) 0,
+                        false,
+                        (char) 0,
+                        (char) 0,
+                        false,
+                        false,
+                        false,
+                        (char) 0,
+                        false,
+                        (char) 2,
+                        false,
+                        false,
+                        (char) 0);
+        return Optional.of(cobolFile);
     }
 
     private static void addCobolFileKeyToList(

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -138,7 +138,6 @@ class IndexedFileUtilMain {
                 System.err.println("error: " + e.getMessage());
                 System.exit(1);
             }
-            System.exit(0);
         } else if ("load".equals(subCommand)) {
             if (unrecognizedArgs.length < 2 || unrecognizedArgs.length > 3) {
                 if (unrecognizedArgs.length < 2) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -282,8 +282,7 @@ class IndexedFileUtilMain {
                 matcher = patternContains0.matcher(keyOption);
                 if (matcher.matches()) {
                     String[] keys = keyOption.split(":");
-                    for (int i = 0; i < keys.length; i++) {
-                        String key = keys[i];
+                    for (String key : keys) {
                         String[] keyInfo = key.split(",");
                         String offsetString = keyInfo[0];
                         if (offsetString.startsWith("d")) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -160,6 +160,7 @@ class IndexedFileUtilMain {
                     throw new IllegalArgumentException(
                             String.format("error: invalid record size: %d", recordSize));
                 }
+
                 for (CobolFileKeyInfo keyInfo : keyInfoList) {
                     if (keyInfo.offset <= 0 || keyInfo.size <= 0) {
                         throw new IllegalArgumentException(
@@ -173,6 +174,28 @@ class IndexedFileUtilMain {
                                         "error: invalid key information: offset=%d, size=%d, record"
                                                 + " size=%d",
                                         keyInfo.offset, keyInfo.size, recordSize));
+                    }
+                }
+
+                // Check if key ranges overlap
+                for (int i = 0; i < keyInfoList.size(); i++) {
+                    CobolFileKeyInfo key1Info = keyInfoList.get(i);
+                    int key1IndexInf = key1Info.offset;
+                    int key1IndexSup = key1Info.offset + key1Info.size - 1;
+                    for (int j = 0; j < i; j++) {
+                        CobolFileKeyInfo key2Info = keyInfoList.get(j);
+                        int key2IndexInf = key2Info.offset;
+                        int key2IndexSup = key2Info.offset + key2Info.size - 1;
+                        if (key1IndexSup >= key2IndexInf || key1IndexInf <= key2IndexSup) {
+                            System.err.println(
+                                    String.format(
+                                            "error: keys overlap: %d,%d and %d,%d",
+                                            key1Info.offset,
+                                            key1Info.size,
+                                            key2Info.offset,
+                                            key2Info.size));
+                            System.exit(1);
+                        }
                     }
                 }
                 Optional<CobolFile> cobolFile =

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -57,6 +57,7 @@ class IndexedFileUtilMain {
         options.addOption("k", "key", true, "Specify the key information of the indexed file.");
         options.addOption(
                 "d", "dup-key", true, "Specify the duplicate key information of the indexed file.");
+        options.addOption("o", "overwrite", false, "Overwrite the indexed file if it exists.");
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd;
 
@@ -141,7 +142,7 @@ class IndexedFileUtilMain {
                 if (keyInfoList.isEmpty()) {
                     System.err.println("error: no key information is specified.");
                     System.exit(1);
-                } else if (keyInforList.get(0).duplicate) {
+                } else if (keyInfoList.get(0).duplicate) {
                     System.err.println(
                             "error: the first key (primary key) must not be a duplicate key.");
                     System.exit(1);
@@ -190,7 +191,19 @@ class IndexedFileUtilMain {
                     System.exit(1);
                 }
                 CobolIndexedFile cobolIndexedFile = (CobolIndexedFile) cobolFile.get();
-                cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
+
+                boolean enableOverwriteOption = cmd.hasOption("o");
+                boolean indexedFileAlreadyExists = new File(indexedFilePath).exists();
+
+                if (enableOverwriteOption || !indexedFileAlreadyExists) {
+                    cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
+                    if (CobolRuntimeException.code != 0) {
+                        System.err.println("error: failed to open the indexed file.");
+                        System.exit(1);
+                    }
+                    cobolIndexedFile.close(0, null);
+                }
+                System.exit(0);
             } catch (Exception e) {
                 System.err.println("error: " + e.getMessage());
                 System.exit(1);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -127,105 +127,13 @@ class IndexedFileUtilMain {
             int exitCode = processInfoCommand(indexedFilePath);
             System.exit(exitCode);
         } else if ("create".equals(subCommand)) {
-            if (unrecognizedArgs.length < 2) {
-                System.err.println("error: no indexed file is specified.");
-                System.exit(1);
-            }
-            if (!cmd.hasOption("r")) {
-                System.err.println("error: no record size is specified.");
-                System.exit(1);
-            }
-            String indexedFilePath = unrecognizedArgs[1];
-            List<CobolFileKeyInfo> keyInfoList;
             try {
-                keyInfoList = parseKeyOptions(cmd.getOptions());
-                if (keyInfoList.isEmpty()) {
-                    System.err.println("error: no key information is specified.");
-                    System.exit(1);
-                } else if (keyInfoList.get(0).duplicate) {
-                    System.err.println(
-                            "error: the first key (primary key) must not be a duplicate key.");
-                    System.exit(1);
-                }
-                String recordSizeString = cmd.getOptionValue("r");
-                int recordSize = 0;
-                try {
-                    recordSize = Integer.parseInt(recordSizeString);
-                } catch (NumberFormatException e) {
-                    System.err.println(
-                            String.format("error: invalid record size: %s", recordSizeString));
-                    System.exit(1);
-                }
-                if (recordSize <= 0) {
-                    throw new IllegalArgumentException(
-                            String.format("error: invalid record size: %d", recordSize));
-                }
-
-                for (CobolFileKeyInfo keyInfo : keyInfoList) {
-                    if (keyInfo.offset <= 0 || keyInfo.size <= 0) {
-                        throw new IllegalArgumentException(
-                                String.format(
-                                        "error: invalid key information: offset=%d, size=%d",
-                                        keyInfo.offset, keyInfo.size));
-                    }
-                    if (keyInfo.offset + keyInfo.size > recordSize + 1) {
-                        throw new IllegalArgumentException(
-                                String.format(
-                                        "error: invalid key information: offset=%d, size=%d, record"
-                                                + " size=%d",
-                                        keyInfo.offset, keyInfo.size, recordSize));
-                    }
-                }
-
-                // Check if key ranges overlap
-                for (int i = 0; i < keyInfoList.size(); i++) {
-                    CobolFileKeyInfo key1Info = keyInfoList.get(i);
-                    int key1IndexInf = key1Info.offset;
-                    int key1IndexSup = key1Info.offset + key1Info.size - 1;
-                    for (int j = 0; j < i; j++) {
-                        CobolFileKeyInfo key2Info = keyInfoList.get(j);
-                        int key2IndexInf = key2Info.offset;
-                        int key2IndexSup = key2Info.offset + key2Info.size - 1;
-                        if (key1IndexSup >= key2IndexInf || key1IndexInf <= key2IndexSup) {
-                            System.err.println(
-                                    String.format(
-                                            "error: keys overlap: %d,%d and %d,%d",
-                                            key1Info.offset,
-                                            key1Info.size,
-                                            key2Info.offset,
-                                            key2Info.size));
-                            System.exit(1);
-                        }
-                    }
-                }
-                Optional<CobolFile> cobolFile =
-                        createCobolFile(indexedFilePath, recordSize, keyInfoList);
-                if (!cobolFile.isPresent()) {
-                    System.err.println(
-                            String.format(
-                                    "error: failed to create a cobol file from the indexed file:"
-                                            + " %s",
-                                    indexedFilePath));
-                    System.exit(1);
-                }
-                CobolIndexedFile cobolIndexedFile = (CobolIndexedFile) cobolFile.get();
-
-                boolean enableOverwriteOption = cmd.hasOption("o");
-                boolean indexedFileAlreadyExists = new File(indexedFilePath).exists();
-
-                if (enableOverwriteOption || !indexedFileAlreadyExists) {
-                    // Set the module
-                    CobolModule module =
-                            new CobolModule(
-                                    null, null, null, null, 0, '.', '$', ',', 1, 1, 1, 0, null);
-                    CobolModule.push(module);
-                    cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
-                    if (CobolRuntimeException.code != 0) {
-                        System.err.println("error: failed to open the indexed file.");
-                        System.exit(1);
-                    }
-                    cobolIndexedFile.close(0, null);
-                }
+                validateCreateCommandArgs(unrecognizedArgs, cmd);
+                String indexedFilePath = unrecognizedArgs[1];
+                int recordSize = parseRecordSize(cmd);
+                List<CobolFileKeyInfo> keyInfoList = parseKeyOptions(cmd.getOptions());
+                validateKeyInfoList(keyInfoList, recordSize);
+                processCreateIndexedFile(indexedFilePath, recordSize, keyInfoList, cmd);
                 System.exit(0);
             } catch (Exception e) {
                 System.err.println("error: " + e.getMessage());
@@ -369,8 +277,8 @@ class IndexedFileUtilMain {
                 int size = Integer.parseInt(keyInfo[1]);
                 boolean duplicate = "d".equals(option.getOpt());
 
-                CobolFileKeyInfo CobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
-                keyInfoList.add(CobolFileKeyInfo);
+                CobolFileKeyInfo cobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
+                keyInfoList.add(cobolFileKeyInfo);
             }
         }
         return keyInfoList;
@@ -739,5 +647,100 @@ class IndexedFileUtilMain {
                 false,
                 false,
                 (char) 0);
+    }
+
+    private static void validateCreateCommandArgs(String[] unrecognizedArgs, CommandLine cmd) {
+        if (unrecognizedArgs.length < 2) {
+            throw new IllegalArgumentException("no indexed file is specified.");
+        }
+        if (!cmd.hasOption("r")) {
+            throw new IllegalArgumentException("no record size is specified.");
+        }
+    }
+
+    private static int parseRecordSize(CommandLine cmd) {
+        String recordSizeString = cmd.getOptionValue("r");
+        int recordSize;
+        try {
+            recordSize = Integer.parseInt(recordSizeString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    String.format("invalid record size: %s", recordSizeString), e);
+        }
+        if (recordSize <= 0) {
+            throw new IllegalArgumentException(
+                    String.format("invalid record size: %d", recordSize));
+        }
+        return recordSize;
+    }
+
+    private static void validateKeyInfoList(List<CobolFileKeyInfo> keyInfoList, int recordSize) {
+        if (keyInfoList.isEmpty()) {
+            throw new IllegalArgumentException("no key information is specified.");
+        } else if (keyInfoList.get(0).duplicate) {
+            throw new IllegalArgumentException(
+                    "the first key (primary key) must not be a duplicate key.");
+        }
+        for (CobolFileKeyInfo keyInfo : keyInfoList) {
+            if (keyInfo.offset <= 0 || keyInfo.size <= 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "invalid key information: offset=%d, size=%d",
+                                keyInfo.offset, keyInfo.size));
+            }
+            if (keyInfo.offset + keyInfo.size > recordSize + 1) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "invalid key information: offset=%d, size=%d, record size=%d",
+                                keyInfo.offset, keyInfo.size, recordSize));
+            }
+        }
+        // Check if key ranges overlap
+        for (int i = 0; i < keyInfoList.size(); i++) {
+            CobolFileKeyInfo key1Info = keyInfoList.get(i);
+            int key1IndexInf = key1Info.offset;
+            int key1IndexSup = key1Info.offset + key1Info.size - 1;
+            for (int j = 0; j < i; j++) {
+                CobolFileKeyInfo key2Info = keyInfoList.get(j);
+                int key2IndexInf = key2Info.offset;
+                int key2IndexSup = key2Info.offset + key2Info.size - 1;
+                if (!(key1IndexSup < key2IndexInf || key2IndexSup < key1IndexInf)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "keys overlap: %d,%d and %d,%d",
+                                    key1Info.offset,
+                                    key1Info.size,
+                                    key2Info.offset,
+                                    key2Info.size));
+                }
+            }
+        }
+    }
+
+    private static void processCreateIndexedFile(
+            String indexedFilePath,
+            int recordSize,
+            List<CobolFileKeyInfo> keyInfoList,
+            CommandLine cmd) {
+        Optional<CobolFile> cobolFile = createCobolFile(indexedFilePath, recordSize, keyInfoList);
+        if (!cobolFile.isPresent()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "failed to create a cobol file from the indexed file: %s",
+                            indexedFilePath));
+        }
+        CobolIndexedFile cobolIndexedFile = (CobolIndexedFile) cobolFile.get();
+        boolean enableOverwriteOption = cmd.hasOption("o");
+        boolean indexedFileAlreadyExists = new File(indexedFilePath).exists();
+        if (enableOverwriteOption || !indexedFileAlreadyExists) {
+            CobolModule module =
+                    new CobolModule(null, null, null, null, 0, '.', '$', ',', 1, 1, 1, 0, null);
+            CobolModule.push(module);
+            cobolIndexedFile.open(CobolFile.COB_OPEN_OUTPUT, 0, null);
+            if (CobolRuntimeException.code != 0) {
+                throw new IllegalArgumentException("failed to open the indexed file.");
+            }
+            cobolIndexedFile.close(0, null);
+        }
     }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -803,7 +803,7 @@ class IndexedFileUtilMain {
         } else {
             throw new IllegalArgumentException(
                     String.format(
-                            "%s is already exists. Use -o or --overwrite option to overwrite it.",
+                            "%s already exists. Use -o or --overwrite option to overwrite it.",
                             indexedFilePath));
         }
     }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -450,13 +450,20 @@ class IndexedFileUtilMain {
         }
     }
 
+    private static Optional<CobolFile> createCobolFileFromIndexedFilePath(String indexedFilePath) {
+        return createCobolFile(indexedFilePath, Optional.empty(), Optional.empty());
+    }
+
     /**
      * Create a CobolFile instance from the path of the indexed file.
      *
      * @param indexedFilePath TODO: 準備中
      * @return CobolFile instance if success, otherwise empty.
      */
-    private static Optional<CobolFile> createCobolFileFromIndexedFilePath(String indexedFilePath) {
+    private static Optional<CobolFile> createCobolFile(
+            String indexedFilePath,
+            Optional<Integer> optionRecordSize,
+            Optional<ArrayList<CobolFileKey>> optionKeyList) {
         SQLiteConfig config = new SQLiteConfig();
         config.setReadOnly(true);
 
@@ -465,14 +472,19 @@ class IndexedFileUtilMain {
                                 "jdbc:sqlite:" + indexedFilePath, config.toProperties());
                 Statement stmt = conn.createStatement(); ) {
 
-            // Retrieve the record size
-            ResultSet rs =
-                    stmt.executeQuery(
-                            "select value from metadata_string_int where key = 'record_size'");
-            if (!rs.next()) {
-                return Optional.empty();
+            int recordSize;
+            if (optionRecordSize.isPresent()) {
+                recordSize = optionRecordSize.get();
+            } else {
+                // Retrieve the record size
+                ResultSet rs =
+                        stmt.executeQuery(
+                                "select value from metadata_string_int where key = 'record_size'");
+                if (!rs.next()) {
+                    return Optional.empty();
+                }
+                recordSize = rs.getInt("value");
             }
-            int recordSize = rs.getInt("value");
 
             // Create a record field
             byte[] recordByteArray = new byte[recordSize];
@@ -484,26 +496,32 @@ class IndexedFileUtilMain {
                             new CobolFieldAttribute(1, 0, 0, 0, null));
 
             // Retrive key information
-            List<CobolFileKey> keyList = new ArrayList<CobolFileKey>();
-            rs =
-                    stmt.executeQuery(
-                            "select idx, offset, size, duplicate from metadata_key order by idx");
-            while (rs.next()) {
-                int offset = rs.getInt("offset");
-                int size = rs.getInt("size");
-                boolean duplicate = rs.getBoolean("duplicate");
+            List<CobolFileKey> keyList;
+            if (optionKeyList.isPresent()) {
+                keyList = optionKeyList.get();
+            } else {
+                keyList = new ArrayList<>();
+                ResultSet rs =
+                        stmt.executeQuery(
+                                "select idx, offset, size, duplicate from metadata_key order by"
+                                        + " idx");
+                while (rs.next()) {
+                    int offset = rs.getInt("offset");
+                    int size = rs.getInt("size");
+                    boolean duplicate = rs.getBoolean("duplicate");
 
-                CobolFileKey cobolFileKey = new CobolFileKey();
-                cobolFileKey.setOffset(offset);
-                cobolFileKey.setFlag(duplicate ? 1 : 0);
-                AbstractCobolField keyField =
-                        CobolFieldFactory.makeCobolField(
-                                size,
-                                recordDataStorage.getSubDataStorage(offset),
-                                new CobolFieldAttribute(33, 0, 0, 0, null));
-                cobolFileKey.setField(keyField);
+                    CobolFileKey cobolFileKey = new CobolFileKey();
+                    cobolFileKey.setOffset(offset);
+                    cobolFileKey.setFlag(duplicate ? 1 : 0);
+                    AbstractCobolField keyField =
+                            CobolFieldFactory.makeCobolField(
+                                    size,
+                                    recordDataStorage.getSubDataStorage(offset),
+                                    new CobolFieldAttribute(33, 0, 0, 0, null));
+                    cobolFileKey.setField(keyField);
 
-                keyList.add(cobolFileKey);
+                    keyList.add(cobolFileKey);
+                }
             }
 
             // Construct a CobolFile instance

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -369,8 +369,8 @@ class IndexedFileUtilMain {
                 int size = Integer.parseInt(keyInfo[1]);
                 boolean duplicate = "d".equals(option.getOpt());
 
-                CobolFileKeyInfo cobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
-                keyInfoList.add(cobolFileKeyInfo);
+                CobolFileKeyInfo CobolFileKeyInfo = new CobolFileKeyInfo(offset, size, duplicate);
+                keyInfoList.add(CobolFileKeyInfo);
             }
         }
         return keyInfoList;
@@ -739,17 +739,5 @@ class IndexedFileUtilMain {
                 false,
                 false,
                 (char) 0);
-    }
-}
-
-class CobolFileKeyInfo {
-    public int offset;
-    public int size;
-    public boolean duplicate;
-
-    public CobolFileKeyInfo(int offset, int size, boolean duplicate) {
-        this.offset = offset;
-        this.size = size;
-        this.duplicate = duplicate;
     }
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/user_util/indexed_file/IndexedFileUtilMain.java
@@ -211,6 +211,14 @@ class IndexedFileUtilMain {
         System.out.println(
                 "    The alternate key can be specified as a duplicate key by using the --dup-key"
                         + " option.");
+        System.out.println(
+                "    Example) cobj-idx create test.idx --record-size=100 --key=1,10 --key=20,5"
+                        + " --dup-key=30,3");
+        System.out.println("             File name: test.idx");
+        System.out.println("             Record size: 100");
+        System.out.println("             Primary key: 1-10");
+        System.out.println("             Alternate key (No Duplicates): 20-24");
+        System.out.println("             Alternate key (Duplicates): 30-32");
         System.out.println();
         System.out.println("cobj-idx load <indexed file>");
         System.out.println("    Load the data from stdin into the indexed file.");

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -198,6 +198,7 @@ command_line_options_DEPENDENCIES = \
 
 cobj_idx_DEPENDENCIES = \
 	cobj-idx.at \
+	cobj-idx.src/create.at \
 	cobj-idx.src/info.at \
 	cobj-idx.src/load.at \
 	cobj-idx.src/unload.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -737,6 +737,7 @@ command_line_options_DEPENDENCIES = \
 
 cobj_idx_DEPENDENCIES = \
 	cobj-idx.at \
+	cobj-idx.src/create.at \
 	cobj-idx.src/info.at \
 	cobj-idx.src/load.at \
 	cobj-idx.src/unload.at \

--- a/tests/cobj-idx.at
+++ b/tests/cobj-idx.at
@@ -1,5 +1,6 @@
 AT_INIT([cobj-idx])
 
+m4_include([create.at])
 m4_include([info.at])
 m4_include([load.at])
 m4_include([unload.at])

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -39,7 +39,7 @@ AT_SETUP([create: overwrite existing file])
 # 既存ファイル作成
 AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=10 --key=1,3], [0], [], [])
 
-# --overwriteオプションなしで上書きを試みる (エラーになるはず)
+# --overwriteオプションなしで上書きを試みる
 AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5], [1], [],
 [error: overwrite.idx is already exists. Use -o or --overwrite option to overwrite it.
 ])
@@ -60,6 +60,14 @@ AT_SETUP([create: error no indexed file])
 
 # 異常系: INDEXEDファイル名未指定
 AT_CHECK([${COBJ_IDX} create], [1], [],
+[error: no indexed file is specified.
+])
+
+AT_CHECK([${COBJ_IDX} create --key=1,3], [1], [],
+[error: no indexed file is specified.
+])
+
+AT_CHECK([${COBJ_IDX} create --dup-key=1,3], [1], [],
 [error: no indexed file is specified.
 ])
 

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -142,12 +142,36 @@ AT_CHECK([${COBJ_IDX} create outrange.idx --size=10 --key=5,10], [1], [],
 
 # Error case: Offset is less than or equal to 0
 AT_CHECK([${COBJ_IDX} create badoffset.idx --size=30 --key=0,5], [1], [],
-[error: invalid key information: 0,5
+[error: key offsets must be greater than 0: 0,5
 ])
 
 # Error case: Size is less than or equal to 0
 AT_CHECK([${COBJ_IDX} create badsize.idx --size=30 --key=1,0], [1], [],
-[error: invalid key information: 1,0
+[error: key sizes must be greater than 0: 1,0
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=0,2:15,4:d20,5], [1], [],
+[error: key offsets must be greater than 0: 0,2:15,4:d20,5
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=10,2:0,4:d20,5], [1], [],
+[error: key offsets must be greater than 0: 10,2:0,4:d20,5
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=10,2:15,4:d0,5], [1], [],
+[error: key offsets must be greater than 0: 10,2:15,4:d0,5
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=10,0:15,4:d20,5], [1], [],
+[error: key sizes must be greater than 0: 10,0:15,4:d20,5
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=10,2:15,0:d20,5], [1], [],
+[error: key sizes must be greater than 0: 10,2:15,0:d20,5
+])
+
+AT_CHECK([${COBJ_IDX} create test.idx --size=100 --key=10,2:15,4:d20,0], [1], [],
+[error: key sizes must be greater than 0: 10,2:15,4:d20,0
 ])
 
 AT_CLEANUP

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -154,9 +154,75 @@ AT_CLEANUP
 AT_SETUP([create: error overlapping keys])
 
 # Error case: Overlapping key ranges
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5], [1], [],
-[error: keys overlap: 3,5 and 1,5
-])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,2 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,4 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=3,5 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --key=1,5 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,6 --key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,5 --key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,4 2> /dev/null], [1])
+
+###############
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=3,5 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,6 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,5 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+
+###############
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=3,5 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,6 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,5 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
 
 AT_CLEANUP
 

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -41,7 +41,7 @@ AT_CHECK([${COBJ_IDX} create overwrite.idx --size=10 --key=1,3])
 
 # Try to overwrite without --overwrite option
 AT_CHECK([${COBJ_IDX} create overwrite.idx --size=20 --key=1,5], [1], [],
-[error: overwrite.idx is already exists. Use -o or --overwrite option to overwrite it.
+[error: overwrite.idx already exists. Use -o or --overwrite option to overwrite it.
 ])
 
 # Overwrite with --overwrite option

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -1,0 +1,153 @@
+AT_SETUP([create: basic])
+
+# 正常系: 基本的なINDEXEDファイル作成テスト
+AT_CHECK([${COBJ_IDX} create test.idx --record-size=30 --key=1,5], [0], [], [])
+
+# 作成したファイルが存在することを確認
+AT_CHECK([test -f test.idx], [0], [], [])
+
+# infoコマンドを使用して作成されたINDEXEDファイルの情報を確認
+AT_CHECK([${COBJ_IDX} info test.idx], [0],
+[Size of a record: 30
+Number of records: 0
+Primary key position: 1-5
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: with multiple keys])
+
+# 正常系: 複数のキーを持つINDEXEDファイル作成テスト
+AT_CHECK([${COBJ_IDX} create multikey.idx --record-size=50 --key=1,5 --key=10,3 --dup-key=20,6], [0], [], [])
+
+# 作成したファイルが存在することを確認
+AT_CHECK([test -f multikey.idx], [0], [], [])
+
+# infoコマンドを使用して作成されたINDEXEDファイルの情報を確認
+AT_CHECK([${COBJ_IDX} info multikey.idx], [0],
+[Size of a record: 50
+Number of records: 0
+Primary key position: 1-5
+Alternate key position (No duplicate): 10-12
+Alternate key position (Duplicates): 20-25
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: overwrite existing file])
+
+# 既存ファイル作成
+AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=10 --key=1,3], [0], [], [])
+
+# --overwriteオプションなしで上書きを試みる (エラーになるはず)
+AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5], [1], [],
+[error: overwrite.idx is already exists. Use -o or --overwrite option to overwrite it.
+])
+
+# --overwriteオプションありで上書き
+AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5 --overwrite], [0], [], [])
+
+# 上書きされたことを確認
+AT_CHECK([${COBJ_IDX} info overwrite.idx], [0],
+[Size of a record: 20
+Number of records: 0
+Primary key position: 1-5
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error no indexed file])
+
+# 異常系: INDEXEDファイル名未指定
+AT_CHECK([${COBJ_IDX} create], [1], [],
+[error: no indexed file is specified.
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error no record size])
+
+# 異常系: レコードサイズ未指定
+AT_CHECK([${COBJ_IDX} create nosize.idx], [1], [],
+[error: no record size is specified.
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error invalid record size])
+
+# 異常系: 不正なレコードサイズ (文字列)
+AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=abc --key=1,5], [1], [],
+[error: invalid record size: abc
+])
+
+# 異常系: 不正なレコードサイズ (負の数)
+AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=-10 --key=1,5], [1], [],
+[error: invalid record size: -10
+])
+
+# 異常系: 不正なレコードサイズ (ゼロ)
+AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=0 --key=1,5], [1], [],
+[error: invalid record size: 0
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error no key])
+
+# 異常系: キー情報未指定
+AT_CHECK([${COBJ_IDX} create nokey.idx --record-size=30], [1], [],
+[error: no key information is specified.
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error primary key is duplicate])
+
+# 異常系: プライマリキーが重複可能と指定されている
+AT_CHECK([${COBJ_IDX} create dupkey.idx --record-size=30 --dup-key=1,5], [1], [],
+[error: the first key (primary key) must not be a duplicate key.
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error invalid key format])
+
+# 異常系: 不正なキー情報フォーマット
+AT_CHECK([${COBJ_IDX} create badkey.idx --record-size=30 --key=1], [1], [],
+[error: invalid key information: 1
+])
+
+AT_CHECK([${COBJ_IDX} create badkey.idx --record-size=30 --key=a,5], [1], [],
+[error: For input string: "a"
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error key out of range])
+
+# 異常系: レコードサイズを超えるキー範囲
+AT_CHECK([${COBJ_IDX} create outrange.idx --record-size=10 --key=5,10], [1], [],
+[error: invalid key information: offset=5, size=10, record size=10
+])
+
+# 異常系: オフセットが0以下
+AT_CHECK([${COBJ_IDX} create badoffset.idx --record-size=30 --key=0,5], [1], [],
+[error: invalid key information: offset=0, size=5, record size=30
+])
+
+# 異常系: サイズが0以下
+AT_CHECK([${COBJ_IDX} create badsize.idx --record-size=30 --key=1,0], [1], [],
+[error: invalid key information: offset=1, size=0, record size=30
+])
+
+AT_CLEANUP
+
+AT_SETUP([create: error overlapping keys])
+
+# 異常系: 重複するキー範囲
+AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5], [1], [],
+[error: keys overlap: 3,5 and 1,5
+])
+
+AT_CLEANUP

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -1,7 +1,7 @@
 AT_SETUP([create: basic])
 
 # Normal case: Test for basic INDEXED file creation
-AT_CHECK([${COBJ_IDX} create test.idx --record-size=30 --key=1,5])
+AT_CHECK([${COBJ_IDX} create test.idx --size=30 --key=1,5])
 
 # Verify that the created file exists
 AT_CHECK([test -f test.idx])
@@ -18,7 +18,7 @@ AT_CLEANUP
 AT_SETUP([create: with multiple keys])
 
 # Normal case: Test for INDEXED file creation with multiple keys
-AT_CHECK([${COBJ_IDX} create multikey.idx --record-size=50 --key=1,5 --key=10,3 --dup-key=20,6], [0], [], [])
+AT_CHECK([${COBJ_IDX} create multikey.idx --size=50 --key=1,5:10,3:d20,6], [0], [], [])
 
 # Verify that the created file exists
 AT_CHECK([test -f multikey.idx])
@@ -37,15 +37,15 @@ AT_CLEANUP
 AT_SETUP([create: overwrite existing file])
 
 # Create an existing file first
-AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=10 --key=1,3])
+AT_CHECK([${COBJ_IDX} create overwrite.idx --size=10 --key=1,3])
 
 # Try to overwrite without --overwrite option
-AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5], [1], [],
+AT_CHECK([${COBJ_IDX} create overwrite.idx --size=20 --key=1,5], [1], [],
 [error: overwrite.idx is already exists. Use -o or --overwrite option to overwrite it.
 ])
 
 # Overwrite with --overwrite option
-AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5 --overwrite])
+AT_CHECK([${COBJ_IDX} create overwrite.idx --size=20 --key=1,5 --overwrite])
 
 # Confirm that the file was overwritten
 AT_CHECK([${COBJ_IDX} info overwrite.idx], [0],
@@ -67,9 +67,10 @@ AT_CHECK([${COBJ_IDX} create --key=1,3], [1], [],
 [error: no indexed file is specified.
 ])
 
-AT_CHECK([${COBJ_IDX} create --dup-key=1,3], [1], [],
+AT_CHECK([${COBJ_IDX} create --key=1,3:5,2], [1], [],
 [error: no indexed file is specified.
 ])
+
 
 AT_CLEANUP
 
@@ -85,17 +86,17 @@ AT_CLEANUP
 AT_SETUP([create: error invalid record size])
 
 # Error case: Invalid record size (string)
-AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=abc --key=1,5], [1], [],
+AT_CHECK([${COBJ_IDX} create invalid.idx --size=abc --key=1,5], [1], [],
 [error: invalid record size: abc
 ])
 
 # Error case: Invalid record size (negative number)
-AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=-10 --key=1,5], [1], [],
+AT_CHECK([${COBJ_IDX} create invalid.idx --size=-10 --key=1,5], [1], [],
 [error: invalid record size: -10
 ])
 
 # Error case: Invalid record size (zero)
-AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=0 --key=1,5], [1], [],
+AT_CHECK([${COBJ_IDX} create invalid.idx --size=0 --key=1,5], [1], [],
 [error: invalid record size: 0
 ])
 
@@ -104,7 +105,7 @@ AT_CLEANUP
 AT_SETUP([create: error no key])
 
 # Error case: No key information is specified
-AT_CHECK([${COBJ_IDX} create nokey.idx --record-size=30], [1], [],
+AT_CHECK([${COBJ_IDX} create nokey.idx --size=30], [1], [],
 [error: no key information is specified.
 ])
 
@@ -113,7 +114,7 @@ AT_CLEANUP
 AT_SETUP([create: error primary key is duplicate])
 
 # Error case: Primary key is specified as a duplicate key
-AT_CHECK([${COBJ_IDX} create dupkey.idx --record-size=30 --dup-key=1,5], [1], [],
+AT_CHECK([${COBJ_IDX} create dupkey.idx --size=30 --key=d1,5], [1], [],
 [error: the first key (primary key) must not be a duplicate key.
 ])
 
@@ -122,12 +123,12 @@ AT_CLEANUP
 AT_SETUP([create: error invalid key format])
 
 # Error case: Invalid key information format
-AT_CHECK([${COBJ_IDX} create badkey.idx --record-size=30 --key=1], [1], [],
+AT_CHECK([${COBJ_IDX} create badkey.idx --size=30 --key=1], [1], [],
 [error: invalid key information: 1
 ])
 
-AT_CHECK([${COBJ_IDX} create badkey.idx --record-size=30 --key=a,5], [1], [],
-[error: For input string: "a"
+AT_CHECK([${COBJ_IDX} create badkey.idx --size=30 --key=a,5], [1], [],
+[error: invalid key information: a,5
 ])
 
 AT_CLEANUP
@@ -135,18 +136,18 @@ AT_CLEANUP
 AT_SETUP([create: error key out of range])
 
 # Error case: Key range exceeds record size
-AT_CHECK([${COBJ_IDX} create outrange.idx --record-size=10 --key=5,10], [1], [],
+AT_CHECK([${COBJ_IDX} create outrange.idx --size=10 --key=5,10], [1], [],
 [error: invalid key information: offset=5, size=10, record size=10
 ])
 
 # Error case: Offset is less than or equal to 0
-AT_CHECK([${COBJ_IDX} create badoffset.idx --record-size=30 --key=0,5], [1], [],
-[error: invalid key information: offset=0, size=5, record size=30
+AT_CHECK([${COBJ_IDX} create badoffset.idx --size=30 --key=0,5], [1], [],
+[error: invalid key information: 0,5
 ])
 
 # Error case: Size is less than or equal to 0
-AT_CHECK([${COBJ_IDX} create badsize.idx --record-size=30 --key=1,0], [1], [],
-[error: invalid key information: offset=1, size=0, record size=30
+AT_CHECK([${COBJ_IDX} create badsize.idx --size=30 --key=1,0], [1], [],
+[error: invalid key information: 1,0
 ])
 
 AT_CLEANUP
@@ -154,82 +155,82 @@ AT_CLEANUP
 AT_SETUP([create: error overlapping keys])
 
 # Error case: Overlapping key ranges
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,2 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:5,2 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=1,6 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:2,4 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=3,5 --key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=3,5:1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,1:1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,2:1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,1:1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,2:1,5 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,6 --key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,5 --key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --key=2,4 2> /dev/null], [1])
-
-###############
-
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=3,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
-
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=1,6 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
-
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=3,5 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
-
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,6 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,5 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,6:2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,5:2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:2,4 2> /dev/null], [1])
 
 ###############
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=3,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,1 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d5,2 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=1,6 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:d1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:d2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:d2,4 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=3,5 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,1 --dup-key=1,5 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=5,2 --dup-key=1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=3,5:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,1:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,2:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,1:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=5,2:d1,5 2> /dev/null], [1])
 
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,6 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,5 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=1,5 --dup-key=2,4 2> /dev/null], [1])
-AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=15,5 --key=2,4 --dup-key=2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,6:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,5:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=1,5:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=2,4:d2,4 2> /dev/null], [1])
+
+###############
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d3,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d5,2 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d5,1 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d5,2 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,4:d1,6 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,4:d2,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,4:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,4:d2,4 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:3,5:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:5,1:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:5,2:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:5,1:d1,5 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:5,2:d1,5 2> /dev/null], [1])
+
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,6:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,5:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:1,5:d2,4 2> /dev/null], [1])
+AT_CHECK([${COBJ_IDX} create overlap.idx --size=30 --key=15,5:2,4:d2,4 2> /dev/null], [1])
 
 AT_CLEANUP
 
 AT_SETUP([create: load and unload after creation])
 
 # Normal case: Create an INDEXED file
-AT_CHECK([${COBJ_IDX} create loadtest.idx --record-size=30 --key=1,5])
+AT_CHECK([${COBJ_IDX} create loadtest.idx --size=30 --key=1,5])
 
 # Prepare test data for loading
 AT_DATA([load_data.txt],
@@ -252,7 +253,7 @@ AT_DATA([binary_data.bin],
 ])
 
 # Create a new file
-AT_CHECK([${COBJ_IDX} create bintest.idx --record-size=25 --key=1,5])
+AT_CHECK([${COBJ_IDX} create bintest.idx --size=25 --key=1,5])
 
 # Load binary data
 AT_CHECK([${COBJ_IDX} load bintest.idx binary_data.bin])
@@ -263,7 +264,7 @@ AT_CHECK([${COBJ_IDX} unload bintest.idx], [0],
 ])
 
 # Test with a file having multiple keys
-AT_CHECK([${COBJ_IDX} create multiloadtest.idx --record-size=30 --key=1,5 --key=10,5 --dup-key=20,5])
+AT_CHECK([${COBJ_IDX} create multiloadtest.idx --size=30 --key=1,5:10,5:d20,5])
 
 AT_DATA([multikey_data.txt],
 [abcde12345hello67890key3@@@@@@

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -1,12 +1,12 @@
 AT_SETUP([create: basic])
 
-# 正常系: 基本的なINDEXEDファイル作成テスト
-AT_CHECK([${COBJ_IDX} create test.idx --record-size=30 --key=1,5], [0], [], [])
+# Normal case: Test for basic INDEXED file creation
+AT_CHECK([${COBJ_IDX} create test.idx --record-size=30 --key=1,5])
 
-# 作成したファイルが存在することを確認
-AT_CHECK([test -f test.idx], [0], [], [])
+# Verify that the created file exists
+AT_CHECK([test -f test.idx])
 
-# infoコマンドを使用して作成されたINDEXEDファイルの情報を確認
+# Check information of the created INDEXED file using info command
 AT_CHECK([${COBJ_IDX} info test.idx], [0],
 [Size of a record: 30
 Number of records: 0
@@ -17,13 +17,13 @@ AT_CLEANUP
 
 AT_SETUP([create: with multiple keys])
 
-# 正常系: 複数のキーを持つINDEXEDファイル作成テスト
+# Normal case: Test for INDEXED file creation with multiple keys
 AT_CHECK([${COBJ_IDX} create multikey.idx --record-size=50 --key=1,5 --key=10,3 --dup-key=20,6], [0], [], [])
 
-# 作成したファイルが存在することを確認
-AT_CHECK([test -f multikey.idx], [0], [], [])
+# Verify that the created file exists
+AT_CHECK([test -f multikey.idx])
 
-# infoコマンドを使用して作成されたINDEXEDファイルの情報を確認
+# Check information of the created INDEXED file using info command
 AT_CHECK([${COBJ_IDX} info multikey.idx], [0],
 [Size of a record: 50
 Number of records: 0
@@ -36,18 +36,18 @@ AT_CLEANUP
 
 AT_SETUP([create: overwrite existing file])
 
-# 既存ファイル作成
-AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=10 --key=1,3], [0], [], [])
+# Create an existing file first
+AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=10 --key=1,3])
 
-# --overwriteオプションなしで上書きを試みる
+# Try to overwrite without --overwrite option
 AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5], [1], [],
 [error: overwrite.idx is already exists. Use -o or --overwrite option to overwrite it.
 ])
 
-# --overwriteオプションありで上書き
-AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5 --overwrite], [0], [], [])
+# Overwrite with --overwrite option
+AT_CHECK([${COBJ_IDX} create overwrite.idx --record-size=20 --key=1,5 --overwrite])
 
-# 上書きされたことを確認
+# Confirm that the file was overwritten
 AT_CHECK([${COBJ_IDX} info overwrite.idx], [0],
 [Size of a record: 20
 Number of records: 0
@@ -58,7 +58,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error no indexed file])
 
-# 異常系: INDEXEDファイル名未指定
+# Error case: No INDEXED file name is specified
 AT_CHECK([${COBJ_IDX} create], [1], [],
 [error: no indexed file is specified.
 ])
@@ -75,7 +75,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error no record size])
 
-# 異常系: レコードサイズ未指定
+# Error case: No record size is specified
 AT_CHECK([${COBJ_IDX} create nosize.idx], [1], [],
 [error: no record size is specified.
 ])
@@ -84,17 +84,17 @@ AT_CLEANUP
 
 AT_SETUP([create: error invalid record size])
 
-# 異常系: 不正なレコードサイズ (文字列)
+# Error case: Invalid record size (string)
 AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=abc --key=1,5], [1], [],
 [error: invalid record size: abc
 ])
 
-# 異常系: 不正なレコードサイズ (負の数)
+# Error case: Invalid record size (negative number)
 AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=-10 --key=1,5], [1], [],
 [error: invalid record size: -10
 ])
 
-# 異常系: 不正なレコードサイズ (ゼロ)
+# Error case: Invalid record size (zero)
 AT_CHECK([${COBJ_IDX} create invalid.idx --record-size=0 --key=1,5], [1], [],
 [error: invalid record size: 0
 ])
@@ -103,7 +103,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error no key])
 
-# 異常系: キー情報未指定
+# Error case: No key information is specified
 AT_CHECK([${COBJ_IDX} create nokey.idx --record-size=30], [1], [],
 [error: no key information is specified.
 ])
@@ -112,7 +112,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error primary key is duplicate])
 
-# 異常系: プライマリキーが重複可能と指定されている
+# Error case: Primary key is specified as a duplicate key
 AT_CHECK([${COBJ_IDX} create dupkey.idx --record-size=30 --dup-key=1,5], [1], [],
 [error: the first key (primary key) must not be a duplicate key.
 ])
@@ -121,7 +121,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error invalid key format])
 
-# 異常系: 不正なキー情報フォーマット
+# Error case: Invalid key information format
 AT_CHECK([${COBJ_IDX} create badkey.idx --record-size=30 --key=1], [1], [],
 [error: invalid key information: 1
 ])
@@ -134,17 +134,17 @@ AT_CLEANUP
 
 AT_SETUP([create: error key out of range])
 
-# 異常系: レコードサイズを超えるキー範囲
+# Error case: Key range exceeds record size
 AT_CHECK([${COBJ_IDX} create outrange.idx --record-size=10 --key=5,10], [1], [],
 [error: invalid key information: offset=5, size=10, record size=10
 ])
 
-# 異常系: オフセットが0以下
+# Error case: Offset is less than or equal to 0
 AT_CHECK([${COBJ_IDX} create badoffset.idx --record-size=30 --key=0,5], [1], [],
 [error: invalid key information: offset=0, size=5, record size=30
 ])
 
-# 異常系: サイズが0以下
+# Error case: Size is less than or equal to 0
 AT_CHECK([${COBJ_IDX} create badsize.idx --record-size=30 --key=1,0], [1], [],
 [error: invalid key information: offset=1, size=0, record size=30
 ])
@@ -153,7 +153,7 @@ AT_CLEANUP
 
 AT_SETUP([create: error overlapping keys])
 
-# 異常系: 重複するキー範囲
+# Error case: Overlapping key ranges
 AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5], [1], [],
 [error: keys overlap: 3,5 and 1,5
 ])
@@ -162,41 +162,41 @@ AT_CLEANUP
 
 AT_SETUP([create: load and unload after creation])
 
-# 正常系: INDEXEDファイル作成
-AT_CHECK([${COBJ_IDX} create loadtest.idx --record-size=30 --key=1,5], [0], [], [])
+# Normal case: Create an INDEXED file
+AT_CHECK([${COBJ_IDX} create loadtest.idx --record-size=30 --key=1,5])
 
-# load用にテストデータを準備
+# Prepare test data for loading
 AT_DATA([load_data.txt],
 [abcde12345test data record 1**
 fghij67890test data record 2**
 ])
 
-# 作成したファイルにデータをロード (LINE_SEQUENTIAL形式)
-AT_CHECK([${COBJ_IDX} load loadtest.idx load_data.txt --format=txt], [0], [], [])
+# Load data into the created file (LINE_SEQUENTIAL format)
+AT_CHECK([${COBJ_IDX} load loadtest.idx load_data.txt --format=txt])
 
-# アンロードしてデータを確認
+# Unload and verify the data
 AT_CHECK([${COBJ_IDX} unload loadtest.idx --format=txt], [0],
 [abcde12345test data record 1**
 fghij67890test data record 2**
 ])
 
-# バイナリ形式でもロード・アンロードをテスト
+# Test loading and unloading with binary format
 AT_DATA([binary_data.bin],
 [key0112345binary format 1key0267890binary format 2
 ])
 
-# 新しいファイルを作成
-AT_CHECK([${COBJ_IDX} create bintest.idx --record-size=25 --key=1,5], [0], [], [])
+# Create a new file
+AT_CHECK([${COBJ_IDX} create bintest.idx --record-size=25 --key=1,5])
 
-# バイナリデータをロード
-AT_CHECK([${COBJ_IDX} load bintest.idx binary_data.bin], [0], [], [])
+# Load binary data
+AT_CHECK([${COBJ_IDX} load bintest.idx binary_data.bin])
 
-# アンロードしてデータを確認
+# Unload and verify the data
 AT_CHECK([${COBJ_IDX} unload bintest.idx], [0],
 [key0112345binary format 1key0267890binary format 2
 ])
 
-# 複数キーを持つファイルでもテスト
+# Test with a file having multiple keys
 AT_CHECK([${COBJ_IDX} create multiloadtest.idx --record-size=30 --key=1,5 --key=10,5 --dup-key=20,5])
 
 AT_DATA([multikey_data.txt],
@@ -205,9 +205,9 @@ fghij54321world12345key4@@@@@@
 klmno12345test 67890key5@@@@@@
 ])
 
-AT_CHECK([${COBJ_IDX} load multiloadtest.idx multikey_data.txt --format=txt], [0], [], [])
+AT_CHECK([${COBJ_IDX} load multiloadtest.idx multikey_data.txt --format=txt])
 
-# アンロードしてデータを確認
+# Unload and verify the data
 AT_CHECK([${COBJ_IDX} unload multiloadtest.idx --format=txt], [0],
 [abcde12345hello67890key3@@@@@@
 fghij54321world12345key4@@@@@@

--- a/tests/cobj-idx.src/create.at
+++ b/tests/cobj-idx.src/create.at
@@ -159,3 +159,59 @@ AT_CHECK([${COBJ_IDX} create overlap.idx --record-size=30 --key=1,5 --key=3,5], 
 ])
 
 AT_CLEANUP
+
+AT_SETUP([create: load and unload after creation])
+
+# 正常系: INDEXEDファイル作成
+AT_CHECK([${COBJ_IDX} create loadtest.idx --record-size=30 --key=1,5], [0], [], [])
+
+# load用にテストデータを準備
+AT_DATA([load_data.txt],
+[abcde12345test data record 1**
+fghij67890test data record 2**
+])
+
+# 作成したファイルにデータをロード (LINE_SEQUENTIAL形式)
+AT_CHECK([${COBJ_IDX} load loadtest.idx load_data.txt --format=txt], [0], [], [])
+
+# アンロードしてデータを確認
+AT_CHECK([${COBJ_IDX} unload loadtest.idx --format=txt], [0],
+[abcde12345test data record 1**
+fghij67890test data record 2**
+])
+
+# バイナリ形式でもロード・アンロードをテスト
+AT_DATA([binary_data.bin],
+[key0112345binary format 1key0267890binary format 2
+])
+
+# 新しいファイルを作成
+AT_CHECK([${COBJ_IDX} create bintest.idx --record-size=25 --key=1,5], [0], [], [])
+
+# バイナリデータをロード
+AT_CHECK([${COBJ_IDX} load bintest.idx binary_data.bin], [0], [], [])
+
+# アンロードしてデータを確認
+AT_CHECK([${COBJ_IDX} unload bintest.idx], [0],
+[key0112345binary format 1key0267890binary format 2
+])
+
+# 複数キーを持つファイルでもテスト
+AT_CHECK([${COBJ_IDX} create multiloadtest.idx --record-size=30 --key=1,5 --key=10,5 --dup-key=20,5])
+
+AT_DATA([multikey_data.txt],
+[abcde12345hello67890key3@@@@@@
+fghij54321world12345key4@@@@@@
+klmno12345test 67890key5@@@@@@
+])
+
+AT_CHECK([${COBJ_IDX} load multiloadtest.idx multikey_data.txt --format=txt], [0], [], [])
+
+# アンロードしてデータを確認
+AT_CHECK([${COBJ_IDX} unload multiloadtest.idx --format=txt], [0],
+[abcde12345hello67890key3@@@@@@
+fghij54321world12345key4@@@@@@
+klmno12345test 67890key5@@@@@@
+])
+
+AT_CLEANUP


### PR DESCRIPTION
This pull request implements `create` command of `cobj-idx`.
The following is a usage of this new command.
```
cobj-idx create <indexed file> --size=<record size> --key=<key information>
    Create a new indexed file.
    The record size and key information are specified by the options.
    By default, this command does not overwrite the indexed file.
    To overwrite the indexed file, use the --overwrite option.
    Example) cobj-idx create test.idx --size=100 --key=2,2:5,4:d15,5
             File name: test.idx
             Record size: 100
             Primary key: 2-3
             Alternate key (No Duplicates):5-8
             Alternate key (Duplicates): 15-19
```

This pull request is a new version of #641