### PR TITLE
Improve the error handling for opening invalid formatted indexed files

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -285,6 +285,30 @@ public class CobolFile {
     /** TODO: 準備中 */
     protected static final int COB_STATUS_91_NOT_AVAILABLE = 91;
 
+    // ==============================================
+    // The following constants must not be equal
+    // to any of the above constants `COB_STATUS_*`
+
+    /** TODO: 準備中 */
+    protected static final int ENOENT = 1002;
+
+    /** TODO: 準備中 */
+    protected static final int EBADF = 1009;
+
+    /** TODO: 準備中 */
+    protected static final int EACCESS = 1013;
+
+    /** TODO: 準備中 */
+    protected static final int EISDIR = 1021;
+
+    /** TODO: 準備中 */
+    protected static final int EROFS = 1030;
+
+    /** TODO: 準備中 */
+    protected static final int EAGAIN = 1011;
+
+    // ==============================================
+
     /** TODO: 準備中 */
     protected static final int COB_LINAGE_INVALID = 16384;
 
@@ -305,24 +329,6 @@ public class CobolFile {
 
     /** TODO: 準備中 */
     protected static final int FNSTATUSSIZE = 3;
-
-    /** TODO: 準備中 */
-    protected static final int ENOENT = 2;
-
-    /** TODO: 準備中 */
-    protected static final int EBADF = 9;
-
-    /** TODO: 準備中 */
-    protected static final int EACCESS = 13;
-
-    /** TODO: 準備中 */
-    protected static final int EISDIR = 21;
-
-    /** TODO: 準備中 */
-    protected static final int EROFS = 30;
-
-    /** TODO: 準備中 */
-    protected static final int EAGAIN = 11;
 
     /** TODO: 準備中 */
     public static CobolFile errorFile;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -219,9 +219,9 @@ public class CobolIndexedFile extends CobolFile {
             p.connection.setAutoCommit(false);
 
             // Check if the file is accessible
-            Statement st = p.connection.createStatement();
-            st.execute("select 1");
-            st.close();
+            try (Statement st = p.connection.createStatement()) {
+                st.execute("select 1");
+            }
             p.connection.commit();
         } catch (SQLException e) {
             int errorCode = e.getErrorCode();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -213,12 +213,17 @@ public class CobolIndexedFile extends CobolFile {
             p.connection =
                     DriverManager.getConnection("jdbc:sqlite:" + filename, config.toProperties());
             p.connection.setAutoCommit(false);
+
+            // Check if the file is accessible
+            Statement st = p.connection.createStatement();
+            st.execute("select 1");
+            st.close();
         } catch (SQLException e) {
             int errorCode = e.getErrorCode();
             if (errorCode == SQLiteErrorCode.SQLITE_BUSY.code) {
                 return COB_STATUS_61_FILE_SHARING;
             } else {
-                return ENOENT;
+                return COB_STATUS_30_PERMANENT_ERROR;
             }
         } catch (Exception e) {
             return COB_STATUS_30_PERMANENT_ERROR;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -222,6 +222,7 @@ public class CobolIndexedFile extends CobolFile {
             Statement st = p.connection.createStatement();
             st.execute("select 1");
             st.close();
+            p.connection.commit();
         } catch (SQLException e) {
             int errorCode = e.getErrorCode();
             if (errorCode == SQLiteErrorCode.SQLITE_BUSY.code) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -208,6 +208,10 @@ public class CobolIndexedFile extends CobolFile {
 
         boolean fileExists = new java.io.File(filename).exists();
 
+        if (mode == COB_OPEN_INPUT && !fileExists) {
+            return ENOENT;
+        }
+
         p.connection = null;
         try {
             p.connection =

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -30,6 +30,9 @@ AT_DATA([load.cbl],
        procedure division.
        main-proc.
            open input f.
+           if file-status not = '00'
+             stop run
+           end-if.
            perform forever
              read f next
                at end

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -13,7 +13,8 @@ AT_DATA([load.cbl],
            alternate record key is alt-key-1
            alternate record key is alt-key-2
            alternate record key is alt-key-dup-1 with duplicates
-           alternate record key is alt-key-dup-2 with duplicates.
+           alternate record key is alt-key-dup-2 with duplicates
+           file status is file-status.
        data division.
        file section.
        fd f.
@@ -25,6 +26,7 @@ AT_DATA([load.cbl],
          03 alt-key-dup-2 pic x(5).
          03 rec-value pic x(5).
        working-storage section.
+       01 file-status pic xx.
        procedure division.
        main-proc.
            open input f.
@@ -981,6 +983,8 @@ a0012b0012c0012d0012e001200
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -989,6 +993,8 @@ a0012b0012c0012d0012e001200
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 # test for input containing long records
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -999,6 +1005,8 @@ a0012b0012c0012d0012e001200012aaa
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -1007,6 +1015,8 @@ a0012b0012c0012d0012e001200012aaa
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 # test for input violating the key duplication rule (primary key)
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -1017,6 +1027,8 @@ a0002b0003c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0003c0003d0003e000300003
@@ -1025,6 +1037,8 @@ a0002b0003c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 # test for input violating the key duplication rule (alternate key)
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -1035,6 +1049,8 @@ a0003b0002c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -1043,6 +1059,8 @@ a0003b0002c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
+AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
+[])
 
 ####### test for the file 'dir-idx-file' with valid input #######
 # basic test

--- a/tests/cobj-idx.src/load.at
+++ b/tests/cobj-idx.src/load.at
@@ -981,8 +981,6 @@ a0012b0012c0012d0012e001200
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -991,8 +989,6 @@ a0012b0012c0012d0012e001200
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 
 # test for input containing long records
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -1003,8 +999,6 @@ a0012b0012c0012d0012e001200012aaa
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -1013,8 +1007,6 @@ a0012b0012c0012d0012e001200012aaa
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 
 # test for input violating the key duplication rule (primary key)
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -1025,8 +1017,6 @@ a0002b0003c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0003c0003d0003e000300003
@@ -1035,8 +1025,6 @@ a0002b0003c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 
 # test for input violating the key duplication rule (alternate key)
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
@@ -1047,8 +1035,6 @@ a0003b0002c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt < input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 AT_CHECK([cp idx-invalid-file work-idx-invalid-file])
 AT_DATA([input.txt],
 [a0002b0002c0002d0002e000200002
@@ -1057,8 +1043,6 @@ a0003b0002c0003d0003e000300003
 AT_CHECK([${COBJ_IDX} load work-idx-invalid-file --format=txt input.txt], [1], [],
 [error: 'work-idx-invalid-file' is not a valid indexed file.
 ])
-AT_CHECK([IDX_FILE_PATH=work-idx-invalid-file java load], [0],
-[])
 
 ####### test for the file 'dir-idx-file' with valid input #######
 # basic test

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -2096,7 +2096,10 @@ AT_CHECK([java prog], [1], [],
 
 AT_CLEANUP
 
-AT_SETUP([ACCEPT])
+AT_SETUP([Open an invalid formatted indexed file])
+
+AT_CHECK([echo invalid-data > invalid-formatted-file])
+
 AT_DATA([prog.cbl],
 [
        IDENTIFICATION DIVISION.

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -2095,3 +2095,40 @@ AT_CHECK([java prog], [1], [],
 ])
 
 AT_CLEANUP
+
+AT_SETUP([ACCEPT])
+AT_DATA([prog.cbl],
+[
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT F ASSIGN TO "invalid-formatted-file"
+               ORGANIZATION IS INDEXED
+               ACCESS MODE IS DYNAMIC
+               RECORD KEY IS REC-KEY
+               FILE STATUS IS FILE-STATUS.
+
+       DATA DIVISION.
+       FILE SECTION.
+       FD  f.
+       01  REC.
+         05  REC-KEY      PIC X(5).
+
+       WORKING-STORAGE SECTION.
+       01  FILE-STATUS      PIC XX.
+       PROCEDURE DIVISION.
+       MAIN-PROCEDURE.
+
+       OPEN INPUT f.
+       DISPLAY FILE-STATUS.
+       CLOSE f.
+])
+
+AT_CHECK([${COMPILE} prog.cbl])
+AT_CHECK([java prog], [0], 
+[30
+])
+AT_CLEANUP


### PR DESCRIPTION
このPRの主目的は、無効なフォーマットのINDEXEDファイルを開いたときにファイルステータスを30番に設定することである。
以前までのバージョンでは、無効なフォーマットのINDXEDファイルを開いてもファイルステータスは00番であった。

この改修に付随していくつか別の修正も実施した。

# CobolFille.java

定数ENOENTやEBADFに設定される値を、COB_STATUS_*に設定される値と重複しないように変更した。
このPRのために修正する過程で、定数の衝突により不具合が生じることがあったため、ついでにこの変更を実施した。

# CobolIndexedFile.java

* ファイルを開いたときに簡単なSQL文`select 1`を実行して、有効なSQLiteファイルを開いているかを確認するプロセスを追加。失敗時にファイルステータスを30にする設定を追加。
* INPUTモードで開いたときに、今までと同様にENOENTを返すように修正した。

# load.at

以前のバージョンのテストケースでは、無効なINDEXEDファイルを開く処理があったが、不具合により成功扱いになっていた。
今回の改修により無効なINDEXEDファイルを開くとエラーコードが設定され、FILE STATUSが宣言されていないファイルのためデフォルトのエラーメッセージが表示されるようになった。
FILE STATUSを明示的に宣言することで、デフォルトのエラーメッセージの表示を抑制して、OPENに失敗した場合のエラーハンドリングを適切に設定することで、既存のテストをpassするように変更した。

# miscellaneous.at

今回のINDEXEDファイルの修正に対するテスト。