### PR TITLE
Fix Java code generation bugs in `VALUE ALL` literal initialization

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2213,7 +2213,7 @@ static void joutput_initialize_literal(cb_tree x, struct cb_field *f,
   if (l->size >= f->size) {
     joutput_prefix();
     joutput_data(x);
-    joutput("memcpy (");
+    joutput(".memcpy (");
     joutput_string(l->data, f->size);
     joutput(", %d);\n", f->size);
     return;
@@ -2234,7 +2234,7 @@ static void joutput_initialize_literal(cb_tree x, struct cb_field *f,
   if (n) {
     joutput_prefix();
     joutput_data(x);
-    joutput(".memcpy(i0 * %u, ", (unsigned int)l->size);
+    joutput(".memcpy(%u, ", (unsigned int)(i * l->size));
     joutput_string(l->data, n);
     joutput(", %u);\n", (unsigned int)n);
   }

--- a/tests/run.src/initialize.at
+++ b/tests/run.src/initialize.at
@@ -142,3 +142,51 @@ AT_CHECK([${COMPILE} prog.cob])
 AT_CHECK([java prog], [0], [ 0])
 
 AT_CLEANUP
+
+AT_SETUP([INITIALIZE with VALUE ALL literal])
+
+AT_DATA([prog.cbl], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 WS-SHORT PIC X(3) VALUE ALL "AB".
+       01 WS-EXACT PIC X(4) VALUE ALL "AB".
+       01 WS-LONG  PIC X(5) VALUE ALL "AB".
+       01 WS-GE1   PIC X(3) VALUE ALL "ABCDE".
+       01 WS-GE2   PIC X(5) VALUE ALL "ABCDE".
+       PROCEDURE DIVISION.
+           DISPLAY "@<:@" WS-SHORT "@:>@".
+           DISPLAY "@<:@" WS-EXACT "@:>@".
+           DISPLAY "@<:@" WS-LONG  "@:>@".
+           DISPLAY "@<:@" WS-GE1   "@:>@".
+           DISPLAY "@<:@" WS-GE2   "@:>@".
+           INITIALIZE WS-SHORT.
+           INITIALIZE WS-EXACT.
+           INITIALIZE WS-LONG.
+           INITIALIZE WS-GE1.
+           INITIALIZE WS-GE2.
+           DISPLAY "@<:@" WS-SHORT "@:>@".
+           DISPLAY "@<:@" WS-EXACT "@:>@".
+           DISPLAY "@<:@" WS-LONG  "@:>@".
+           DISPLAY "@<:@" WS-GE1   "@:>@".
+           DISPLAY "@<:@" WS-GE2   "@:>@".
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} prog.cbl], [0], [],
+[prog.cbl:9: Warning: Value size exceeds data size
+])
+AT_CHECK([java prog], [0], [[[ABA]]
+[[ABAB]]
+[[ABABA]]
+[[ABC]]
+[[ABCDE]]
+[[   ]]
+[[    ]]
+[[     ]]
+[[   ]]
+[[     ]]
+])
+
+AT_CLEANUP


### PR DESCRIPTION
Related to https://github.com/opensourcecobol/opensourcecobol4j/issues/785

This pull request makes minor adjustments to the code generation logic in `cobj/codegen.c` related to how the `memcpy` function is invoked in the generated output. The changes focus on correcting the syntax and parameters used for the `.memcpy` calls.

Most important changes:

**Code generation output corrections:**

* Changed the generated function call from `memcpy (` to `.memcpy (` to ensure correct method invocation syntax in the output.
* Fixed the calculation of the offset parameter for `.memcpy` in a loop, replacing `i0 * %u` with `%u` where the value is now explicitly calculated as `(i * l->size)`.