### PR TITLE
Format the generated code for GO TO statements slightly

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3211,7 +3211,8 @@ static void joutput_goto_1(cb_tree x) {
   joutput_prefix();
   joutput("if(true) return Optional.of(contList[");
   joutput_label_variable(CB_LABEL(cb_ref(x)));
-  joutput_line("]);\n");
+  joutput("]);");
+  joutput_newline();
 }
 
 static void joutput_goto(struct cb_goto *p) {


### PR DESCRIPTION
```cobol
       identification division.
       program-id.      prog.
       procedure          division.
           GO TO PROC-A.
       PROC-A.
           STOP RUN.
```
Older compilers generates the following Java code for the above GO TO statement

```java
        /* prog.cbl:4: GO TO */
        {
          if(true) return Optional.of(contList[l_MAIN__PROC_A          ]);

        }
```

Due to this PR, the compiler will generate the following code

```java
        /* prog.cbl:4: GO TO */
        {
          if(true) return Optional.of(contList[l_MAIN__PROC_A]);
        }
```