### PR TITLE
Invoke `javac` once to optimize compliation time

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -2370,6 +2370,13 @@ int main(int argc, char *argv[]) {
     cb_pretty_display = 0;
   }
 
+  /* Check if the number of COBOL programs exceeds the limit */
+  if (argc - iargs > PROGRAM_ID_LIST_MAX_LEN) {
+    fprintf(stderr, "Error: Too many COBOL programs (max %d)\n",
+            PROGRAM_ID_LIST_MAX_LEN);
+    exit(1);
+  }
+
   while (iargs < argc) {
     fn = process_filename(argv[iargs++]);
     if (!fn) {

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1888,9 +1888,11 @@ static int process_compile_all(void) {
 #else
       char remove_cmd[] = "rm";
 #endif
-      snprintf(buff, COB_MEDIUM_BUFF, "%s %s%c%s.class %s%c%s$*.class",
-               remove_cmd, output_name_a, file_path_delimitor, *program_id,
-               output_name_a, file_path_delimitor, *program_id);
+      snprintf(buff, COB_MEDIUM_BUFF, "%s %s%c%s%c%s.class %s%c%s%c%s$*.class",
+               remove_cmd, output_name_a, file_path_delimitor, package_dir,
+               file_path_delimitor, *program_id, output_name_a,
+               file_path_delimitor, package_dir, file_path_delimitor,
+               *program_id);
       process(buff);
     }
   }

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1854,12 +1854,15 @@ static int process_compile_all(void) {
       java_source_dir == NULL ? current_dir : java_source_dir;
 
   /* Build list of Java files to compile */
-  char java_files[COB_LARGE_BUFF] = "";
+  /* Reserve space for "javac ... -encoding ... -d ... " prefix (at least 1024
+   * bytes) */
+#define JAVA_FILES_MAX_LEN (COB_LARGE_BUFF / 2)
+  char java_files[JAVA_FILES_MAX_LEN] = "";
   char **program_id;
   for (program_id = program_id_list; *program_id; ++program_id) {
     if (strlen(java_files) + strlen(java_source_dir_a) + strlen(*program_id) +
             10 >
-        COB_LARGE_BUFF) {
+        JAVA_FILES_MAX_LEN) {
       fprintf(stderr, "Too many Java files to compile at once\n");
       return -1;
     }
@@ -1868,6 +1871,7 @@ static int process_compile_all(void) {
     strcat(java_files, *program_id);
     strcat(java_files, ".java ");
   }
+#undef JAVA_FILES_MAX_LEN
 
   /* Compile all Java files at once */
   snprintf(buff, COB_LARGE_BUFF, "javac %s -encoding %s -d %s %s",

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -200,6 +200,7 @@ char *cb_info_json_dir = NULL;
 
 #define PROGRAM_ID_LIST_MAX_LEN 1024
 char *program_id_list[PROGRAM_ID_LIST_MAX_LEN];
+int program_id_list_index = 0;
 
 #ifdef _MSC_VER
 #if _MSC_VER >= 1400
@@ -1814,11 +1815,14 @@ static int process_translate(struct filename *fn) {
   }
 
   /* translate to Java */
-  for (i = 0; i < PROGRAM_ID_LIST_MAX_LEN; ++i) {
-    program_id_list[i] = NULL;
-  }
-  codegen(p, 0, program_id_list,
+  codegen(p, 0, &program_id_list[program_id_list_index],
           java_source_dir == NULL ? (char *)"./" : java_source_dir, fn->source);
+
+  /* update program_id_list_index to point to the next empty slot */
+  while (program_id_list_index < PROGRAM_ID_LIST_MAX_LEN &&
+         program_id_list[program_id_list_index] != NULL) {
+    program_id_list_index++;
+  }
 
   return 0;
 }
@@ -1835,10 +1839,9 @@ static void package_name_to_path(char *buff, char *package_name) {
   }
 }
 
-static int process_compile(struct filename *fn) {
+static int process_compile_all(void) {
   char buff[COB_MEDIUM_BUFF];
   char buff2[COB_SMALL_BUFF];
-  char name[COB_MEDIUM_BUFF];
   int ret = 0;
 #ifdef _WIN32
   char current_dir[] = ".\\";
@@ -1848,37 +1851,36 @@ static int process_compile(struct filename *fn) {
   char remove_cmd[] = "rm -rf";
 #endif
 
-  if (output_name) {
-    strcpy(name, output_name);
-  } else {
-    file_basename(fn->source, name);
-  }
-
   char *output_name_a = output_name == NULL ? current_dir : output_name;
   char *java_source_dir_a =
       java_source_dir == NULL ? current_dir : java_source_dir;
 
-  char **program_id;
-  for (program_id = program_id_list; *program_id; ++program_id) {
-    snprintf(buff, COB_MEDIUM_BUFF, "javac %s -encoding %s -d %s %s/%s.java",
-             cob_java_flags, JAVAC_ENCODING, output_name_a, java_source_dir_a,
-             *program_id);
-    ret = process(buff);
+  /* Compile all Java files at once */
+  snprintf(buff, COB_MEDIUM_BUFF, "javac %s -encoding %s -d %s %s/*.java",
+           cob_java_flags, JAVAC_ENCODING, output_name_a, java_source_dir_a);
+  ret = process(buff);
+  if (ret) {
+    return ret;
+  }
 
-    if (ret) {
-      return ret;
+  /* Create jar files if cb_flag_jar is set */
+  if (cb_flag_jar) {
+    char *package_dir;
+    if (cb_java_package_name) {
+      package_name_to_path(buff2, cb_java_package_name);
+      package_dir = buff2;
+    } else {
+      package_dir = (char *)".";
     }
-    if (cb_flag_jar) {
-      char *package_dir;
-      if (cb_java_package_name) {
-        package_name_to_path(buff2, cb_java_package_name);
-        package_dir = buff2;
-      } else {
-        package_dir = (char *)".";
-      }
+
+    char **program_id;
+    for (program_id = program_id_list; *program_id; ++program_id) {
       snprintf(buff, COB_MEDIUM_BUFF,
-               "cd %s && jar --create --main-class=%s --file=%s.jar %s/*.class",
-               output_name_a, *program_id, *program_id, package_dir);
+               "cd %s && jar --create --main-class=%s --file=%s.jar "
+               "%s%c%s.class %s%c%s$*.class",
+               output_name_a, *program_id, *program_id, package_dir,
+               file_path_delimitor, *program_id, package_dir,
+               file_path_delimitor, *program_id);
       ret = process(buff);
       if (ret) {
         return ret;
@@ -1892,47 +1894,25 @@ static int process_compile(struct filename *fn) {
   return ret;
 }
 
-static int process_build_module(struct filename *fn) {
+static int process_build_module_all(void) {
   int ret = 0;
   char buff[COB_MEDIUM_BUFF];
-  char name[COB_MEDIUM_BUFF];
-
-  char basename[COB_MEDIUM_BUFF];
-  file_basename(fn->source, basename);
-  struct cb_program *p;
 #ifdef _WIN32
   char remove_cmd[] = "del";
 #else
   char remove_cmd[] = "rm";
 #endif
 
-  if (output_name) {
-    strcpy(name, output_name);
-#if defined(_MSC_VER)
-    file_stripext(name);
-#else
-    if (strchr(output_name, '.') == NULL) {
-      strcat(name, ".");
-      strcat(name, COB_MODULE_EXT);
-    }
-#endif
-  } else {
-    file_basename(fn->source, name);
-#if !defined(_MSC_VER)
-    strcat(name, ".");
-    strcat(name, COB_MODULE_EXT);
-#endif
-  }
-
-  for (p = current_program; p; p = p->next_program) {
-    sprintf(buff, "jar cf %s.jar ./%s.class ./%s$*.class", p->program_id,
-            p->program_id, p->program_id);
+  char **program_id;
+  for (program_id = program_id_list; *program_id; ++program_id) {
+    sprintf(buff, "jar cf %s.jar ./%s.class ./%s$*.class", *program_id,
+            *program_id, *program_id);
     ret = process(buff);
     if (ret) {
       return ret;
     }
-    sprintf(buff, "%s %s.class %s$*.class", remove_cmd, p->program_id,
-            p->program_id);
+    sprintf(buff, "%s %s.class %s$*.class", remove_cmd, *program_id,
+            *program_id);
     ret = process(buff);
     if (ret) {
       return ret;
@@ -2381,6 +2361,13 @@ int main(int argc, char *argv[]) {
       }
     }
   }
+
+  /* Initialize program_id_list before translation loop */
+  program_id_list_index = 0;
+  for (int i = 0; i < PROGRAM_ID_LIST_MAX_LEN; ++i) {
+    program_id_list[i] = NULL;
+  }
+
   for (fn = file_list; fn; fn = fn->next) {
     cb_id = 1;
     cb_attr_id = 1;
@@ -2426,24 +2413,26 @@ int main(int argc, char *argv[]) {
       continue;
     }
 
-    /* Compile */
-    if (!cb_single_jar_name && (cb_compile_level == CB_LEVEL_COMPILE ||
-                                cb_compile_level == CB_LEVEL_MODULE)) {
-      if (process_compile(fn) != 0) {
-        cobc_clean_up(status);
-        return status;
-      }
-    }
-
-    /* Build module */
-    if (cb_compile_level == CB_LEVEL_MODULE) {
-      if (process_build_module(fn) != 0) {
-        cobc_clean_up(status);
-        return status;
-      }
-      /* Build executable */
-    } else if (cb_compile_level == CB_LEVEL_EXECUTABLE) {
+    /* Build executable */
+    if (cb_compile_level == CB_LEVEL_EXECUTABLE) {
       fprintf(stderr, "Building executable files is not supported");
+    }
+  }
+
+  /* Compile all Java files at once after all translations are complete */
+  if (!cb_single_jar_name && (cb_compile_level == CB_LEVEL_COMPILE ||
+                              cb_compile_level == CB_LEVEL_MODULE)) {
+    if (process_compile_all() != 0) {
+      cobc_clean_up(status);
+      return status;
+    }
+  }
+
+  /* Build module for all programs */
+  if (cb_compile_level == CB_LEVEL_MODULE) {
+    if (process_build_module_all() != 0) {
+      cobc_clean_up(status);
+      return status;
     }
   }
 

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1840,7 +1840,7 @@ static void package_name_to_path(char *buff, char *package_name) {
 }
 
 static int process_compile_all(void) {
-  char buff[COB_MEDIUM_BUFF];
+  char buff[COB_LARGE_BUFF];
   char buff2[COB_SMALL_BUFF];
   int ret = 0;
 #ifdef _WIN32
@@ -1853,9 +1853,25 @@ static int process_compile_all(void) {
   char *java_source_dir_a =
       java_source_dir == NULL ? current_dir : java_source_dir;
 
+  /* Build list of Java files to compile */
+  char java_files[COB_LARGE_BUFF] = "";
+  char **program_id;
+  for (program_id = program_id_list; *program_id; ++program_id) {
+    if (strlen(java_files) + strlen(java_source_dir_a) + strlen(*program_id) +
+            10 >
+        COB_LARGE_BUFF) {
+      fprintf(stderr, "Too many Java files to compile at once\n");
+      return -1;
+    }
+    strcat(java_files, java_source_dir_a);
+    strcat(java_files, "/");
+    strcat(java_files, *program_id);
+    strcat(java_files, ".java ");
+  }
+
   /* Compile all Java files at once */
-  snprintf(buff, COB_MEDIUM_BUFF, "javac %s -encoding %s -d %s %s/*.java",
-           cob_java_flags, JAVAC_ENCODING, output_name_a, java_source_dir_a);
+  snprintf(buff, COB_LARGE_BUFF, "javac %s -encoding %s -d %s %s",
+           cob_java_flags, JAVAC_ENCODING, output_name_a, java_files);
   ret = process(buff);
   if (ret) {
     return ret;

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1815,14 +1815,8 @@ static int process_translate(struct filename *fn) {
   }
 
   /* translate to Java */
-  codegen(p, 0, &program_id_list[program_id_list_index],
+  codegen(p, 0, &program_id_list[program_id_list_index++],
           java_source_dir == NULL ? (char *)"./" : java_source_dir, fn->source);
-
-  /* update program_id_list_index to point to the next empty slot */
-  while (program_id_list_index < PROGRAM_ID_LIST_MAX_LEN &&
-         program_id_list[program_id_list_index] != NULL) {
-    program_id_list_index++;
-  }
 
   return 0;
 }

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -198,7 +198,7 @@ char *cb_single_jar_name = NULL;
 int cb_flag_info_json = 0;
 char *cb_info_json_dir = NULL;
 
-#define PROGRAM_ID_LIST_MAX_LEN 1024
+#define PROGRAM_ID_LIST_MAX_LEN (65536)
 char *program_id_list[PROGRAM_ID_LIST_MAX_LEN];
 int program_id_list_index = 0;
 

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1840,7 +1840,8 @@ static void package_name_to_path(char *buff, char *package_name) {
 }
 
 static int process_compile_all(void) {
-  char buff[COB_LARGE_BUFF];
+#define BUFF_SIZE (COB_LARGE_BUFF * 32)
+  char buff[BUFF_SIZE];
   char buff2[COB_SMALL_BUFF];
   int ret = 0;
 #ifdef _WIN32
@@ -1856,7 +1857,7 @@ static int process_compile_all(void) {
   /* Build list of Java files to compile */
   /* Reserve space for "javac ... -encoding ... -d ... " prefix (at least 1024
    * bytes) */
-#define JAVA_FILES_MAX_LEN (COB_LARGE_BUFF / 2)
+#define JAVA_FILES_MAX_LEN (BUFF_SIZE / 2)
   char java_files[JAVA_FILES_MAX_LEN] = "";
   char **program_id;
   for (program_id = program_id_list; *program_id; ++program_id) {
@@ -1874,8 +1875,8 @@ static int process_compile_all(void) {
 #undef JAVA_FILES_MAX_LEN
 
   /* Compile all Java files at once */
-  snprintf(buff, COB_LARGE_BUFF, "javac %s -encoding %s -d %s %s",
-           cob_java_flags, JAVAC_ENCODING, output_name_a, java_files);
+  snprintf(buff, BUFF_SIZE, "javac %s -encoding %s -d %s %s", cob_java_flags,
+           JAVAC_ENCODING, output_name_a, java_files);
   ret = process(buff);
   if (ret) {
     return ret;
@@ -1892,7 +1893,7 @@ static int process_compile_all(void) {
     }
 
     for (program_id = program_id_list; *program_id; ++program_id) {
-      snprintf(buff, COB_MEDIUM_BUFF,
+      snprintf(buff, BUFF_SIZE,
                "cd %s && jar --create --main-class=%s --file=%s.jar "
                "%s%c%s.class %s%c%s$*.class",
                output_name_a, *program_id, *program_id, package_dir,
@@ -1907,7 +1908,7 @@ static int process_compile_all(void) {
 #else
       char remove_cmd[] = "rm";
 #endif
-      snprintf(buff, COB_MEDIUM_BUFF, "%s %s%c%s%c%s.class %s%c%s%c%s$*.class",
+      snprintf(buff, BUFF_SIZE, "%s %s%c%s%c%s.class %s%c%s%c%s$*.class",
                remove_cmd, output_name_a, file_path_delimitor, package_dir,
                file_path_delimitor, *program_id, output_name_a,
                file_path_delimitor, package_dir, file_path_delimitor,
@@ -1915,6 +1916,7 @@ static int process_compile_all(void) {
       process(buff);
     }
   }
+#undef BUFF_SIZE
   return ret;
 }
 

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1845,10 +1845,8 @@ static int process_compile_all(void) {
   int ret = 0;
 #ifdef _WIN32
   char current_dir[] = ".\\";
-  char remove_cmd[] = "del";
 #else
   char current_dir[] = "./";
-  char remove_cmd[] = "rm -rf";
 #endif
 
   char *output_name_a = output_name == NULL ? current_dir : output_name;
@@ -1885,6 +1883,11 @@ static int process_compile_all(void) {
       if (ret) {
         return ret;
       }
+#ifdef _WIN32
+      char remove_cmd[] = "del";
+#else
+      char remove_cmd[] = "rm";
+#endif
       snprintf(buff, COB_MEDIUM_BUFF, "%s %s%c%s.class %s%c%s$*.class",
                remove_cmd, output_name_a, file_path_delimitor, *program_id,
                output_name_a, file_path_delimitor, *program_id);

--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1891,7 +1891,6 @@ static int process_compile_all(void) {
       package_dir = (char *)".";
     }
 
-    char **program_id;
     for (program_id = program_id_list; *program_id; ++program_id) {
       snprintf(buff, COB_MEDIUM_BUFF,
                "cd %s && jar --create --main-class=%s --file=%s.jar "


### PR DESCRIPTION
The older version compiler invokes javac for each input COBOL files.
This PR makes the compiler to invokes javac once even if multiple input COBOL files are passed to `cobj`.

Due to this improvement, the compilation time for 100 COBOL programs changed as follows.

[Benchmark programs](https://github.com/yutaro-sakamoto/opensourcecobol4j/tree/4696db61c739afb87cf301cb09755f7de38a1c7f/benchmark)

**Before**

```
real    0m38.071s
user    1m38.242s
sys     0m8.492s
```

**After**

```
real    0m1.275s
user    0m5.944s
sys     0m0.417s
```