### PR TITLE
Fix: the help message of -single-jar

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -914,7 +914,7 @@ static void cobc_print_usage(void) {
          "generated source code"));
   puts(_("  -m, -jar                          Create <PROGRAM-ID>.jar and "
          "remove class files"));
-  puts(_("  -single-jar=<JAR file name>       Create <JAR file name>.jar and "
+  puts(_("  -single-jar=<JAR file name>       Create <JAR file name> and "
          "remove class files"));
   puts(_("                                    The JAR file contains all class "
          "files of all specified COBOL programs"));


### PR DESCRIPTION
This pull request makes a minor update to the usage message in the `cobj/cobj.c` file. The change clarifies the description for the `-single-jar` option by removing the `.jar` extension from the output file name in the help text.

This pull request resolves the problem described in #745 and #519