### PR TITLE
build: update target Windows SDK to latest version

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps: 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v5

--- a/win/cobj/cobj.vcxproj
+++ b/win/cobj/cobj.vcxproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{d69ade50-ab78-4311-95a7-a9676e9bac36}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cobj</RootNamespace>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
# Summary
- This PR fixes [issue717](https://github.com/opensourcecobol/opensourcecobol4j/issues/717)
# Code Changes
-  win/cobj/cobj.vcxproj
   - Changed the solution's target SDK from the specific version `10.0.22621.0` to target the latest installed version.
- .github/workflows/windows-build.yml, windows-test.yml
  - Reverted the changes from [Pull Request718](https://github.com/opensourcecobol/opensourcecobol4j/pull/718), which was a temporary workaround for [issue717](https://github.com/opensourcecobol/opensourcecobol4j/issues/717)
