### PR TITLE
Remove unnecessary exception handling and related imports

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5045,8 +5045,6 @@ static void joutput_init_method(struct cb_program *prog) {
   joutput_line("public void init() ");
   joutput_line("{");
   joutput_indent_level += 2;
-  joutput_line("try {");
-  joutput_indent_level += 2;
 
   if (prog->decimal_index_max) {
     joutput_line("/* Decimal structures */\n");
@@ -5264,10 +5262,6 @@ static void joutput_init_method(struct cb_program *prog) {
                  CB_PREFIX_FIELD, CB_PREFIX_ATTR, index);
   }
 
-  joutput_indent_level -= 2;
-  joutput_line("} catch(IndexOutOfBoundsException e) {");
-  joutput_line("  System.out.println(\"Error - IndexOutOfBoundsException\");");
-  joutput_line("}");
   joutput_indent_level -= 2;
   joutput_line("}\n");
 
@@ -6086,7 +6080,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput_line("import jp.osscons.opensourcecobol.libcobj.file.*;");
   joutput_line("import jp.osscons.opensourcecobol.libcobj.ui.*;");
   joutput_line("import java.util.Optional;");
-  joutput_line("import java.lang.IndexOutOfBoundsException;");
   joutput("\n");
 
   /*if (!cb_flag_no_cobol_comment) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5265,8 +5265,6 @@ static void joutput_init_method(struct cb_program *prog) {
   }
 
   joutput_indent_level -= 2;
-  joutput_line("} catch(NullPointerException e) {");
-  joutput_line("  System.out.println(\"Error - NullpointerException\");");
   joutput_line("} catch(IndexOutOfBoundsException e) {");
   joutput_line("  System.out.println(\"Error - IndexOutOfBoundsException\");");
   joutput_line("}");
@@ -6088,7 +6086,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput_line("import jp.osscons.opensourcecobol.libcobj.file.*;");
   joutput_line("import jp.osscons.opensourcecobol.libcobj.ui.*;");
   joutput_line("import java.util.Optional;");
-  joutput_line("import java.lang.NullPointerException;");
   joutput_line("import java.lang.IndexOutOfBoundsException;");
   joutput("\n");
 


### PR DESCRIPTION
This pull request simplifies the generated Java code by removing unnecessary exception handling and related imports from the `init()` method in the code generator. The changes focus on making the output Java code cleaner and easier to read.

**Java code generation cleanup:**

* Removed the `try-catch` block for `NullPointerException` and `IndexOutOfBoundsException` from the generated `init()` method in `cobj/codegen.c`, eliminating redundant error handling code. [[1]](diffhunk://#diff-92e09701bd613a805e09be47306909e3e3abb869c44ad69ad4695ba84bb0c421L5048-L5049) [[2]](diffhunk://#diff-92e09701bd613a805e09be47306909e3e3abb869c44ad69ad4695ba84bb0c421L5267-L5272)
* Removed the import statements for `java.lang.NullPointerException` and `java.lang.IndexOutOfBoundsException` from the generated Java files, as they are no longer needed.