### PR TITLE
fix: Output error when directories specified by -j and -o options are invalid

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1048,8 +1048,12 @@ static int process_command_line(const int argc, char *argv[]) {
     case 'o':
       /* -o : the directory where class files are stored */
       /* -class-file-dir : the directory where class files are stored */
+      if (optarg == NULL || *optarg == '\0') {
+        fprintf(stderr, "Error: Missing directory path argument\n");
+        exit(1);
+      }
       if (stat(optarg, &st) != 0 || !(S_ISDIR(st.st_mode))) {
-        fprintf(stderr, "Error - '%s' is not a valid directory\n", optarg);
+        fprintf(stderr, "Error: '%s' is not a valid directory\n", optarg);
         exit(1);
       }
       output_name = strdup(optarg);
@@ -1058,8 +1062,12 @@ static int process_command_line(const int argc, char *argv[]) {
     case 'j':
       /* -j : the directory where java files are stored */
       /* -java-source-dir : the directory where java files are stored */
+      if (optarg == NULL || *optarg == '\0') {
+        fprintf(stderr, "Error: Missing directory path argument\n");
+        exit(1);
+      }
       if (stat(optarg, &st) != 0 || !(S_ISDIR(st.st_mode))) {
-        fprintf(stderr, "Error - '%s' is not a valid directory\n", optarg);
+        fprintf(stderr, "Error: '%s' is not a valid directory\n", optarg);
         exit(1);
       }
       java_source_dir = strdup(optarg);

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1048,12 +1048,20 @@ static int process_command_line(const int argc, char *argv[]) {
     case 'o':
       /* -o : the directory where class files are stored */
       /* -class-file-dir : the directory where class files are stored */
+      if (stat(optarg, &st) != 0 || !(S_ISDIR(st.st_mode))) {
+        fprintf(stderr, "Error - '%s' is not a valid directory\n", optarg);
+        exit(1);
+      }
       output_name = strdup(optarg);
       break;
 
     case 'j':
       /* -j : the directory where java files are stored */
       /* -java-source-dir : the directory where java files are stored */
+      if (stat(optarg, &st) != 0 || !(S_ISDIR(st.st_mode))) {
+        fprintf(stderr, "Error - '%s' is not a valid directory\n", optarg);
+        exit(1);
+      }
       java_source_dir = strdup(optarg);
       break;
 

--- a/tests/command-line-options.src/file-path.at
+++ b/tests/command-line-options.src/file-path.at
@@ -137,19 +137,27 @@ AT_DATA([prog.cbl], [
 ])
 
 AT_CHECK([${COBJ} -j java_dir prog.cbl], [1], [], 
-[Error - 'java_dir' is not a valid directory
+[Error: 'java_dir' is not a valid directory
 ])
 
 AT_CHECK([${COBJ} -java-source-dir=java_dir prog.cbl], [1], [], 
-[Error - 'java_dir' is not a valid directory
+[Error: 'java_dir' is not a valid directory
+])
+
+AT_CHECK([${COBJ} -java-source-dir= prog.cbl], [1], [], 
+[Error: Missing directory path argument
 ])
 
 AT_CHECK([${COBJ} -o class_dir prog.cbl], [1], [], 
-[Error - 'class_dir' is not a valid directory
+[Error: 'class_dir' is not a valid directory
 ])
 
 AT_CHECK([${COBJ} -class-file-dir=class_dir prog.cbl], [1], [], 
-[Error - 'class_dir' is not a valid directory
+[Error: 'class_dir' is not a valid directory
+])
+
+AT_CHECK([${COBJ} -class-file-dir= prog.cbl], [1], [], 
+[Error: Missing directory path argument
 ])
 
 AT_CLEANUP

--- a/tests/command-line-options.src/file-path.at
+++ b/tests/command-line-options.src/file-path.at
@@ -123,3 +123,33 @@ AT_CHECK([test ! -e prog.java])
 AT_CHECK([rm -f *.java *.class class_dir/* java_dir/*])
 
 AT_CLEANUP
+
+
+AT_SETUP([file-path options with non-existent directory])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION              DIVISION.
+       PROGRAM-ID.                 prog.
+       DATA                        DIVISION.
+       WORKING-STORAGE             SECTION.
+       PROCEDURE                   DIVISION.
+           DISPLAY "HELLO".
+])
+
+AT_CHECK([${COBJ} -j java_dir prog.cbl], [1], [], 
+[Error - 'java_dir' is not a valid directory
+])
+
+AT_CHECK([${COBJ} -java-source-dir=java_dir prog.cbl], [1], [], 
+[Error - 'java_dir' is not a valid directory
+])
+
+AT_CHECK([${COBJ} -o class_dir prog.cbl], [1], [], 
+[Error - 'class_dir' is not a valid directory
+])
+
+AT_CHECK([${COBJ} -class-file-dir=class_dir prog.cbl], [1], [], 
+[Error - 'class_dir' is not a valid directory
+])
+
+AT_CLEANUP


### PR DESCRIPTION
Currently, if the directories specified by the `-j` (`-java-source-dir`) and `-o` (`-class-file-dir=`) options do not exist, it leads to the following behavior.
```
# cobj op_sample.cbl -j ./Java
Segmentation fault (core dumped)
```
```
# cobj op_sample.cbl -o ./Class
Segmentation fault (core dumped)
```

## 1. Directory not found
This commit fixes this by outputting a clear error message as shown below.
```
# cobj op_sample.cbl -j ./Java
Error: './Java' is not a valid directory
```
```
# cobj op_sample.cbl -o ./Class
Error: './Class' is not a valid directory
```

## 2. Missing argument
If no directory is specified for the `-java-source-dir` or `-class-file-dir` options (i.e., the argument is empty), the following error message is output.
```
# cobj op_sample.cbl -java-source-dir=
Error - Missing directory path argument
```
```
# cobj op_sample.cbl -class-file-dir=
Error - Missing directory path argument
```