### PR TITLE
Fix typo in method name

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -2138,12 +2138,12 @@ public class CobolIntrinsic {
             return currField;
         }
         if (CobolRuntimeException.getOrigSection() != null
-                && CobolRuntimeException.getOrigParagragh() != null) {
+                && CobolRuntimeException.getOrigParagraph() != null) {
             buff =
                     String.format(
                             "%s; %s OF %s; %d",
                             CobolRuntimeException.getOrigProgramId(),
-                            CobolRuntimeException.getOrigParagragh(),
+                            CobolRuntimeException.getOrigParagraph(),
                             CobolRuntimeException.getOrigSection(),
                             CobolRuntimeException.getOrigLine());
         } else if (CobolRuntimeException.getOrigSection() != null) {
@@ -2153,12 +2153,12 @@ public class CobolIntrinsic {
                             CobolRuntimeException.getOrigProgramId(),
                             CobolRuntimeException.getOrigSection(),
                             CobolRuntimeException.getOrigLine());
-        } else if (CobolRuntimeException.getOrigParagragh() != null) {
+        } else if (CobolRuntimeException.getOrigParagraph() != null) {
             buff =
                     String.format(
                             "%s; %s; %d",
                             CobolRuntimeException.getOrigProgramId(),
-                            CobolRuntimeException.getOrigParagragh(),
+                            CobolRuntimeException.getOrigParagraph(),
                             CobolRuntimeException.getOrigLine());
         } else {
             buff =

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolRuntimeException.java
@@ -135,7 +135,7 @@ public class CobolRuntimeException extends RuntimeException {
      *
      * @return エラー発生時のパラグラフ名
      */
-    public static String getOrigParagragh() {
+    public static String getOrigParagraph() {
         return origParagraph;
     }
 


### PR DESCRIPTION
# 概要                                                                                                                                                                                                                       
メソッド名のタイポを修正した。`getOrigParagragh` を正しいスペル `getOrigParagraph` に変更した。                                                                                                                    
                                                                                                                                                                                                                               
# 変更点                                                                                                                                                                                                                     
- メソッド名 `getOrigParagragh` を `getOrigParagraph` に修正                                                                                                                                                                 
- 上記メソッドの呼び出し箇所を修正 