### PR TITLE
Improve a test to execute untested code in write_json_info in cobj/codegen.c

### DIFF
--- a/tests/command-line-options.src/info-java-dir.at
+++ b/tests/command-line-options.src/info-java-dir.at
@@ -10,7 +10,8 @@ AT_DATA([callee.cbl], [
        LINKAGE          SECTION.
        01 P1            PIC X ANY LENGTH.
        01 P2            PIC 99.
-       PROCEDURE        DIVISION USING P1 P2.
+       01 P3            PIC 9V9.
+       PROCEDURE        DIVISION USING P1 P2 P3.
            GOBACK.
 ])
 
@@ -38,6 +39,10 @@ AT_CHECK([cat info_callee.json], [0],
     {
       "variable_name": "P2",
       "java_type": "int"
+    },
+    {
+      "variable_name": "P3",
+      "java_type": "double"
     }
   @:>@
 }

--- a/tests/command-line-options.src/info-java-dir.at
+++ b/tests/command-line-options.src/info-java-dir.at
@@ -79,6 +79,10 @@ AT_CHECK([cat bbb/info_callee.json], [0],
     {
       "variable_name": "P2",
       "java_type": "int"
+    },
+    {
+      "variable_name": "P3",
+      "java_type": "double"
     }
   @:>@
 }


### PR DESCRIPTION
This pull request improves a test in `tests/command-line-options.src/info-java-dir.at`.
Due to this modification, the modified test would run the following untested code. See also #662

https://github.com/opensourcecobol/opensourcecobol4j/blob/2794a5ea1e3843bf11663b50caf741875665d808/cobj/codegen.c#L4239