### PR TITLE
fix: add set -e to format scripts and fix formatting

### DIFF
--- a/check-format
+++ b/check-format
@@ -1,3 +1,6 @@
 #!/bin/bash
-cd libcobj && ./gradlew spotlessCheck
-cd ../cobj && ./check-format
+set -e
+cd libcobj
+./gradlew spotlessCheck
+cd ../cobj
+./check-format

--- a/format
+++ b/format
@@ -1,3 +1,6 @@
 #!/bin/bash
-cd libcobj && ./gradlew spotlessApply
-cd ../cobj && ./format
+set -e
+cd libcobj
+./gradlew spotlessApply
+cd ../cobj
+./format

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolveTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolveTest.java
@@ -144,70 +144,76 @@ class CobolResolveTest {
 
     @Test
     void testPushAndPopCallStackList() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.pushCallStackList("PROGRAM1");
-            CobolResolve.pushCallStackList("PROGRAM2");
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.pushCallStackList("PROGRAM1");
+                    CobolResolve.pushCallStackList("PROGRAM2");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test
     void testPushCallStackListSameName() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.pushCallStackList("PROGRAM1");
-            CobolResolve.pushCallStackList("PROGRAM1");
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.pushCallStackList("PROGRAM1");
+                    CobolResolve.pushCallStackList("PROGRAM1");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test
     void testPushCallStackListMultipleSiblings() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.pushCallStackList("PROGRAM1");
-            CobolResolve.popCallStackList();
-            CobolResolve.pushCallStackList("PROGRAM2");
-            CobolResolve.popCallStackList();
-            CobolResolve.pushCallStackList("PROGRAM3");
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.pushCallStackList("PROGRAM1");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.pushCallStackList("PROGRAM2");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.pushCallStackList("PROGRAM3");
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test
     void testPushCallStackListDeepNesting() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.pushCallStackList("LEVEL1");
-            CobolResolve.pushCallStackList("LEVEL2");
-            CobolResolve.pushCallStackList("LEVEL3");
-            CobolResolve.pushCallStackList("LEVEL4");
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.pushCallStackList("LEVEL1");
+                    CobolResolve.pushCallStackList("LEVEL2");
+                    CobolResolve.pushCallStackList("LEVEL3");
+                    CobolResolve.pushCallStackList("LEVEL4");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test
     void testPushCallStackListMixedPattern() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.pushCallStackList("MAIN");
-            CobolResolve.pushCallStackList("SUB1");
-            CobolResolve.popCallStackList();
-            CobolResolve.pushCallStackList("SUB2");
-            CobolResolve.pushCallStackList("SUB2A");
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.pushCallStackList("MAIN");
+                    CobolResolve.pushCallStackList("SUB1");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.pushCallStackList("SUB2");
+                    CobolResolve.pushCallStackList("SUB2A");
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test
     void testPopCallStackListOnEmpty() {
-        assertDoesNotThrow(() -> {
-            CobolResolve.popCallStackList();
-            CobolResolve.popCallStackList();
-        });
+        assertDoesNotThrow(
+                () -> {
+                    CobolResolve.popCallStackList();
+                    CobolResolve.popCallStackList();
+                });
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `check-format` と `format` スクリプトに `set -e` を追加し、コマンドを独立行に分割
  - `set -e` がなかったため、`spotlessCheck` が失敗しても後続コマンドの終了コードでスクリプト全体が成功扱いになっていた
- `CobolResolveTest.java` の `spotlessApply` によるフォーマット修正

## Test plan
- [ ] CIの `static-analysis` ジョブが成功することを確認
- [ ] `./check-format` がローカルで正常に動作することを確認
