### PR TITLE
Fix the duplicate output

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5067,12 +5067,6 @@ static void joutput_init_method(struct cb_program *prog) {
         prevprog = blp->curr_prog;
         joutput_prefix();
         joutput("/* PROGRAM-ID : %s */\n", prevprog);
-        joutput_prefix();
-        joutput("%s = new CobolDataStorage(%d);", base_name,
-                blp->f->memory_size);
-        free(base_name);
-        joutput("\t/* %s */\n", blp->f->name);
-        continue;
       }
 
       if (blp->f->flag_external) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5070,6 +5070,9 @@ static void joutput_init_method(struct cb_program *prog) {
         joutput_prefix();
         joutput("%s = new CobolDataStorage(%d);", base_name,
                 blp->f->memory_size);
+        free(base_name);
+        joutput("\t/* %s */\n", blp->f->name);
+        continue;
       }
 
       if (blp->f->flag_external) {


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/pull/747 でCobolDataStorage型の変数の出力をするときに、base_cacheを出力するところのif文を修正したが、`b_RETURN_CODE` が2回出力されてしまうようになっていたので、1回のみ出力されるように修正した。