### PR TITLE
Fix C-style code generation for intrinsic function data in CALL statements

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -964,7 +964,7 @@ static void joutput_data(cb_tree x) {
     joutput_param(x, 0);
     break;
   case CB_TAG_INTRINSIC:
-    joutput("module.cob_procedure_parameters[%d]->data", field_iteration);
+    joutput("CobolModule.getCurrentModule().cob_procedure_parameters.get(%d).getDataStorage()", field_iteration);
     break;
   case CB_TAG_CONST:
     if (x == cb_null) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -964,7 +964,9 @@ static void joutput_data(cb_tree x) {
     joutput_param(x, 0);
     break;
   case CB_TAG_INTRINSIC:
-    joutput("CobolModule.getCurrentModule().cob_procedure_parameters.get(%d).getDataStorage()", field_iteration);
+    joutput("CobolModule.getCurrentModule().cob_procedure_parameters.get(%d)."
+            "getDataStorage()",
+            field_iteration);
     break;
   case CB_TAG_CONST:
     if (x == cb_null) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3033,6 +3033,7 @@ static void joutput_call(struct cb_call *p) {
   joutput(" (");
   for (l = p->args, n = 1; l; l = CB_CHAIN(l), n++) {
     x = CB_VALUE(l);
+    field_iteration = (int)n - 1;
     switch (CB_PURPOSE_INT(l)) {
     case CB_CALL_BY_REFERENCE:
       if (CB_NUMERIC_LITERAL_P(x) || CB_BINARY_OP_P(x)) {

--- a/tests/run.src/functions.at
+++ b/tests/run.src/functions.at
@@ -1898,3 +1898,110 @@ AT_CHECK([java prog], [0],
 ])
 
 AT_CLEANUP
+
+AT_SETUP([CALL USING FUNCTION UPPER-CASE])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 X             PIC X(5).
+       PROCEDURE        DIVISION USING X.
+           DISPLAY X
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "hello".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING FUNCTION UPPER-CASE(X)
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[HELLO
+])
+
+AT_CLEANUP
+
+AT_SETUP([CALL USING FUNCTION LENGTH])
+AT_CHECK([${SKIP_TEST}])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LEN            PIC 9(4).
+       PROCEDURE        DIVISION USING LEN.
+           DISPLAY LEN
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "HELLO".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING FUNCTION LENGTH(X)
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[0005
+])
+
+AT_CLEANUP
+
+AT_SETUP([CALL USING FUNCTION MEAN])
+AT_CHECK([${SKIP_TEST}])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 X             PIC 9(3)V9(2).
+       PROCEDURE        DIVISION USING X.
+           DISPLAY X
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM1       PIC 9(3)V9(2) VALUE 10.50.
+       01 WS-NUM2       PIC 9(3)V9(2) VALUE 20.30.
+       01 WS-NUM3       PIC 9(3)V9(2) VALUE 30.20.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               FUNCTION MEAN(WS-NUM1 WS-NUM2 WS-NUM3)
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[020.33
+])
+
+AT_CLEANUP

--- a/tests/run.src/functions.at
+++ b/tests/run.src/functions.at
@@ -1933,6 +1933,53 @@ AT_CHECK([java caller], [0],
 
 AT_CLEANUP
 
+AT_SETUP([CALL USING mixed fields and FUNCTION UPPER-CASE])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 A             PIC X(5).
+       01 B             PIC X(5).
+       01 C             PIC X(5).
+       PROCEDURE        DIVISION USING A B C.
+           DISPLAY A
+           END-DISPLAY.
+           DISPLAY B
+           END-DISPLAY.
+           DISPLAY C
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "hello".
+       01 Y             PIC X(5) VALUE "world".
+       01 Z             PIC X(5) VALUE "cobol".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               Y
+               FUNCTION UPPER-CASE(X)
+               FUNCTION UPPER-CASE(Z)
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[world
+HELLO
+COBOL
+])
+
+AT_CLEANUP
+
 AT_SETUP([CALL USING FUNCTION LENGTH])
 AT_CHECK([${SKIP_TEST}])
 


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/785 に関する修正

# 概要
- `joutput_data()` の `CB_TAG_INTRINSIC` ケースで、C言語スタイルのコード生成（`module.cob_procedure_parameters[%d]->data`）を正しいJavaスタイル（`CobolModule.getCurrentModule().cob_procedure_parameters.get(%d).getDataStorage()`）に変換
- `joutput_call()` の引数出力ループで `field_iteration` が更新されていなかったバグを修正。複数のINTRINSIC引数を持つCALL文で誤ったインデックスが生成される問題を解消
  - `field_iteration` が `setParameters` ループでのみ更新され、後続の引数出力ループでは更新されていなかったため、複数引数のCALL文で常に最後のインデックスが使われる問題があった。

# 変更点
## `cobj/codegen.c`                                                                                                                                            
1. `joutput_data()` の `CB_TAG_INTRINSIC` ケース
  - `module.cob_procedure_parameters[%d]->data` を`CobolModule.getCurrentModule().cob_procedure_parameters.get(%d).getDataStorage()` に変換
2. `joutput_call()` の引数出力ループ
  - `field_iteration = (int)n - 1;` を追加。`joutput_data()` 内の `CB_TAG_INTRINSIC` ケースが正しいインデックスを参照できるようにした。

# テスト
- CALL USING FUNCTION UPPER-CASE — 単一の英数字型INTRINSIC引数
- CALL USING mixed fields and FUNCTION UPPER-CASE — 通常フィールドと複数INTRINSIC引数の混在
- CALL USING FUNCTION LENGTH — 数値型INTRINSIC（スキップ、既存制限）
- CALL USING FUNCTION MEAN — 数値型INTRINSIC（スキップ、既存制限）

> [!WARNING]
数値型INTRINSIC関数（FUNCTION LENGTH, FUNCTION MEANなど）の結果をCALL引数として渡す場合、INTRINSIC関数がCOB_TYPE_NUMERIC_BINARY 形式でデータを格納するのに対し、callee側がCOB_TYPE_NUMERIC_DISPLAY（ASCII数字）として解釈するため、正しく表示されない。これはopensource COBOLでも同様の動作であり、本PRのスコープ外とする。該当テストはスキップすることにした。