### PR TITLE
fix: remove an extra backslash in tests/Makefile.am

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -263,7 +263,7 @@ misc_DEPENDENCIES = \
 	misc.src/display-inspect-sign.at \
 	misc.src/comp1-comp2.at \
 	misc.src/variable-length-file.at \
-	misc.src/convert-string-concat.at \
+	misc.src/convert-string-concat.at
 
 EXTRA_DIST = $(srcdir)/package.m4 \
 	$(TESTS) \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -802,7 +802,7 @@ misc_DEPENDENCIES = \
 	misc.src/display-inspect-sign.at \
 	misc.src/comp1-comp2.at \
 	misc.src/variable-length-file.at \
-	misc.src/convert-string-concat.at \
+	misc.src/convert-string-concat.at
 
 EXTRA_DIST = $(srcdir)/package.m4 \
 	$(TESTS) \


### PR DESCRIPTION
In order to fix the following error generated by `autoreconf`, this pull request removes an extra backslashes in tests/Makefile.am and tests/Makefile.in

```
aclocal: warning: couldn't open directory 'm4': No such file or directory
bin/Makefile.am:24: warning: variable 'cobcrun_SOURCES' is defined but no program or
bin/Makefile.am:24: library has 'cobcrun' as canonical name (possible typo)
cobj/Makefile.am:33: warning: '%'-style pattern rules are a GNU make extension
cobj/Makefile.am:36: warning: '%'-style pattern rules are a GNU make extension
cobj/Makefile.am:39: warning: '%'-style pattern rules are a GNU make extension
libcobj/Makefile.am:70: warning: whitespace following trailing backslash
tests/Makefile.am:267: error: blank line following trailing backslash
tests/Makefile.am:297: warning: '%'-style pattern rules are a GNU make extension
tests/Makefile.am:201: warning: variable 'cobj_idx_DEPENDENCIES' is defined but no program or
tests/Makefile.am:201: library has 'cobj_idx' as canonical name (possible typo)
tests/Makefile.am:115: warning: variable 'cobol_utf8_DEPENDENCIES' is defined but no program or
tests/Makefile.am:115: library has 'cobol_utf8' as canonical name (possible typo)
tests/Makefile.am:163: warning: variable 'command_line_options_DEPENDENCIES' is defined but no program or
tests/Makefile.am:163: library has 'command_line_options' as canonical name (possible typo)
tests/Makefile.am:81: warning: variable 'data_rep_DEPENDENCIES' is defined but no program or
tests/Makefile.am:81: library has 'data_rep' as canonical name (possible typo)
tests/Makefile.am:104: warning: variable 'i18n_sjis_DEPENDENCIES' is defined but no program or
tests/Makefile.am:104: library has 'i18n_sjis' as canonical name (possible typo)
tests/Makefile.am:90: warning: variable 'i18n_utf8_DEPENDENCIES' is defined but no program or
tests/Makefile.am:90: library has 'i18n_utf8' as canonical name (possible typo)
tests/Makefile.am:211: warning: variable 'indexed_lock_DEPENDENCIES' is defined but no program or
tests/Makefile.am:211: library has 'indexed_lock' as canonical name (possible typo)
tests/Makefile.am:131: warning: variable 'jp_compat_DEPENDENCIES' is defined but no program or
tests/Makefile.am:131: library has 'jp_compat' as canonical name (possible typo)
tests/Makefile.am:68: warning: variable 'run_DEPENDENCIES' is defined but no program or
tests/Makefile.am:68: library has 'run' as canonical name (possible typo)
tests/Makefile.am:49: warning: variable 'syntax_DEPENDENCIES' is defined but no program or
tests/Makefile.am:49: library has 'syntax' as canonical name (possible typo)
autoreconf: automake failed with exit status: 1
```