### PR TITLE
Generate code coverage reports

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,14 +41,10 @@ jobs:
       - name: Run other tests
         working-directory: tests
         run: |
-          ./command-line-options || true
-          ./data-rep || true
-          ./i18n_sjis || true
-          ./jp-compat || true
-          ./run || true
-          ./syntax || true
-          ./cobj-idx || true
-          ./misc || true
+          tests=("command-line-options" "data-rep" "i18n_sjis" "jp-compat" "run" "syntax" "cobj-idx" "misc")
+          for test in "${tests[@]}"; do
+            ./$test || true
+          done
 
       - name: Generate a coverage report
         working-directory: cobj

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           tests=("command-line-options" "data-rep" "i18n_sjis" "jp-compat" "run" "syntax" "cobj-idx" "misc")
           for test in "${tests[@]}"; do
-            ./$test || true
+            ./"$test" || true
           done
 
       - name: Generate a coverage report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies on Ubuntu 24.04
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y build-essential gettext autoconf bison flex
+          sudo apt-get install -y build-essential gettext autoconf bison flex gcovr
 
       - name: Checkout opensource COBOL 4J
         uses: actions/checkout@v4
@@ -36,27 +36,29 @@ jobs:
 
       - name: Run NIST test
         working-directory: tests/cobol85
-        run: make test
+        run: make test || true
 
       - name: Run other tests
         working-directory: tests
         run: |
-          ./command-line-options
-          ./data-rep
-          ./i18n_sjis
-          ./jp-compat
-          ./run
-          ./syntax
-          ./cobj-idx
-          ./misc
+          ./command-line-options ||
+          ./data-rep ||
+          ./i18n_sjis ||
+          ./jp-compat ||
+          ./run ||
+          ./syntax ||
+          ./cobj-idx ||
+          ./misc ||
+          true
 
       - name: Generate a coverage report
         working-directory: cobj
         run: |
           gcov -l ./*.gcda
-          gcovr -r . --html -o report.html
-          mkdir coverage-report
-          cp ./*.gcno ./*.gcda ./*.gcov report.html coverage-report
+          gcovr -r . --html-details --html-self-contained --html -o report.html --branches
+          mkdir -p coverage-report
+          cp ./*.gcno ./*.gcda ./*.gcov ./*.html coverage-report
+
 
       - name: Archive a coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,15 +41,14 @@ jobs:
       - name: Run other tests
         working-directory: tests
         run: |
-          ./command-line-options ||
-          ./data-rep ||
-          ./i18n_sjis ||
-          ./jp-compat ||
-          ./run ||
-          ./syntax ||
-          ./cobj-idx ||
-          ./misc ||
-          true
+          ./command-line-options || true
+          ./data-rep || true
+          ./i18n_sjis || true
+          ./jp-compat || true
+          ./run || true
+          ./syntax || true
+          ./cobj-idx || true
+          ./misc || true
 
       - name: Generate a coverage report
         working-directory: cobj

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Install dependencies on Ubuntu 24.04
+      - name: Install dependencies on Ubuntu
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential gettext autoconf bison flex gcovr

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,65 @@
+name: Coverage
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CLASSPATH: ":/usr/lib/opensourcecobol4j/libcobj.jar"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps: 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies on Ubuntu 24.04
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential gettext autoconf bison flex
+
+      - name: Checkout opensource COBOL 4J
+        uses: actions/checkout@v4
+      
+      - name: Install opensource COBOL 4J
+        run: |
+          ./configure --prefix=/usr/ CFLAGS='-fprofile-arcs -ftest-coverage'
+          make
+          sudo make install
+
+      - name: Run NIST test
+        working-directory: tests/cobol85
+        run: make test
+
+      - name: Run other tests
+        working-directory: tests
+        run: |
+          ./command-line-options
+          ./data-rep
+          ./i18n_sjis
+          ./jp-compat
+          ./run
+          ./syntax
+          ./cobj-idx
+          ./misc
+
+      - name: Generate a coverage report
+        working-directory: cobj
+        run: |
+          gcov -l ./*.gcda
+          gcovr -r . --html -o report.html
+          mkdir coverage-report
+          cp ./*.gcno ./*.gcda ./*.gcov report.html coverage-report
+
+      - name: Archive a coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: cobj/coverage-report/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,10 +55,13 @@ jobs:
         working-directory: cobj
         run: |
           gcov -l ./*.gcda
-          gcovr -r . --html-details --html-self-contained --html -o report.html --branches
+          gcovr -r . \
+            -e cobj-parser -e cobj-scanner -e cobj-pplex -e cobj-ppparse \
+            -e parser.c -e parser.y -e scanner.l -e scanner.c -e pplex.l -e pplex.c -e ppparse.y -e ppparse.c \
+            -e flag-help.def -e warning-help.def -e warning.def \
+            --html-details --html-self-contained --html -o report.html --txt-metric=branch
           mkdir -p coverage-report
-          cp ./*.gcno ./*.gcda ./*.gcov ./*.html coverage-report
-
+          cp ./*.html coverage-report
 
       - name: Archive a coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,7 @@ jobs:
 
   coverage:
     needs: check-workflows
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/develop'
     uses: ./.github/workflows/coverage.yml
 
   run-test-other:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,6 +40,10 @@ jobs:
       os: ${{ matrix.os }}
       configure-args: --enable-utf8
 
+  coverage:
+    needs: check-workflows
+    uses: ./.github/workflows/coverage.yml
+
   run-test-other:
     needs: build
     strategy:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,6 +42,7 @@ jobs:
 
   coverage:
     needs: check-workflows
+    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/coverage.yml
 
   run-test-other:


### PR DESCRIPTION
This pull request introduces a new workflow to generate code coverage reports for this project and integrates it into the existing CI pipeline. The changes include the addition of a dedicated `coverage.yml` workflow file and modifications to the `push.yml`.

You can run the workflow that generates code coverage manually and the workflow is also triggered if `main` branch is changed.

[code-coverage-report.zip](https://github.com/user-attachments/files/20477654/code-coverage-report.zip) is an example of code coverage reports.

### Addition of Code Coverage Workflow:
* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R1-R69): Created a new workflow named "Coverage" that sets up the environment, installs dependencies, runs tests, generates code coverage reports using `gcov` and `gcovr`, and archives the reports. The workflow is triggered manually (`workflow_dispatch`) or via other workflows (`workflow_call`).

### Integration into CI Pipeline:
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R43-R47): Added a new job `coverage` that depends on the `check-workflows` job and triggers the `coverage.yml` workflow when changes are pushed to the `main` branch.