### PR TITLE
Fix the installation of cobj-idx

### DIFF
--- a/libcobj/bin/cobj-idx
+++ b/libcobj/bin/cobj-idx
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LIBCOBJ_JAR="$SCRIPT_DIR/../app/build/libs/libcobj.jar"
-
-java -cp "$LIBCOBJ_JAR" jp.osscons.opensourcecobol.libcobj.user_util.indexed_file.IndexedFileUtilMain $@
+java jp.osscons.opensourcecobol.libcobj.user_util.indexed_file.IndexedFileUtilMain $@

--- a/libcobj/bin/cobj-idx-test
+++ b/libcobj/bin/cobj-idx-test
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBCOBJ_JAR="$SCRIPT_DIR/../app/build/libs/libcobj.jar"
+
+java -cp "$LIBCOBJ_JAR" jp.osscons.opensourcecobol.libcobj.user_util.indexed_file.IndexedFileUtilMain $@

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -30,7 +30,7 @@ PATH="${abs_top_builddir}/cobj:${abs_top_builddir}/bin:${abs_top_builddir}/libco
 CONF_JP_COMPAT="-conf=${abs_top_builddir}/config/jp-compat.conf"
 CONF_LIMIT_TEST="-conf=${abs_top_builddir}/config/boundary-limit.conf"
 COBJ="${abs_top_builddir}/cobj/cobj"
-COBJ_IDX="${abs_top_builddir}/libcobj/bin/cobj-idx"
+COBJ_IDX="${abs_top_builddir}/libcobj/bin/cobj-idx-test"
 RUN_MODULE="java"
 #COBCRUN="${abs_top_builddir}/bin/cobcrun"
 


### PR DESCRIPTION
With older version, cobj-idx does not work on a user machine, while all tests for cobj-idx succeed.
The cause of this error is that the settings of cobj-idx is optimized for test environment.

```sh
#!/bin/bash

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
LIBCOBJ_JAR="$SCRIPT_DIR/../app/build/libs/libcobj.jar"

java -cp "$LIBCOBJ_JAR" jp.osscons.opensourcecobol.libcobj.user_util.indexed_file.IndexedFileUtilMain $@
```
The above is the content of old `cobj-idx`.
This script woks well only if it locates in the directory libcobj/bin in opensource COBOL 4J repository.
Therefore cobj-idx in /usr/bin which is the ordinary installation directory for cobj-idx does not work.