### PR TITLE
fix: Fix bug with SECTION names containing full-width hyphens

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -5979,7 +5979,9 @@ static void joutput_label_variable_name(char *s, int key,
   if (s) {
     if (section && section->name) {
       const char *c;
-      for (c = (const char *)section->name; *c; ++c) {
+      char section_buf[COB_SMALL_BUFF];
+      strcpy_identifier_cobol_to_java(section_buf, (const char *)section->name);
+      for (c = (const char *)section_buf; *c; ++c) {
         if (*c == ' ') {
           joutput("_");
         } else if (*c == '-') {
@@ -5990,9 +5992,9 @@ static void joutput_label_variable_name(char *s, int key,
       }
       joutput("__");
     }
-    char buf[COB_SMALL_BUFF];
-    strcpy_identifier_cobol_to_java(buf, s);
-    char *p = buf;
+    char label_buf[COB_SMALL_BUFF];
+    strcpy_identifier_cobol_to_java(label_buf, s);
+    char *p = label_buf;
     while (*p) {
       if (*p < 0x80) {
         if (*p == '-') {
@@ -6009,7 +6011,7 @@ static void joutput_label_variable_name(char *s, int key,
         }
       }
     }
-    joutput("%s", buf);
+    joutput("%s", label_buf);
   } else {
     joutput("anonymous__%d", key);
   }

--- a/tests/cobol_utf8.src/user-defined-word.at
+++ b/tests/cobol_utf8.src/user-defined-word.at
@@ -149,6 +149,24 @@ prog.cob:9: Error: User defined name must be less than 32 characters
 
 AT_CLEANUP
 
+AT_SETUP([Section and Paragraph name])
+export LC_ALL=''
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+       Ｓ－初期化       SECTION.
+       Ｐ－初期化.
+           DISPLAY "Hello, " WITH NO ADVANCING.
+           STOP RUN.
+])
+AT_CHECK([${COMPILE} prog.cob])
+AT_CHECK([java prog], [0], [Hello, ])
+AT_CLEANUP
+
 AT_SETUP([Nihongo Filename])
 export LC_ALL=''
 

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -142,6 +142,22 @@ prog.cob:9: Error: User defined name must be less than 32 characters
 
 AT_CLEANUP
 
+AT_SETUP([Section and Paragraph name])
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+       ÇrÅ|èâä˙âª       SECTION.
+       ÇoÅ|èâä˙âª.
+           DISPLAY "Hello, " WITH NO ADVANCING.
+           STOP RUN.
+])
+AT_CHECK([${COMPILE} prog.cob])
+AT_CHECK([java prog], [0], [Hello, ])
+AT_CLEANUP
+
 AT_SETUP([Nihongo Filename])
 
 AT_DATA([prog.cob], [


### PR DESCRIPTION
# Summary

* By design, full-width hyphens (`ー`) in SECTION names are converted to full-width underscores (`＿`) when outputting to Java code. However, this conversion failed under specific conditions. This pull request fixes that issue.
* Added new tests for SECTION names containing full-width hyphens (`ー`).

**Pattern where full-width hyphen (`ー`) conversion fails:**
When a paragraph is defined within a SECTION whose name contains a full-width hyphen (`ー`), the variable representing the paragraph name in the generated Java code incorrectly retains the full-width hyphen (`ー`) without converting it.

```cobol
       Ｓ－初期化       SECTION.
       サンプルパラグラフ.

```

```java
  /* Sections and Labels */
  private final static int l_Ｓ＿初期化 = 4;
  private final static int l_Ｓー初期化__サンプルパラグラフ = 5;

```

# Changes

* Refactored `joutput_label_variable_name` in `cobj/codegen.c` to use dedicated buffers (`section_buf` and `label_buf`) to convert COBOL SECTION and label names into valid Java identifiers.
* Fixed the call to `strcpy_identifier_cobol_to_java` to ensure hyphens are processed correctly.

# Added Tests

* Added new tests to `tests/cobol_utf8.src/user-defined-word.at` and `tests/i18n_sjis.src/user-defined-word.at`.
* The new tests verify that the conversion to full-width underscores (`＿`) is correctly performed when a paragraph is nested inside a SECTION whose name contains a full-width hyphen (`ー`).

