### PR TITLE
Improve constant representaion

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5068,6 +5068,69 @@ static const char *get_type_constant_name(int type) {
 }
 
 /**
+ * flagsの値をCobolFieldAttributeのフラグ定数名の組み合わせに変換する
+ */
+static const char *get_flags_constant_name(int flags) {
+  static char buffer[512];
+  buffer[0] = '\0';
+
+  if (flags == 0) {
+    return "0";
+  }
+
+  int first = 1;
+
+  if (flags & 0x01) {
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
+    first = 0;
+  }
+  if (flags & 0x02) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE");
+    first = 0;
+  }
+  if (flags & 0x04) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_LEADING");
+    first = 0;
+  }
+  if (flags & 0x08) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BLANK_ZERO");
+    first = 0;
+  }
+  if (flags & 0x10) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_JUSTIFIED");
+    first = 0;
+  }
+  if (flags & 0x20) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BINARY_SWAP");
+    first = 0;
+  }
+  if (flags & 0x40) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_REAL_BINARY");
+    first = 0;
+  }
+  if (flags & 0x80) {
+    if (!first)
+      strcat(buffer, " | ");
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_IS_POINTER");
+    first = 0;
+  }
+
+  return buffer;
+}
+
+/**
  * メンバ変数の初期化を行うメソッドinitを出力する
  */
 static void joutput_init_method(struct cb_program *prog) {
@@ -5311,8 +5374,9 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%s, %d, %d, %d, ",
-              get_type_constant_name(j->type), j->digits, j->scale, j->flags);
+      joutput("new CobolFieldAttribute (%s, %d, %d, %s, ",
+              get_type_constant_name(j->type), j->digits, j->scale,
+              get_flags_constant_name(j->flags));
       if (j->pic) {
         joutput("\"");
         unsigned char *s;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5374,7 +5374,8 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%s, %d, %d, %s, ",
+      joutput("new CobolFieldAttribute (%s, /* digits = */%d, /* scale = */%d, "
+              "%s, ",
               get_type_constant_name(j->type), j->digits, j->scale,
               get_flags_constant_name(j->flags));
       if (j->pic) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5375,8 +5375,11 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%s, /* digits = */%d, /* scale = */%d, "
-              "%s, ",
+      joutput("new CobolFieldAttribute (");
+      joutput_newline();
+      joutput_indent_level += 2;
+      joutput_prefix();
+      joutput("%s, /* digits = */%d, /* scale = */%d, %s, ",
               get_type_constant_name(j->type), j->digits, j->scale,
               get_flags_constant_name(j->flags));
       if (j->pic) {
@@ -5395,6 +5398,7 @@ static void joutput_init_method(struct cb_program *prog) {
         joutput("null");
       }
       joutput(");\n");
+      joutput_indent_level -= 2;
     }
   }
 

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5028,6 +5028,46 @@ static void *list_cache_sort(void *inlist,
 }
 
 /**
+ * typeの値をCobolFieldAttributeの定数名に変換する
+ */
+static const char *get_type_constant_name(int type) {
+  switch (type) {
+  case 0x00:
+    return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
+  case 0x01:
+    return "CobolFieldAttribute.COB_TYPE_GROUP";
+  case 0x02:
+    return "CobolFieldAttribute.COB_TYPE_BOOLEAN";
+  case 0x10:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY";
+  case 0x11:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY";
+  case 0x12:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_PACKED";
+  case 0x13:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_FLOAT";
+  case 0x14:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_DOUBLE";
+  case 0x24:
+    return "CobolFieldAttribute.COB_TYPE_NUMERIC_EDITED";
+  case 0x21:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC";
+  case 0x22:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL";
+  case 0x23:
+    return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_EDITED";
+  case 0x40:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL";
+  case 0x41:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL_EDITED";
+  case 0x42:
+    return "CobolFieldAttribute.COB_TYPE_NATIONAL_ALL";
+  default:
+    return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
+  }
+}
+
+/**
  * メンバ変数の初期化を行うメソッドinitを出力する
  */
 static void joutput_init_method(struct cb_program *prog) {
@@ -5271,8 +5311,8 @@ static void joutput_init_method(struct cb_program *prog) {
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
       joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (%d, %d, %d, %d, ", j->type, j->digits,
-              j->scale, j->flags);
+      joutput("new CobolFieldAttribute (%s, %d, %d, %d, ",
+              get_type_constant_name(j->type), j->digits, j->scale, j->flags);
       if (j->pic) {
         joutput("\"");
         unsigned char *s;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5068,81 +5068,49 @@ static const char *get_type_constant_name(int type) {
 }
 
 /**
- * flagsの値をCobolFieldAttributeのフラグ定数名の組み合わせに変換する
- * indent_spaces: 2番目以降のフラグの前に付けるインデントのスペース数
- *                0の場合は従来通り" | "で区切る
+ * flagsの値をCobolFieldAttributeのフラグ定数名の組み合わせとして出力する
+ * additional_indent: 2番目以降のフラグの前に付ける追加インデントのスペース数
  */
-static const char *get_flags_constant_name(int flags, int indent_spaces) {
-  static char buffer[1024];
-  buffer[0] = '\0';
-
+static void joutput_flags(int flags) {
   if (flags == 0) {
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_NOT_SPECIFIED");
-    return buffer;
+    joutput("CobolFieldAttribute.COB_FLAG_NOT_SPECIFIED");
+    return;
   }
 
   int first = 1;
-  char separator[64];
-  if (indent_spaces > 0) {
-    separator[0] = '\n';
-    for (int i = 0; i < indent_spaces; i++) {
-      separator[i + 1] = ' ';
-    }
-    separator[indent_spaces + 1] = '|';
-    separator[indent_spaces + 2] = ' ';
-    separator[indent_spaces + 3] = '\0';
-  } else {
-    strcpy(separator, " | ");
-  }
+  int indent_increased = 0;
 
   if (flags & COB_FLAG_HAVE_SIGN) {
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
-    first = 0;
-  }
-  if (flags & COB_FLAG_SIGN_SEPARATE) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE");
-    first = 0;
-  }
-  if (flags & COB_FLAG_SIGN_LEADING) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_LEADING");
-    first = 0;
-  }
-  if (flags & COB_FLAG_BLANK_ZERO) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BLANK_ZERO");
-    first = 0;
-  }
-  if (flags & COB_FLAG_JUSTIFIED) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_JUSTIFIED");
-    first = 0;
-  }
-  if (flags & COB_FLAG_BINARY_SWAP) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_BINARY_SWAP");
-    first = 0;
-  }
-  if (flags & COB_FLAG_REAL_BINARY) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_REAL_BINARY");
-    first = 0;
-  }
-  if (flags & COB_FLAG_IS_POINTER) {
-    if (!first)
-      strcat(buffer, separator);
-    strcat(buffer, "CobolFieldAttribute.COB_FLAG_IS_POINTER");
+    joutput("CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
     first = 0;
   }
 
-  return buffer;
+#define HANDLE_FLAG(flag)                                                      \
+  if (flags & flag) {                                                          \
+    if (!first) {                                                              \
+      joutput_newline();                                                       \
+      if (!indent_increased) {                                                 \
+        joutput_indent_level += 2;                                             \
+        indent_increased = 1;                                                  \
+      }                                                                        \
+      joutput_prefix();                                                        \
+      joutput("| ");                                                           \
+    }                                                                          \
+    joutput("CobolFieldAttribute." #flag);                                     \
+    first = 0;                                                                 \
+  }
+
+  HANDLE_FLAG(COB_FLAG_SIGN_SEPARATE)
+  HANDLE_FLAG(COB_FLAG_SIGN_LEADING)
+  HANDLE_FLAG(COB_FLAG_BLANK_ZERO)
+  HANDLE_FLAG(COB_FLAG_JUSTIFIED)
+  HANDLE_FLAG(COB_FLAG_BINARY_SWAP)
+  HANDLE_FLAG(COB_FLAG_REAL_BINARY)
+  HANDLE_FLAG(COB_FLAG_IS_POINTER)
+
+  if (indent_increased) {
+    joutput_indent_level -= 2;
+  }
 }
 
 /**
@@ -5405,8 +5373,8 @@ static void joutput_init_method(struct cb_program *prog) {
       joutput_newline();
       // flags
       joutput_prefix();
-      joutput("%s,",
-              get_flags_constant_name(j->flags, joutput_indent_level + 2));
+      joutput_flags(j->flags);
+      joutput(",");
       joutput_newline();
       // pic
       joutput_prefix();

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5069,9 +5069,11 @@ static const char *get_type_constant_name(int type) {
 
 /**
  * flagsの値をCobolFieldAttributeのフラグ定数名の組み合わせに変換する
+ * indent_spaces: 2番目以降のフラグの前に付けるインデントのスペース数
+ *                0の場合は従来通り" | "で区切る
  */
-static const char *get_flags_constant_name(int flags) {
-  static char buffer[512];
+static const char *get_flags_constant_name(int flags, int indent_spaces) {
+  static char buffer[1024];
   buffer[0] = '\0';
 
   if (flags == 0) {
@@ -5080,6 +5082,18 @@ static const char *get_flags_constant_name(int flags) {
   }
 
   int first = 1;
+  char separator[64];
+  if (indent_spaces > 0) {
+    separator[0] = '\n';
+    for (int i = 0; i < indent_spaces; i++) {
+      separator[i + 1] = ' ';
+    }
+    separator[indent_spaces + 1] = '|';
+    separator[indent_spaces + 2] = ' ';
+    separator[indent_spaces + 3] = '\0';
+  } else {
+    strcpy(separator, " | ");
+  }
 
   if (flags & COB_FLAG_HAVE_SIGN) {
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
@@ -5087,43 +5101,43 @@ static const char *get_flags_constant_name(int flags) {
   }
   if (flags & COB_FLAG_SIGN_SEPARATE) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE");
     first = 0;
   }
   if (flags & COB_FLAG_SIGN_LEADING) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_LEADING");
     first = 0;
   }
   if (flags & COB_FLAG_BLANK_ZERO) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_BLANK_ZERO");
     first = 0;
   }
   if (flags & COB_FLAG_JUSTIFIED) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_JUSTIFIED");
     first = 0;
   }
   if (flags & COB_FLAG_BINARY_SWAP) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_BINARY_SWAP");
     first = 0;
   }
   if (flags & COB_FLAG_REAL_BINARY) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_REAL_BINARY");
     first = 0;
   }
   if (flags & COB_FLAG_IS_POINTER) {
     if (!first)
-      strcat(buffer, " | ");
+      strcat(buffer, separator);
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_IS_POINTER");
     first = 0;
   }
@@ -5374,14 +5388,29 @@ static void joutput_init_method(struct cb_program *prog) {
     attr_cache = attr_list_reverse(attr_cache);
     for (j = attr_cache; j; j = j->next) {
       joutput_prefix();
-      joutput("%s%d = ", CB_PREFIX_ATTR, j->id);
-      joutput("new CobolFieldAttribute (");
+      joutput("%s%d = new CobolFieldAttribute(", CB_PREFIX_ATTR, j->id);
       joutput_newline();
       joutput_indent_level += 2;
+      // type
       joutput_prefix();
-      joutput("%s, /* digits = */%d, /* scale = */%d, %s, ",
-              get_type_constant_name(j->type), j->digits, j->scale,
-              get_flags_constant_name(j->flags));
+      joutput("%s,", get_type_constant_name(j->type));
+      joutput_newline();
+      // digits
+      joutput_prefix();
+      joutput("/* digits= */ %d,", j->digits);
+      joutput_newline();
+      // scale
+      joutput_prefix();
+      joutput("/* scale= */ %d,", j->scale);
+      joutput_newline();
+      // flags
+      joutput_prefix();
+      joutput("%s,",
+              get_flags_constant_name(j->flags, joutput_indent_level + 2));
+      joutput_newline();
+      // pic
+      joutput_prefix();
+      joutput("/* pic= */ ");
       if (j->pic) {
         joutput("\"");
         unsigned char *s;
@@ -5397,7 +5426,8 @@ static void joutput_init_method(struct cb_program *prog) {
       } else {
         joutput("null");
       }
-      joutput(");\n");
+      joutput(");");
+      joutput_newline();
       joutput_indent_level -= 2;
     }
   }

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5032,35 +5032,35 @@ static void *list_cache_sort(void *inlist,
  */
 static const char *get_type_constant_name(int type) {
   switch (type) {
-  case 0x00:
+  case COB_TYPE_UNKNOWN:
     return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
-  case 0x01:
+  case COB_TYPE_GROUP:
     return "CobolFieldAttribute.COB_TYPE_GROUP";
-  case 0x02:
+  case COB_TYPE_BOOLEAN:
     return "CobolFieldAttribute.COB_TYPE_BOOLEAN";
-  case 0x10:
+  case COB_TYPE_NUMERIC_DISPLAY:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY";
-  case 0x11:
+  case COB_TYPE_NUMERIC_BINARY:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_BINARY";
-  case 0x12:
+  case COB_TYPE_NUMERIC_PACKED:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_PACKED";
-  case 0x13:
+  case COB_TYPE_NUMERIC_FLOAT:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_FLOAT";
-  case 0x14:
+  case COB_TYPE_NUMERIC_DOUBLE:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_DOUBLE";
-  case 0x24:
+  case COB_TYPE_NUMERIC_EDITED:
     return "CobolFieldAttribute.COB_TYPE_NUMERIC_EDITED";
-  case 0x21:
+  case COB_TYPE_ALPHANUMERIC:
     return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC";
-  case 0x22:
+  case COB_TYPE_ALPHANUMERIC_ALL:
     return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL";
-  case 0x23:
+  case COB_TYPE_ALPHANUMERIC_EDITED:
     return "CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_EDITED";
-  case 0x40:
+  case COB_TYPE_NATIONAL:
     return "CobolFieldAttribute.COB_TYPE_NATIONAL";
-  case 0x41:
+  case COB_TYPE_NATIONAL_EDITED:
     return "CobolFieldAttribute.COB_TYPE_NATIONAL_EDITED";
-  case 0x42:
+  case COB_TYPE_NATIONAL_ALL:
     return "CobolFieldAttribute.COB_TYPE_NATIONAL_ALL";
   default:
     return "CobolFieldAttribute.COB_TYPE_UNKNOWN";
@@ -5081,47 +5081,47 @@ static const char *get_flags_constant_name(int flags) {
 
   int first = 1;
 
-  if (flags & 0x01) {
+  if (flags & COB_FLAG_HAVE_SIGN) {
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_HAVE_SIGN");
     first = 0;
   }
-  if (flags & 0x02) {
+  if (flags & COB_FLAG_SIGN_SEPARATE) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE");
     first = 0;
   }
-  if (flags & 0x04) {
+  if (flags & COB_FLAG_SIGN_LEADING) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_SIGN_LEADING");
     first = 0;
   }
-  if (flags & 0x08) {
+  if (flags & COB_FLAG_BLANK_ZERO) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_BLANK_ZERO");
     first = 0;
   }
-  if (flags & 0x10) {
+  if (flags & COB_FLAG_JUSTIFIED) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_JUSTIFIED");
     first = 0;
   }
-  if (flags & 0x20) {
+  if (flags & COB_FLAG_BINARY_SWAP) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_BINARY_SWAP");
     first = 0;
   }
-  if (flags & 0x40) {
+  if (flags & COB_FLAG_REAL_BINARY) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_REAL_BINARY");
     first = 0;
   }
-  if (flags & 0x80) {
+  if (flags & COB_FLAG_IS_POINTER) {
     if (!first)
       strcat(buffer, " | ");
     strcat(buffer, "CobolFieldAttribute.COB_FLAG_IS_POINTER");

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5075,7 +5075,8 @@ static const char *get_flags_constant_name(int flags) {
   buffer[0] = '\0';
 
   if (flags == 0) {
-    return "0";
+    strcat(buffer, "CobolFieldAttribute.COB_FLAG_NOT_SPECIFIED");
+    return buffer;
   }
 
   int first = 1;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldAttribute.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldAttribute.java
@@ -74,6 +74,9 @@ public class CobolFieldAttribute {
     /* field flags */
 
     /** TODO: 準備中 */
+    public static final int COB_FLAG_NOT_SPECIFIED = 0x00;
+
+    /** TODO: 準備中 */
     public static final int COB_FLAG_HAVE_SIGN = 0x01;
 
     /** TODO: 準備中 */


### PR DESCRIPTION
This pull request introduces utility functions to improve code readability and maintainability in the COBOL code generator, specifically when outputting Java code for CobolFieldAttribute. The main enhancement is the replacement of raw numeric literals for field types and flags with descriptive constant names, making the generated code easier to understand.

**An example**

```cobol
01 NUM PIC S9(5) COMP-3
  SIGN IS LEADING SEPARATE.
```
Due to this change, CobolFieldAttribute corresponding to the above code will be converted into the following code.
```java
    a_1 = new CobolFieldAttribute (
      CobolFieldAttribute.COB_TYPE_NUMERIC_PACKED, /* digits = */5, /* scale = */0, CobolFieldAttribute.COB_FLAG_HAVE_SIGN | CobolFieldAttribute.COB_FLAG_SIGN_SEPARATE | CobolFieldAttribute.COB_FLAG_SIGN_LEADING, null);
```

This PR resolves the issue described in #758 partially.

**Improvements to code generation and readability:**

* Added two helper functions, `get_type_constant_name` and `get_flags_constant_name`, to convert numeric `type` and `flags` values into their corresponding `CobolFieldAttribute` constant names for use in generated Java code.
* Updated the `joutput_init_method` function to use these new helper functions, replacing raw integers with descriptive constant names in the generated constructor calls for `CobolFieldAttribute`.