### PR TITLE
Fix the bug about EXTERNAL data item

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -853,12 +853,12 @@ static void joutput_base(struct cb_field *f) {
   // EDIT
   /* Base name */
   strcpy_identifier_cobol_to_java(name, top->name);
-  if (!top->flag_external) {
+  // if (!top->flag_external) {
     register_data_storage_list(f, top);
-  }
+  // }
 
   if (!top->flag_base) {
-    if (!top->flag_external) {
+    // if (!top->flag_external) {
       if (!top->flag_local || top->flag_is_global) {
         bl = cobc_malloc(sizeof(struct base_list));
         bl->f = top;
@@ -877,17 +877,17 @@ static void joutput_base(struct cb_field *f) {
           joutput_local("\t/* %s */\n", top->name);
         }
       }
-    }
+    // }
     top->flag_base = 1;
   }
 
-  if (top->flag_external) {
-    joutput("%s%s", CB_PREFIX_BASE, name);
-  } else {
+  // if (top->flag_external) {
+  //   joutput("%s%s", CB_PREFIX_BASE, name);
+  // } else {
     if (joutput_field_storage(f, top) && f->offset != 0) {
       joutput(".getSubDataStorage(%d)", f->offset);
     }
-  }
+  // }
 
   if (cb_field_variable_address(f)) {
     for (p = f->parent; p; f = f->parent, p = f->parent) {
@@ -2260,14 +2260,14 @@ static void joutput_initialize_external(cb_tree x, struct cb_field *f) {
   joutput_prefix();
   joutput_data(x);
   if (f->ename) {
-    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);\n", f->ename,
+    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);", f->ename,
             f->size);
   } else if (f->storage == CB_STORAGE_FILE) {
     file = CB_TREE(f->file);
-    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);\n",
+    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);",
             CB_FILE(file)->record->name, f->size);
   } else {
-    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);\n", f->name,
+    joutput(" = CobolExternal.getStorageAddress (\"%s\", %d);", f->name,
             f->size);
   }
 }
@@ -2597,12 +2597,12 @@ static void joutput_initialize(struct cb_initialize *p) {
   int c;
 
   f = cb_field(p->var);
-  if (f->flag_external) {
-    joutput_initialize_external(p->var, f);
-    if (!p->flag_statement) {
-      return;
-    }
-  }
+  // if (f->flag_external) {
+  //   joutput_initialize_external(p->var, f);
+  //   if (!p->flag_statement) {
+  //     return;
+  //   }
+  // }
   switch (initialize_type(p, f, 1)) {
   case INITIALIZE_NONE:
     break;
@@ -4240,6 +4240,10 @@ static void joutput_initial_values(struct cb_field *p) {
     if (p->flag_no_init && !p->count) {
       continue;
     }
+    /* EXTERNAL items */
+    if (p->flag_external) {
+      continue;
+    }
     int tmp_flag = integer_reference_flag;
     integer_reference_flag = 1;
     joutput_stmt(cb_build_initialize(x, cb_true, NULL, def, 0),
@@ -5079,6 +5083,9 @@ static void joutput_init_method(struct cb_program *prog) {
         joutput_prefix();
         joutput("%s = new CobolDataStorage(%d);", base_name,
                 blp->f->memory_size);
+      } else if (blp->f->flag_external) {
+        joutput_initialize_external(cb_build_field_reference(blp->f, NULL),
+                                     blp->f);
       } else {
         joutput_prefix();
         joutput("%s = new CobolDataStorage(%d);", base_name,
@@ -5595,25 +5602,25 @@ static void joutput_declare_member_variables(struct cb_program *prog,
   }
 
   /* External items */
-  for (f = prog->working_storage; f; f = f->sister) {
-    if (f->flag_external) {
-      joutput_prefix();
-      joutput("private CobolDataStorage ");
-      joutput_base(f);
-      joutput(" = null;  /* %s */", f->name);
-      joutput_newline();
-    }
-  }
-  for (l = prog->file_list; l; l = CB_CHAIN(l)) {
-    f = CB_FILE(CB_VALUE(l))->record;
-    if (f->flag_external) {
-      joutput_prefix();
-      joutput("private CobolDataStorage ");
-      joutput_base(f);
-      joutput(" = null;  /* %s */", f->name);
-      joutput_newline();
-    }
-  }
+  // for (f = prog->working_storage; f; f = f->sister) {
+  //   if (f->flag_external) {
+  //     joutput_prefix();
+  //     joutput("private CobolDataStorage ");
+  //     joutput_base(f);
+  //     joutput(" = null;  /* %s */", f->name);
+  //     joutput_newline();
+  //   }
+  // }
+  // for (l = prog->file_list; l; l = CB_CHAIN(l)) {
+  //   f = CB_FILE(CB_VALUE(l))->record;
+  //   if (f->flag_external) {
+  //     joutput_prefix();
+  //     joutput("private CobolDataStorage ");
+  //     joutput_base(f);
+  //     joutput(" = null;  /* %s */", f->name);
+  //     joutput_newline();
+  //   }
+  // }
 
   /* AbstractCobolField型変数の宣言(非定数) */
   if (field_cache) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5588,27 +5588,6 @@ static void joutput_declare_member_variables(struct cb_program *prog,
     joutput("\n");
   }
 
-  /* External items */
-  // for (f = prog->working_storage; f; f = f->sister) {
-  //   if (f->flag_external) {
-  //     joutput_prefix();
-  //     joutput("private CobolDataStorage ");
-  //     joutput_base(f);
-  //     joutput(" = null;  /* %s */", f->name);
-  //     joutput_newline();
-  //   }
-  // }
-  // for (l = prog->file_list; l; l = CB_CHAIN(l)) {
-  //   f = CB_FILE(CB_VALUE(l))->record;
-  //   if (f->flag_external) {
-  //     joutput_prefix();
-  //     joutput("private CobolDataStorage ");
-  //     joutput_base(f);
-  //     joutput(" = null;  /* %s */", f->name);
-  //     joutput_newline();
-  //   }
-  // }
-
   /* AbstractCobolField型変数の宣言(非定数) */
   if (field_cache) {
     joutput_line("/* Fields */\n");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -854,29 +854,29 @@ static void joutput_base(struct cb_field *f) {
   /* Base name */
   strcpy_identifier_cobol_to_java(name, top->name);
   // if (!top->flag_external) {
-    register_data_storage_list(f, top);
+  register_data_storage_list(f, top);
   // }
 
   if (!top->flag_base) {
     // if (!top->flag_external) {
-      if (!top->flag_local || top->flag_is_global) {
-        bl = cobc_malloc(sizeof(struct base_list));
-        bl->f = top;
-        bl->curr_prog = excp_current_program_id;
-        bl->next = base_cache;
-        base_cache = bl;
+    if (!top->flag_local || top->flag_is_global) {
+      bl = cobc_malloc(sizeof(struct base_list));
+      bl->f = top;
+      bl->curr_prog = excp_current_program_id;
+      bl->next = base_cache;
+      base_cache = bl;
+    } else {
+      if (current_prog->flag_global_use) {
+        joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
+        joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
+        joutput_local("\t/* %s */\n", top->name);
+        joutput_local("static unsigned char\t*save_%s%s;\n", CB_PREFIX_BASE,
+                      name);
       } else {
-        if (current_prog->flag_global_use) {
-          joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
-          joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
-          joutput_local("\t/* %s */\n", top->name);
-          joutput_local("static unsigned char\t*save_%s%s;\n", CB_PREFIX_BASE,
-                        name);
-        } else {
-          joutput_local("unsigned char\t*%s%s = NULL;", CB_PREFIX_BASE, name);
-          joutput_local("\t/* %s */\n", top->name);
-        }
+        joutput_local("unsigned char\t*%s%s = NULL;", CB_PREFIX_BASE, name);
+        joutput_local("\t/* %s */\n", top->name);
       }
+    }
     // }
     top->flag_base = 1;
   }
@@ -884,9 +884,9 @@ static void joutput_base(struct cb_field *f) {
   // if (top->flag_external) {
   //   joutput("%s%s", CB_PREFIX_BASE, name);
   // } else {
-    if (joutput_field_storage(f, top) && f->offset != 0) {
-      joutput(".getSubDataStorage(%d)", f->offset);
-    }
+  if (joutput_field_storage(f, top) && f->offset != 0) {
+    joutput(".getSubDataStorage(%d)", f->offset);
+  }
   // }
 
   if (cb_field_variable_address(f)) {
@@ -5085,7 +5085,7 @@ static void joutput_init_method(struct cb_program *prog) {
                 blp->f->memory_size);
       } else if (blp->f->flag_external) {
         joutput_initialize_external(cb_build_field_reference(blp->f, NULL),
-                                     blp->f);
+                                    blp->f);
       } else {
         joutput_prefix();
         joutput("%s = new CobolDataStorage(%d);", base_name,

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5070,7 +5070,9 @@ static void joutput_init_method(struct cb_program *prog) {
         joutput_prefix();
         joutput("%s = new CobolDataStorage(%d);", base_name,
                 blp->f->memory_size);
-      } else if (blp->f->flag_external) {
+      }
+
+      if (blp->f->flag_external) {
         joutput_initialize_external(cb_build_field_reference(blp->f, NULL),
                                     blp->f);
       } else {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -853,12 +853,10 @@ static void joutput_base(struct cb_field *f) {
   // EDIT
   /* Base name */
   strcpy_identifier_cobol_to_java(name, top->name);
-  // if (!top->flag_external) {
+
   register_data_storage_list(f, top);
-  // }
 
   if (!top->flag_base) {
-    // if (!top->flag_external) {
     if (!top->flag_local || top->flag_is_global) {
       bl = cobc_malloc(sizeof(struct base_list));
       bl->f = top;
@@ -868,7 +866,6 @@ static void joutput_base(struct cb_field *f) {
     } else {
       if (current_prog->flag_global_use) {
         joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
-        joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
         joutput_local("\t/* %s */\n", top->name);
         joutput_local("static unsigned char\t*save_%s%s;\n", CB_PREFIX_BASE,
                       name);
@@ -877,17 +874,12 @@ static void joutput_base(struct cb_field *f) {
         joutput_local("\t/* %s */\n", top->name);
       }
     }
-    // }
     top->flag_base = 1;
   }
 
-  // if (top->flag_external) {
-  //   joutput("%s%s", CB_PREFIX_BASE, name);
-  // } else {
   if (joutput_field_storage(f, top) && f->offset != 0) {
     joutput(".getSubDataStorage(%d)", f->offset);
   }
-  // }
 
   if (cb_field_variable_address(f)) {
     for (p = f->parent; p; f = f->parent, p = f->parent) {
@@ -2597,12 +2589,6 @@ static void joutput_initialize(struct cb_initialize *p) {
   int c;
 
   f = cb_field(p->var);
-  // if (f->flag_external) {
-  //   joutput_initialize_external(p->var, f);
-  //   if (!p->flag_statement) {
-  //     return;
-  //   }
-  // }
   switch (initialize_type(p, f, 1)) {
   case INITIALIZE_NONE:
     break;
@@ -2622,6 +2608,7 @@ static void joutput_initialize(struct cb_initialize *p) {
     break;
   }
 }
+
 /*
  * SEARCH
  */

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -88,7 +88,6 @@ AT_CLEANUP
 
 
 AT_SETUP([EXTERNAL data item])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION   DIVISION.
@@ -122,7 +121,7 @@ AT_DATA([caller.cob], [
 
 AT_CHECK([${COMPILE_MODULE} callee.cob])
 AT_CHECK([${COMPILE} caller.cob])
-AT_CHECK([java prog], [0],
+AT_CHECK([${RUN_MODULE} caller], [0],
 [Hello
 World
 ])
@@ -131,7 +130,6 @@ AT_CLEANUP
 
 
 AT_SETUP([EXTERNAL AS data item])
-AT_CHECK([${SKIP_TEST}])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION   DIVISION.
@@ -168,7 +166,7 @@ AT_DATA([caller.cob], [
 
 AT_CHECK([${COMPILE_MODULE} callee.cob])
 AT_CHECK([${COMPILE} caller.cob])
-AT_CHECK([java prog], [0],
+AT_CHECK([${RUN_MODULE} caller], [0],
 [Extrn
 Hello
 World

--- a/tests/run.src/miscellaneous.at
+++ b/tests/run.src/miscellaneous.at
@@ -174,6 +174,73 @@ World
 
 AT_CLEANUP
 
+AT_SETUP([EXTERNAL group data item])
+
+AT_DATA([prog.cbl], [
+        IDENTIFICATION  DIVISION. 
+        PROGRAM-ID.     prog.
+        DATA DIVISION.
+        WORKING-STORAGE SECTION.
+        01 A            EXTERNAL.
+           03 A1        PIC X(5).
+           03 A2        PIC X(3).
+           03 A3.
+             05 A3-1    PIC 9(1).
+             05 A3-2    PIC 9(1).
+        PROCEDURE DIVISION.
+            MOVE "HELLO" TO A1.
+            MOVE "ABC"   TO A2.
+            MOVE 12      TO A3.
+
+            DISPLAY A.
+            DISPLAY A1.
+            DISPLAY A2.
+            DISPLAY A3.
+
+            MOVE "DEF"   TO A2.
+            DISPLAY A.
+
+            CALL "sub".
+
+            MOVE 5       TO A3-2.
+
+            DISPLAY A.
+
+            STOP RUN.
+])
+
+AT_DATA([sub.cbl], [
+        IDENTIFICATION  DIVISION.
+        PROGRAM-ID.     sub.
+        DATA DIVISION.
+        WORKING-STORAGE SECTION.
+        01 A            EXTERNAL.
+           03 A1        PIC X(5).
+           03 A2        PIC X(3).
+           03 A3.
+             05 A3-1    PIC 9(1).
+             05 A3-2    PIC 9(1).
+        PROCEDURE DIVISION.
+            DISPLAY A.
+            MOVE 34      TO A3.
+            MOVE "WORLD" TO A1.
+            GOBACK.
+])
+
+AT_CHECK([${COBJ} prog.cbl])
+AT_CHECK([${COBJ} sub.cbl])
+AT_CHECK([java prog], [0], 
+[HELLOABC12
+HELLO
+ABC
+12
+HELLODEF12
+HELLODEF12
+WORLDDEF35
+])
+
+AT_CLEANUP
+
 
 AT_SETUP([java command validation])
 


### PR DESCRIPTION
# 事象
* 集団項目にEXTERNALが付いている場合、下位項目にMOVEをすると先頭バイトに値がセットされてしまう。

# 何が問題か
* 集団項目にEXTERNALを付けた場合、下位項目に対応するCobolDataStorage型の変数が出力されない。

# 変更点
**主要な変更点を以下に書く。**

まず、EXTERNAL付きの集団項目の下位項目が出力されるように以下の条件分岐を無効にした。
* joutput_base
```c
  // if (!top->flag_external) {
    register_data_storage_list(f, top);
  // }
```

これは、`NullpointerException` を引き起こす。`init()` メソッドで`AbstractCobolField` 型の変数（`f_~~~`）に `CobolDataStorage` 型の変数（`b_~~~`）を `setDataStorage` でセットしているが、`CobolDataStorage` 型の変数はこの時点ではnullなので、この例外が発生してしまう。実際、`CobolExternal.getStorageAddress()` は `run_module()` で実行されるが、これは `init()` メソッドの後に実行される。これを解消するために、`CobolExternal.getStorageAddress()` も `init()` メソッドで出力されるようにした。

* `joutput_init_method` ... else if節を追加して、ここで `CobolExternal.getStorageAddress` を出力するようにした。
```c
  /* CobolDataStorage型変数の初期化(定数) */
  if (base_cache) {
    joutput_line("/* Data storage */\n");
    joutput_line("cob_unifunc = null;\n");
    base_cache = list_cache_sort(base_cache, &base_cache_cmp);
    prevprog = NULL;
    // EDIT
    for (blp = base_cache; blp; blp = blp->next) {
      char *base_name = get_java_identifier_base(blp->f);
      if (blp->curr_prog != prevprog) {
        prevprog = blp->curr_prog;
        joutput_prefix();
        joutput("/* PROGRAM-ID : %s */\n", prevprog);
        joutput_prefix();
        joutput("%s = new CobolDataStorage(%d);", base_name,
                blp->f->memory_size);
      } else if (blp->f->flag_external) {
        joutput_initialize_external(cb_build_field_reference(blp->f, NULL), blp->f);
      } else {
        joutput_prefix();
        joutput("%s = new CobolDataStorage(%d);", base_name,
                blp->f->memory_size);
      }
      free(base_name);
      joutput("\t/* %s */\n", blp->f->name);
    }
```

* `joutput_initialize` ... `run_module` 関数に `CobolExternal.getStorageAddress` を出力する以下の処理を削除した。
```c
  if (f->flag_external) {
    joutput_initialize_external(p->var, f);
    if (!p->flag_statement) {
      return;
    }
  }
```

また、base_cacheにEXTERNALの変数が加えられていなかったため、そこも修正した。
* joutput_base ... `if(!top->flag_external)` の分岐を無効にした。
```c
  if (!top->flag_base) {
    // if (!top->flag_external) {
      if (!top->flag_local || top->flag_is_global) {
        bl = cobc_malloc(sizeof(struct base_list));
        bl->f = top;
        bl->curr_prog = excp_current_program_id;
        bl->next = base_cache;
        base_cache = bl;
      } else {
        if (current_prog->flag_global_use) {
          joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
          joutput_local("unsigned char\t\t*%s%s = NULL;", CB_PREFIX_BASE, name);
          joutput_local("\t/* %s */\n", top->name);
          joutput_local("static unsigned char\t*save_%s%s;\n", CB_PREFIX_BASE,
                        name);
        } else {
          joutput_local("unsigned char\t*%s%s = NULL;", CB_PREFIX_BASE, name);
          joutput_local("\t/* %s */\n", top->name);
        }
      }
    // }
    top->flag_base = 1;
  }
```

ここまでの修正だと、`CobolDataStorage` 型の変数が重複して宣言されてしまっていたので、これを修正した。
* `joutput_declare_member_variables` ... 以下の記述をコメントアウト
```c
  /* External items */
  for (f = prog->working_storage; f; f = f->sister) {
    if (f->flag_external) {
      joutput_prefix();
      joutput("private CobolDataStorage ");
      joutput_base(f);
      joutput(" = null;  /* %s */", f->name);
      joutput_newline();
    }
  }
  for (l = prog->file_list; l; l = CB_CHAIN(l)) {
    f = CB_FILE(CB_VALUE(l))->record;
    if (f->flag_external) {
      joutput_prefix();
      joutput("private CobolDataStorage ");
      joutput_base(f);
      joutput(" = null;  /* %s */", f->name);
      joutput_newline();
    }
  }
```

`run_module` 関数の初期化処理で `fillBytes` を使用してスペース埋めや0埋めをしているが、複数のプログラムでEXTERNALの変数を共有しているときに、ここで初期化されてしまうと想定外の値になってしまうので、EXTERNALの値はfillBytesが実行されないようにした。
* `joutput_initial_values` ... EXTERNALのときは処理をスキップするようにした。
```c
    /* EXTERNAL items */
    if (p->flag_external) {
      continue;
    }
```

# テスト
## `run/miscellaneous.at`
* `EXTERNAL data item` / `EXTERNAL AS data item`
  * スキップされていたが、有効化してパスすることが確認できている。
* `EXTERNAL group data item`
  * 新規に追加した。集団項目にEXTERNALが付いている場合のテスト。