### PR TITLE
Check UTF-8 NATIONAL and NATIONAL EDITED size

### DIFF
--- a/cobj/tree.c
+++ b/cobj/tree.c
@@ -1565,15 +1565,14 @@ cb_tree cb_build_picture(const char *str) {
     break;
   case PIC_NATIONAL:
     pic->category = CB_CATEGORY_NATIONAL;
-    // #ifdef I18N_UTF8
-    //     /* I18N_UTF8: NATIONAL allocates 3bytes/char for BMP. */
-    //     CHECK_CHARACTER_LENGTH(cb_max_utf8_character_data_size,
-    //                            "National field cannot be larger than %d
-    //                            digits");
-    // #else  /*!I18N_UTF8*/
+#ifdef I18N_UTF8
+    /* I18N_UTF8: NATIONAL allocates 3bytes/char for BMP. */
+    CHECK_CHARACTER_LENGTH(cb_max_utf8_character_data_size,
+                           "National field cannot be larger than %d digits");
+#else  /*!I18N_UTF8*/
     CHECK_CHARACTER_LENGTH(cb_max_sjis_character_data_size,
                            "National field cannot be larger than %d digits");
-    // #endif /*I18N_UTF8*/
+#endif /*I18N_UTF8*/
     break;
   case PIC_NUMERIC_EDITED:
     pic->str = cobc_malloc(idx + 1);
@@ -1599,16 +1598,16 @@ cb_tree cb_build_picture(const char *str) {
     memcpy(pic->str, buff, idx);
     pic->category = CB_CATEGORY_NATIONAL_EDITED;
     pic->lenstr = idx;
-    // #ifdef I18N_UTF8
-    //     /* I18N_UTF8: NATIONAL allocates 3bytes/char for BMP. */
-    //     CHECK_CHARACTER_LENGTH(
-    //         cb_max_utf8_character_data_size,
-    //         "NationalEdit field cannot be larger than %d digits");
-    // #else  /*!I18N_UTF8*/
+#ifdef I18N_UTF8
+    /* I18N_UTF8: NATIONAL allocates 3bytes/char for BMP. */
+    CHECK_CHARACTER_LENGTH(
+        cb_max_utf8_character_data_size,
+        "NationalEdit field cannot be larger than %d digits");
+#else  /*!I18N_UTF8*/
     CHECK_CHARACTER_LENGTH(
         cb_max_sjis_character_data_size,
         "NationalEdit field cannot be larger than %d digits");
-    // #endif /*I18N_UTF8*/
+#endif /*I18N_UTF8*/
     break;
   default:
     goto error;

--- a/tests/cobol_utf8.src/limits.at
+++ b/tests/cobol_utf8.src/limits.at
@@ -215,7 +215,7 @@ AT_CHECK([${COMPILE_LIMIT_TEST} prog.cob], [1], [],
 
 AT_CLEANUP
 
-AT_SETUP([Field length limit PIC N/VALID (SJIS)])
+AT_SETUP([Field length limit PIC N/VALID (UTF-8)])
 export LC_ALL=''
 
 AT_DATA([prog.cob], [
@@ -223,7 +223,7 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
-       01 VALID-N       PIC N(8388608).
+       01 VALID-N       PIC N(5592405).
        PROCEDURE        DIVISION.
            STOP RUN.
 ])
@@ -232,7 +232,7 @@ AT_CHECK([${COMPILE_LIMIT_TEST} prog.cob], [0])
 
 AT_CLEANUP
 
-AT_SETUP([Field length limit PIC N/TOO LONG (SJIS)])
+AT_SETUP([Field length limit PIC N/TOO LONG (UTF-8)])
 export LC_ALL=''
 
 AT_DATA([prog.cob], [
@@ -240,18 +240,18 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
-       01 INVALID-N     PIC N(8388609).
+       01 INVALID-N     PIC N(5592406).
        PROCEDURE        DIVISION.
            STOP RUN.
 ])
 
 AT_CHECK([${COMPILE_LIMIT_TEST} prog.cob], [1], [],
-[prog.cob:6: Error: National field cannot be larger than 8388608 digits
+[prog.cob:6: Error: National field cannot be larger than 5592405 digits
 ])
 
 AT_CLEANUP
 
-AT_SETUP([Field length limit PIC BN/VALID (SJIS)])
+AT_SETUP([Field length limit PIC BN/VALID (UTF-8)])
 export LC_ALL=''
 
 AT_DATA([prog.cob], [
@@ -259,7 +259,7 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
-       01 VALID-BN      PIC BN(8388607).
+       01 VALID-BN      PIC BN(5592404).
        PROCEDURE        DIVISION.
            STOP RUN.
 ])
@@ -268,7 +268,7 @@ AT_CHECK([${COMPILE_LIMIT_TEST} prog.cob], [0])
 
 AT_CLEANUP
 
-AT_SETUP([Field length limit PIC BN/TOO LONG (SJIS)])
+AT_SETUP([Field length limit PIC BN/TOO LONG (UTF-8)])
 export LC_ALL=''
 
 AT_DATA([prog.cob], [
@@ -276,13 +276,13 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
-       01 INVALID-BN    PIC BN(8388608).
+       01 INVALID-BN    PIC BN(5592405).
        PROCEDURE        DIVISION.
            STOP RUN.
 ])
 
 AT_CHECK([${COMPILE_LIMIT_TEST} prog.cob], [1], [],
-[prog.cob:6: Error: NationalEdit field cannot be larger than 8388608 digits
+[prog.cob:6: Error: NationalEdit field cannot be larger than 5592405 digits
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This pull request updates the handling of field length limits for NATIONAL and NATIONAL EDITED data types to properly support UTF-8 encoding, both in the implementation and in the related tests. The changes ensure that the maximum allowed field sizes reflect the increased storage requirements of UTF-8 compared to SJIS, and that the code and tests consistently use UTF-8 logic and limits.

**Implementation updates for UTF-8 support:**

* Replaced commented-out SJIS logic with active UTF-8 checks in `cb_build_picture` in `cobj/tree.c`, ensuring that field length validation uses the correct maximum size for UTF-8 encoded data. [[1]](diffhunk://#diff-050dcd28337263c06e4d0cfc53c58468824b73c59df1bb75d87d848b7196e564L1568-R1575) [[2]](diffhunk://#diff-050dcd28337263c06e4d0cfc53c58468824b73c59df1bb75d87d848b7196e564L1602-R1610)

**Test adjustments for new UTF-8 limits:**

* Updated test descriptions and cases in `tests/cobol_utf8.src/limits.at` to reflect UTF-8 encoding, including new valid and invalid field size limits for NATIONAL and NATIONAL EDITED types. [[1]](diffhunk://#diff-231577c0ff646e9f3ad482761caad275923680aef874322ecbf6bd89a4c70284L218-R226) [[2]](diffhunk://#diff-231577c0ff646e9f3ad482761caad275923680aef874322ecbf6bd89a4c70284L235-R262) [[3]](diffhunk://#diff-231577c0ff646e9f3ad482761caad275923680aef874322ecbf6bd89a4c70284L271-R285)
* Changed error messages and expected outcomes in tests to match the new UTF-8-based limits, ensuring consistency between implementation and validation. [[1]](diffhunk://#diff-231577c0ff646e9f3ad482761caad275923680aef874322ecbf6bd89a4c70284L235-R262) [[2]](diffhunk://#diff-231577c0ff646e9f3ad482761caad275923680aef874322ecbf6bd89a4c70284L271-R285)