### PR TITLE
`AbstractCobolField` now includes an `int` variable to represent memory size

### DIFF
--- a/doc/converted_Java_file_JP.md
+++ b/doc/converted_Java_file_JP.md
@@ -11,11 +11,12 @@ COBOLで定義された変数は、AbstractCobolFieldクラスのインスタン
 **PICTURE句に応じて、各変数はAbstractCobolFieldクラスの派生クラスへと変換される。**
 例えば、`PIC 9(5)`の変数はCobolNumericFieldクラスのインスタンスへ変換され、`PIC X(3)`の変数はCobolAlphanumericFieldに変換される。
 
-また、AbstractCobolFieldは実際のデータをバイト配列として保持するCobolDataStorageクラスと、その他の情報を格納するCobolFieldAttributeクラスを持つ。
+また、AbstractCobolFieldはメモリ上のデータサイズを示すint型の変数、実際のデータをバイト配列として保持するCobolDataStorageクラス、その他の情報を格納するCobolFieldAttributeクラスを持つ。
 
 ```mermaid
 classDiagram
     class AbstractCobolField {
+        - int size
         - CobolDataStorage data
         - CobolFieldAttribute attr
     }

--- a/doc/converted_Java_file_JP.md
+++ b/doc/converted_Java_file_JP.md
@@ -16,9 +16,9 @@ COBOLで定義された変数は、AbstractCobolFieldクラスのインスタン
 ```mermaid
 classDiagram
     class AbstractCobolField {
-        - int size
-        - CobolDataStorage data
-        - CobolFieldAttribute attr
+        # int size
+        # CobolDataStorage data
+        # CobolFieldAttribute attr
     }
 ```
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the structure of the `AbstractCobolField` class, specifically by documenting the inclusion of a new member representing the memory size of data.

Documentation improvements:

* Updated the description and class diagram in `doc/converted_Java_file_JP.md` to indicate that `AbstractCobolField` now includes an `int size` member for memory size, in addition to the existing `CobolDataStorage` and `CobolFieldAttribute` members. This PR replaces `-` with `#` since `#` and `-` respectively indicate `protected` and `private` in mermaid.