### PR TITLE
Update Java compatibility settings in build.gradle.kts

### DIFF
--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -44,9 +44,8 @@ dependencies {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 pmd {


### PR DESCRIPTION
This pull request makes a small change to how the Java version is specified in the Gradle build configuration. Instead of using the `toolchain` block, it now sets `sourceCompatibility` and `targetCompatibility` directly to Java 8.

With the previous settings, building opensource COBOL 4J fails in some environments.

* https://github.com/yutaro-sakamoto/opensourcecobol4j/actions/runs/20048872129/job/57500357257
* https://github.com/yutaro-sakamoto/opensourcecobol4j/actions/runs/20048872129/job/57500451988

It seems that toolchain settings cause these network errors.
https://bufferings.hatenablog.com/entry/2021/02/06/124725