### PR TITLE
Update Javadoc for libcobj/exceptions

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
@@ -137,7 +137,7 @@ public class CobolExceptionId {
     /** COBOL例外EC-I-O-INVALID-KEYに対応する例外コード。不正なキーによるファイルアクセスの場合に使用される。 */
     public static final int COB_EC_I_O_INVALID_KEY = 38;
 
-    /** COBOL例外EC-I-O-LINAGEに対応する例外コード。LINAGE句に関連するエラーの場合に使用される。 */
+    /** この例外コードは使用されない */
     public static final int COB_EC_I_O_LINAGE = 39;
 
     /** COBOL例外EC-I-O-LOGIC-ERRORに対応する例外コード。ファイル操作の論理エラーの場合に使用される。 */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
@@ -125,7 +125,7 @@ public class CobolExceptionId {
     /** COBOL例外EC-I-O-EOPに対応する例外コード。ページの終端に達した場合に使用される。 */
     public static final int COB_EC_I_O_EOP = 34;
 
-    /** COBOL例外EC-I-O-EOP-OVERFLOWに対応する例外コード。ページの終端を超えた場合に使用される。 */
+    /** この例外コードは使用されない */
     public static final int COB_EC_I_O_EOP_OVERFLOW = 35;
 
     /** COBOL例外EC-I-O-FILE-SHARINGに対応する例外コード。ファイル共有の競合が発生した場合に使用される。 */
@@ -215,7 +215,7 @@ public class CobolExceptionId {
     /** COBOL例外EC-OVERFLOWに対応する例外コード。オーバーフローに関するエラーのカテゴリを示す。 */
     public static final int COB_EC_OVERFLOW = 64;
 
-    /** COBOL例外EC-OVERFLOW-IMPに対応する例外コード。実装固有のオーバーフローエラーを示す。 */
+    /** この例外コードは使用されない */
     public static final int COB_EC_OVERFLOW_IMP = 65;
 
     /** COBOL例外EC-OVERFLOW-STRINGに対応する例外コード。STRING文でポインタが範囲外、またはデータが領域を超えた場合に使用される。 */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
@@ -26,10 +26,10 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_ALL = 1;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-ARGUMENTに対応する例外コード。引数に関するエラーのカテゴリを示す。 */
     public static final int COB_EC_ARGUMENT = 2;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-ARGUMENT-FUNCTIONに対応する例外コード。組み込み関数に不正な引数が渡された場合に使用される。 */
     public static final int COB_EC_ARGUMENT_FUNCTION = 3;
 
     /** この例外コードは使用されない */
@@ -47,16 +47,16 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_BOUND_OVERFLOW = 8;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-BOUND-PTRに対応する例外コード。ポインタの境界違反を示す。 */
     public static final int COB_EC_BOUND_PTR = 9;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-BOUND-REF-MODに対応する例外コード。参照変更のオフセットや長さが範囲外の場合に使用される。 */
     public static final int COB_EC_BOUND_REF_MOD = 10;
 
     /** この例外コードは使用されない */
     public static final int COB_EC_BOUND_SET = 11;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-BOUND-SUBSCRIPTに対応する例外コード。配列の添え字が範囲外の場合に使用される。 */
     public static final int COB_EC_BOUND_SUBSCRIPT = 12;
 
     /** この例外コードは使用されない */
@@ -116,46 +116,46 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_FLOW_USE = 31;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-Oに対応する例外コード。ファイルI/O操作に関するエラーのカテゴリを示す。 */
     public static final int COB_EC_I_O = 32;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-AT-ENDに対応する例外コード。ファイルの終端に達した場合に使用される。 */
     public static final int COB_EC_I_O_AT_END = 33;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-EOPに対応する例外コード。ページの終端に達した場合に使用される。 */
     public static final int COB_EC_I_O_EOP = 34;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-EOP-OVERFLOWに対応する例外コード。ページの終端を超えた場合に使用される。 */
     public static final int COB_EC_I_O_EOP_OVERFLOW = 35;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-FILE-SHARINGに対応する例外コード。ファイル共有の競合が発生した場合に使用される。 */
     public static final int COB_EC_I_O_FILE_SHARING = 36;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-IMPに対応する例外コード。実装固有のI/Oエラーを示す。 */
     public static final int COB_EC_I_O_IMP = 37;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-INVALID-KEYに対応する例外コード。不正なキーによるファイルアクセスの場合に使用される。 */
     public static final int COB_EC_I_O_INVALID_KEY = 38;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-LINAGEに対応する例外コード。LINAGE句に関連するエラーの場合に使用される。 */
     public static final int COB_EC_I_O_LINAGE = 39;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-LOGIC-ERRORに対応する例外コード。ファイル操作の論理エラーの場合に使用される。 */
     public static final int COB_EC_I_O_LOGIC_ERROR = 40;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-PERMANENT-ERRORに対応する例外コード。回復不能なI/Oエラーの場合に使用される。 */
     public static final int COB_EC_I_O_PERMANENT_ERROR = 41;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-I-O-RECORD-OPERATIONに対応する例外コード。レコード操作に関するエラーの場合に使用される。 */
     public static final int COB_EC_I_O_RECORD_OPERATION = 42;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-IMPに対応する例外コード。実装固有のエラーのカテゴリを示す。 */
     public static final int COB_EC_IMP = 43;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-IMP-ACCEPTに対応する例外コード。ACCEPT文で環境変数が見つからない場合などに使用される。 */
     public static final int COB_EC_IMP_ACCEPT = 44;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-IMP-DISPLAYに対応する例外コード。DISPLAY文で環境変数が未設定の場合などに使用される。 */
     public static final int COB_EC_IMP_DISPLAY = 45;
 
     /** この例外コードは使用されない */
@@ -212,16 +212,16 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_ORDER_NOT_SUPPORTED = 63;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-OVERFLOWに対応する例外コード。オーバーフローに関するエラーのカテゴリを示す。 */
     public static final int COB_EC_OVERFLOW = 64;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-OVERFLOW-IMPに対応する例外コード。実装固有のオーバーフローエラーを示す。 */
     public static final int COB_EC_OVERFLOW_IMP = 65;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-OVERFLOW-STRINGに対応する例外コード。STRING文でポインタが範囲外、またはデータが領域を超えた場合に使用される。 */
     public static final int COB_EC_OVERFLOW_STRING = 66;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-OVERFLOW-UNSTRINGに対応する例外コード。UNSTRING文でポインタが範囲外、またはデータが領域を超えた場合に使用される。 */
     public static final int COB_EC_OVERFLOW_UNSTRING = 67;
 
     /** この例外コードは使用されない */
@@ -239,7 +239,7 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_PROGRAM_IMP = 72;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-PROGRAM-NOT-FOUNDに対応する例外コード。CALL文で呼び出し先のプログラムが見つからない場合に使用される。 */
     public static final int COB_EC_PROGRAM_NOT_FOUND = 73;
 
     /** この例外コードは使用されない */
@@ -269,7 +269,7 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_RANGE_INDEX = 82;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-RANGE-INSPECT-SIZEに対応する例外コード。INSPECT文でオペランドのフィールドサイズが不正な場合に使用される。 */
     public static final int COB_EC_RANGE_INSPECT_SIZE = 83;
 
     /** この例外コードは使用されない */
@@ -353,7 +353,7 @@ public class CobolExceptionId {
     /** この例外コードは使用されない */
     public static final int COB_EC_SIZE_IMP = 110;
 
-    /** TODO: 準備中 */
+    /** COBOL例外EC-SIZE-OVERFLOWに対応する例外コード。数値演算の結果がフィールドの桁数を超えた場合に使用される。 */
     public static final int COB_EC_SIZE_OVERFLOW = 111;
 
     /** この例外コードは使用されない */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -20,7 +20,11 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** エラーコードを保持する。 */
 public class CobolExceptionInfo {
-    /** 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。 */
+    /**
+     * 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。
+     * CobolRuntimeExceptionとは異なりコンテキスト情報は保持せず、エラーコードのみを管理する。
+     * 主にACCEPT文やDISPLAY文の実装固有エラーの判定に使用される。
+     */
     public static int code = 0;
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -20,13 +20,13 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** エラーコードを保持する。 */
 public class CobolExceptionInfo {
-    /** エラーコード。TODO: 準備中 */
+    /** 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。 */
     public static int code = 0;
 
     /**
-     * エラーコードを設定する。TODO: 準備中
+     * エラーコードを設定する。指定された例外IDに対応するエラーコードをCobolExceptionTabCode.codeテーブルから取得し、codeフィールドに設定する。
      *
-     * @param id TODO: 準備中
+     * @param id CobolExceptionIdで定義された例外ID
      */
     public static void setException(int id) {
         CobolExceptionInfo.code = CobolExceptionTabCode.code[id];

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
@@ -18,8 +18,12 @@
  */
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
-/** エラーコード関連の計算に用いる */
+/**
+ * CobolExceptionIdで定義された例外IDから、COBOL標準の16進数エラーコードへの変換テーブルを保持するクラス。
+ * codeテーブルのインデックスはCobolExceptionIdの定数値に対応し、値はCOBOL標準で規定された16進数のエラーコードである。
+ */
 public class CobolExceptionTabCode {
+    /** CobolExceptionIdの例外IDをインデックスとし、対応する16進数のCOBOLエラーコードを格納する配列 */
     static int[] code = {
         0, 0xFFFF, 0x0100, 0x0101, 0x0102, 0x0200, 0x0201, 0x0202, 0x0203, 0x0204, 0x0205, 0x0206,
         0x0207, 0x0208, 0x0300, 0x0301, 0x0302, 0x0303, 0x0304, 0x0305, 0x0306, 0x0307, 0x0308,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -23,7 +23,12 @@ import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 
 /** 実行時エラーを示す例外。エラー番号とエラーメッセージを保持する */
 public class CobolRuntimeException extends RuntimeException {
-    /** 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。 */
+    /**
+     * 現在のエラーコード。16進数のエラーコードが格納される。
+     * 通常はsetExceptionメソッドによりCobolExceptionTabCode.codeテーブルから設定されるが、
+     * CobolFileやCobolLineSequentialFile等から直接代入される場合もある。
+     * 主にファイルI/O操作や数値演算のエラー判定に使用される。
+     */
     public static int code;
 
     private static int cobException = 0;
@@ -104,9 +109,9 @@ public class CobolRuntimeException extends RuntimeException {
     }
 
     /**
-     * 例外が設定されているかどうかを返す。
+     * 例外が設定されたことがあるかどうかを返す。 setExceptionが一度でも呼ばれると1を返し、以降0に戻ることはない。
      *
-     * @return 例外が設定されている場合は1、未設定の場合は0
+     * @return setExceptionが呼ばれたことがある場合は1、一度も呼ばれていない場合は0
      */
     public static int getException() {
         return cobException;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -23,7 +23,7 @@ import jp.osscons.opensourcecobol.libcobj.common.CobolUtil;
 
 /** 実行時エラーを示す例外。エラー番号とエラーメッセージを保持する */
 public class CobolRuntimeException extends RuntimeException {
-    /** TODO: 準備中 */
+    /** 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。 */
     public static int code;
 
     private static int cobException = 0;
@@ -69,7 +69,7 @@ public class CobolRuntimeException extends RuntimeException {
     }
 
     /**
-     * 実行時例外を設定する。 エラーIDをベースに、CobolExceptioTabCode.codeテーブルを参照して、対応するエラーコードが設定される。
+     * 実行時例外を設定する。 エラーIDをベースに、CobolExceptionTabCode.codeテーブルを参照して、対応するエラーコードが設定される。
      * また、エラー発生時のプログラムID、セクション名、パラグラフ名、行番号、ステートメントを取得し、このクラスの静的変数に保持する。
      *
      * @param id エラーID
@@ -104,9 +104,9 @@ public class CobolRuntimeException extends RuntimeException {
     }
 
     /**
-     * 常に0を返す。TODO: 必要に応じてこのメソッドは削除ないし修正する。
+     * 例外が設定されているかどうかを返す。
      *
-     * @return 0
+     * @return 例外が設定されている場合は1、未設定の場合は0
      */
     public static int getException() {
         return cobException;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -110,6 +110,7 @@ public class CobolRuntimeException extends RuntimeException {
 
     /**
      * 例外が設定されたことがあるかどうかを返す。 setExceptionが一度でも呼ばれると1を返し、以降0に戻ることはない。
+     * setException(0)を呼ぶとcodeは0にリセットされるが、cobExceptionは1のまま変わらない。
      *
      * @return setExceptionが呼ばれたことがある場合は1、一度も呼ばれていない場合は0
      */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolStopRunException.java
@@ -58,7 +58,7 @@ public final class CobolStopRunException extends Exception {
      * CobolStopRunExceptionを例外としてスローする。 COBOLプログラム終了時のデフォルトの終了処理は実行されない。
      *
      * @param returnCode STOP RUNの返り値
-     * @throws CobolStopRunException TODO: 準備中
+     * @throws CobolStopRunException 常にスローされる
      */
     public static void throwException(int returnCode) throws CobolStopRunException {
         throw new CobolStopRunException(returnCode);
@@ -68,7 +68,7 @@ public final class CobolStopRunException extends Exception {
      * CobolStopRunExceptionを例外としてスローする。 COBOLプログラム終了時のデフォルトの終了処理は実行されない。
      *
      * @param storage STOP RUNの返り値
-     * @throws CobolStopRunException TODO: 準備中
+     * @throws CobolStopRunException 常にスローされる
      */
     public static void throwException(CobolDataStorage storage) throws CobolStopRunException {
         throw new CobolStopRunException(storage);


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/787 に関する修正

# 概要                                                                                                                                                                                                                      
                                                                                                                                                                                                                               
`libcobj/exceptions` パッケージのJavadocを整備する。TODOプレースホルダー（`TODO: 準備中`）を、コードの実際の動作に基づいた説明に置き換える。                                                                                                                                     

# 変更点
## CobolExceptionId.java
- 使用されている例外コード定数に、対応するCOBOL標準の例外名と用途の説明を追加
- 使用されていない例外コード定数（`COB_EC_I_O_EOP_OVERFLOW`、`COB_EC_OVERFLOW_IMP`）を「この例外コードは使用されない」に統一

## CobolExceptionInfo.java
- `code` フィールドおよび `setException` メソッドのJavadocを追加

## CobolExceptionTabCode.java
- クラスレベルのJavadocを拡充し、例外IDから16進数エラーコードへの変換テーブルである旨を明記
- `code` 配列にJavadocを追加

## CobolRuntimeException.java
- `code` フィールドのJavadocを追加（`setException` 経由の設定だけでなく、`CobolFile` 等からの直接代入もある旨を記載）
- `setException` メソッドのJavadocのタイポを修正（`CobolExceptioTabCode` → `CobolExceptionTabCode`）
- `getException` メソッドの誤ったJavadoc（「常に0を返す」）を、実際の動作に基づく記述に修正

## CobolStopRunException.java
- `@throws CobolStopRunException` の説明を「常にスローされる」に更新