### PR TITLE
Improve the code generation of parameters of

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5068,6 +5068,69 @@ static const char *get_type_constant_name(int type) {
 }
 
 /**
+ * flagsの値をCobolFieldAttributeのフラグ定数名の組み合わせに変換する
+ */
+static const char *get_flags_constant_name(int flags) {
+  static char buffer[512];
+  buffer[0] = '\0';
+
+  if (flags == 0) {
+    return "0";
+  }
+
+  int first = 1;
+
+  if (flags & 0x01) {
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
+    first = 0;
+  }
+  if (flags & 0x02) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE");
+    first = 0;
+  }
+  if (flags & 0x04) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_LEADING");
+    first = 0;
+  }
+  if (flags & 0x08) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BLANK_ZERO");
+    first = 0;
+  }
+  if (flags & 0x10) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_JUSTIFIED");
+    first = 0;
+  }
+  if (flags & 0x20) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BINARY_SWAP");
+    first = 0;
+  }
+  if (flags & 0x40) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_REAL_BINARY");
+    first = 0;
+  }
+  if (flags & 0x80) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_IS_POINTER");
+    first = 0;
+  }
+
+  return buffer;
+}
+
+/**
  * メンバ変数の初期化を行うメソッドinitを出力する
  */
 static void joutput_init_method(struct cb_program *prog) {
@@ -5311,8 +5374,9 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%s, %d, %d, %d, ",
-              get_type_constant_name(j->type), j->digits, j->scale, j->flags);
+      joutput("new CobolFieldAttribute (%s, %d, %d, %s, ",
+              get_type_constant_name(j->type), j->digits, j->scale,
+              get_flags_constant_name(j->flags));
       if (j->pic) {
         joutput("\"");
         unsigned char *s;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5374,7 +5374,8 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%s, %d, %d, %s, ",
+      joutput("new CobolFieldAttribute (%s, /* digits = */%d, /* scale = */%d, "
+              "%s, ",
               get_type_constant_name(j->type), j->digits, j->scale,
               get_flags_constant_name(j->flags));
       if (j->pic) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5028,6 +5028,46 @@ static void *list_cache_sort(void *inlist,
 }
 
 /**
+ * typeの値をCobolFieldAttributeの定数名に変換する
+ */
+static const char *get_type_constant_name(int type) {
+  switch (type) {
+  case 0x00:
+    return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
+  case 0x01:
+    return "CobolFieldAttribute.COB_TYPE_GROUP";
+  case 0x02:
+    return "CobolFieldAttribute.COB_TYPE_BOOLEAN";
+  case 0x10:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY";
+  case 0x11:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY";
+  case 0x12:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_PACKED";
+  case 0x13:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_FLOAT";
+  case 0x14:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_DOUBLE";
+  case 0x24:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_EDITED";
+  case 0x21:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC";
+  case 0x22:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL";
+  case 0x23:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_EDITED";
+  case 0x40:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL";
+  case 0x41:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL_EDITED";
+  case 0x42:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL_ALL";
+  default:
+    return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
+  }
+}
+
+/**
  * メンバ変数の初期化を行うメソッドinitを出力する
  */
 static void joutput_init_method(struct cb_program *prog) {
@@ -5271,8 +5311,8 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%d, %d, %d, %d, ", j->type, j->digits,
-              j->scale, j->flags);
+      joutput("new CobolFieldAttribute (%s, %d, %d, %d, ",
+              get_type_constant_name(j->type), j->digits, j->scale, j->flags);
       if (j->pic) {
         joutput("\"");
         unsigned char *s;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5075,7 +5075,8 @@ static const char *get_flags_constant_name(int flags) {
   buffer[0] = '\0';
 
   if (flags == 0) {
-    return "0";
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_NOT_SPECIFIED");
+    return buffer;
   }
 
   int first = 1;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldAttribute.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldAttribute.java
@@ -74,6 +74,9 @@ public class CobolFieldAttribute {
     /* field flags */
 
     /** TODO: 準備中 */
+    public static final int COB_FLAG_NOT_SPECIFIED = 0x00;
+
+    /** TODO: 準備中 */
     public static final int COB_FLAG_HAVE_SIGN = 0x01;
 
     /** TODO: 準備中 */


### PR DESCRIPTION
This pull request introduces utility functions to improve code readability and maintainability in the COBOL code generator, specifically when outputting Java code for CobolFieldAttribute. The main enhancement is the replacement of raw numeric literals for field types and flags with descriptive constant names, making the generated code easier to understand.

**Improvements to code generation and readability:**

* Added two helper functions, `get_type_constant_name` and `get_flags_constant_name`, to convert numeric `type` and `flags` values into their corresponding `CobolFieldAttribute` constant names for use in generated Java code.
* Updated the `joutput_init_method` function to use these new helper functions, replacing raw integers with descriptive constant names in the generated constructor calls for `CobolFieldAttribute`.