### PR TITLE
Fix CI trigger

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: test on pull request
 
 on:
   pull_request:
-    types: [opened, reopened, review_requested, synchronize]
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - '*.md'
       - 'ChangeLog'


### PR DESCRIPTION
I removed the CI trigger `review_requested` from `pull-request.yml`.  
This prevents duplicate runs of the same pipeline.
The follwing is the summary generated by Copilot.


This pull request updates the GitHub Actions workflow configuration to adjust the types of pull request events that trigger the workflow.

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L5-R5): Removed the `review_requested` event type from the list of pull request events that trigger the workflow.
