### PR TITLE
Detect duplicate labels

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1779,16 +1779,14 @@ static int process_translate(struct filename *fn) {
   if (ret) {
     return ret;
   }
-  if (cb_flag_syntax_only || current_program->entry_list == NULL) {
-    return 0;
-  }
 
   /* Validate duplicate labels in the same section */
   for (q = current_program; q; q = q->next_program) {
     cb_validate_labels(q);
   }
-  if (errorcount > 0) {
-    return 1;
+
+  if (cb_flag_syntax_only || current_program->entry_list == NULL) {
+    return 0;
   }
 
   /* Set up USE GLOBAL handlers */

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1782,7 +1782,9 @@ static int process_translate(struct filename *fn) {
 
   /* Validate duplicate labels in the same section */
   for (q = current_program; q; q = q->next_program) {
-    cb_validate_labels(q);
+    if (cb_validate_labels(q)) {
+      return -1;
+    }
   }
 
   if (cb_flag_syntax_only || current_program->entry_list == NULL) {

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1783,6 +1783,14 @@ static int process_translate(struct filename *fn) {
     return 0;
   }
 
+  /* Validate duplicate labels in the same section */
+  for (q = current_program; q; q = q->next_program) {
+    cb_validate_labels(q);
+  }
+  if (errorcount > 0) {
+    return 1;
+  }
+
   /* Set up USE GLOBAL handlers */
   p = current_program;
   for (q = p; q; q = q->next_program) {

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -1500,6 +1500,7 @@ extern void cb_validate_program_environment(struct cb_program *prog);
 extern void cb_validate_program_data(struct cb_program *prog);
 extern void cb_validate_program_body(struct cb_program *prog);
 extern void cb_validate_indexed_file_key(const struct cb_file *f);
+extern int cb_validate_labels(struct cb_program *prog);
 
 extern cb_tree cb_build_expr(cb_tree list);
 extern cb_tree cb_build_cond(cb_tree x);

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -1512,10 +1512,14 @@ int cb_validate_labels(struct cb_program *prog) {
       }
 
       if (strcmp((const char *)label1->name, (const char *)label2->name) == 0) {
-        cb_error_x(x2, _("Duplicate paragraph '%s' in section '%s'"),
-                   label2->name,
-                   label2->section ? label2->section->name
-                                   : (const unsigned char *)"MAIN SECTION");
+        if (!label2->section || !label2->section->name ||
+            strcmp((char *)label2->section->name, "MAIN SECTION") == 0) {
+          cb_error_x(x2, _("Duplicate paragraph '%s' in the default section"),
+                     label2->name);
+        } else {
+          cb_error_x(x2, _("Duplicate paragraph '%s' in section '%s'"),
+                     label2->name, label2->section->name);
+        }
         cb_error_x(x1, _("'%s' previously defined here"), label1->name);
         duplicate_count++;
       }

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -1483,6 +1483,47 @@ void cb_validate_program_body(struct cb_program *prog) {
   }
 }
 
+int cb_validate_labels(struct cb_program *prog) {
+  cb_tree l1, l2;
+  int duplicate_count = 0;
+
+  for (l1 = prog->exec_list; l1; l1 = CB_CHAIN(l1)) {
+    cb_tree x1 = CB_VALUE(l1);
+    if (CB_TREE_TAG(x1) != CB_TAG_LABEL) {
+      continue;
+    }
+    struct cb_label *label1 = CB_LABEL(x1);
+    if (label1->is_section) {
+      continue;
+    }
+
+    for (l2 = CB_CHAIN(l1); l2; l2 = CB_CHAIN(l2)) {
+      cb_tree x2 = CB_VALUE(l2);
+      if (CB_TREE_TAG(x2) != CB_TAG_LABEL) {
+        continue;
+      }
+      struct cb_label *label2 = CB_LABEL(x2);
+      if (label2->is_section) {
+        continue;
+      }
+
+      if (label1->section != label2->section) {
+        continue;
+      }
+
+      if (strcmp((const char *)label1->name, (const char *)label2->name) == 0) {
+        cb_error_x(x2, _("Duplicate paragraph '%s' in section '%s'"),
+                   label2->name,
+                   label2->section ? label2->section->name
+                                   : (const unsigned char *)"MAIN SECTION");
+        cb_error_x(x1, _("'%s' previously defined here"), label1->name);
+        duplicate_count++;
+      }
+    }
+  }
+  return duplicate_count;
+}
+
 /*
  * Expressions
  */

--- a/cobj/typeck.c
+++ b/cobj/typeck.c
@@ -1489,7 +1489,7 @@ int cb_validate_labels(struct cb_program *prog) {
 
   for (l1 = prog->exec_list; l1; l1 = CB_CHAIN(l1)) {
     cb_tree x1 = CB_VALUE(l1);
-    if (CB_TREE_TAG(x1) != CB_TAG_LABEL) {
+    if (!CB_LABEL_P(x1)) {
       continue;
     }
     struct cb_label *label1 = CB_LABEL(x1);
@@ -1499,16 +1499,16 @@ int cb_validate_labels(struct cb_program *prog) {
 
     for (l2 = CB_CHAIN(l1); l2; l2 = CB_CHAIN(l2)) {
       cb_tree x2 = CB_VALUE(l2);
-      if (CB_TREE_TAG(x2) != CB_TAG_LABEL) {
+      if (!CB_LABEL_P(x2)) {
         continue;
       }
       struct cb_label *label2 = CB_LABEL(x2);
       if (label2->is_section) {
-        continue;
+        break;
       }
 
       if (label1->section != label2->section) {
-        continue;
+        break;
       }
 
       if (strcmp((const char *)label1->name, (const char *)label2->name) == 0) {

--- a/tests/syntax.src/definition.at
+++ b/tests/syntax.src/definition.at
@@ -511,14 +511,9 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_ONLY} prog.cob], [0], ,
-[])
-
-## Change when we DON'T allow this
-## AT_CHECK([${COMPILE_ONLY} prog.cob], [1], ,
-## [prog.cob: In paragraph 'L':
-## prog.cob:6: Error: redefinition of 'L'
-## prog.cob:5: Error: 'L' previously defined here
-## ])
+[prog.cbl:6: Error: Duplicate paragraph 'L' in the default section
+prog.cbl:5: Error: 'L' previously defined here
+])
 
 AT_CLEANUP
 

--- a/tests/syntax.src/definition.at
+++ b/tests/syntax.src/definition.at
@@ -501,18 +501,84 @@ AT_CLEANUP
 
 AT_SETUP([Redefinition of paragraph names])
 
-AT_DATA([prog.cob], [
+AT_DATA([prog1.cob], [
        IDENTIFICATION   DIVISION.
-       PROGRAM-ID.      prog.
+       PROGRAM-ID.      prog1.
        PROCEDURE        DIVISION.
+      *No Label
        L.
+      *No Label
        L.
            STOP RUN.
 ])
 
-AT_CHECK([${COMPILE_ONLY} prog.cob], [0], ,
-[prog.cbl:6: Error: Duplicate paragraph 'L' in the default section
-prog.cbl:5: Error: 'L' previously defined here
+AT_DATA([prog2.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog2.
+       PROCEDURE        DIVISION.
+       SECTION-A SECTION.
+       L.
+      *No Label
+       L.
+           STOP RUN.
+])
+
+AT_DATA([prog3.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog3.
+       PROCEDURE        DIVISION.
+       SECTION-A SECTION.
+       L.
+       SECTION-B SECTION.
+       L.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -fsyntax-only prog1.cob], [1], ,
+[prog1.cob:8: Error: Duplicate paragraph 'L' in the default section
+prog1.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} -fsyntax-only prog2.cob], [1], ,
+[prog2.cob:8: Error: Duplicate paragraph 'L' in section 'SECTION-A'
+prog2.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} -fsyntax-only prog3.cob])
+
+AT_CHECK([${COMPILE} prog1.cob], [1], ,
+[prog1.cob:8: Error: Duplicate paragraph 'L' in the default section
+prog1.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} prog2.cob], [1], ,
+[prog2.cob:8: Error: Duplicate paragraph 'L' in section 'SECTION-A'
+prog2.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} prog3.cob])
+
+AT_CHECK([${COMPILE} prog1.cob prog3.cob], [1], ,
+[prog1.cob:8: Error: Duplicate paragraph 'L' in the default section
+prog1.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} prog2.cob prog3.cob], [1], ,
+[prog2.cob:8: Error: Duplicate paragraph 'L' in section 'SECTION-A'
+prog2.cob:6: Error: 'L' previously defined here
+])
+
+AT_CHECK([${COMPILE} prog3.cob prog1.cob], [1], ,
+[prog1.cob:8: Error: Duplicate paragraph 'L' in the default section
+prog1.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} prog3.cob prog2.cob], [1], ,
+[prog2.cob:8: Error: Duplicate paragraph 'L' in section 'SECTION-A'
+prog2.cob:6: Error: 'L' previously defined here
+])
+
+AT_CHECK([${COMPILE} prog1.cob prog2.cob], [1], ,
+[prog1.cob:8: Error: Duplicate paragraph 'L' in the default section
+prog1.cob:6: Error: 'L' previously defined here
+])
+AT_CHECK([${COMPILE} prog2.cob prog1.cob], [1], ,
+[prog2.cob:8: Error: Duplicate paragraph 'L' in section 'SECTION-A'
+prog2.cob:6: Error: 'L' previously defined here
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This pull request introduces a new validation step to detect and report duplicate paragraph (label) names within the same section of a COBOL program. This pull request will resolve #334 

**Label validation and error reporting:**

* Added the function `cb_validate_labels` in `typeck.c` to check for duplicate paragraph (label) names within the same section, reporting detailed errors when duplicates are found.
* Declared `cb_validate_labels` in the header file `tree.h` for use in other modules.
* Integrated label validation into the compilation pipeline in `cobj.c` by invoking `cb_validate_labels` for each program before further processing.

**Test coverage improvements:**

* Expanded and updated the test suite in `definition.at` to cover cases with duplicate labels in the default section and named sections, ensuring that errors are correctly reported and that valid cases pass as expected.