### PR TITLE
doc: add batch compilation tip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ Run.
 java [PROGRAM-ID]
 ```
 
+> **Tip:** When compiling multiple COBOL source files, pass all files to a single `cobj` invocation instead of invoking `cobj` separately for each file. This can significantly reduce the total compilation time.
+>
+> ```bash
+> # Recommended: compile all files at once
+> cobj file1.cbl file2.cbl file3.cbl
+>
+> # You can also use wildcards
+> cobj *.cbl
+>
+> # Not recommended: compile each file separately
+> cobj file1.cbl
+> cobj file2.cbl
+> cobj file3.cbl
+> ```
+
 ## Documentation
 
 * [The API reference of the runtime library `libcobj.jar`](https://opensourcecobol.github.io/opensourcecobol4j/javadoc/libcobj/index.html)

--- a/README_JP.md
+++ b/README_JP.md
@@ -155,6 +155,21 @@ cobj [COBOL source file]
 java [PROGRAM-ID]
 ```
 
+> **Tip:** 複数のCOBOLソースファイルをコンパイルする場合は、`cobj`をファイルごとに個別に呼び出すのではなく、すべてのファイルを一度の`cobj`呼び出しに渡すことを推奨します。これにより、合計のコンパイル時間を大幅に短縮できます。
+>
+> ```bash
+> # 推奨: すべてのファイルを一度にコンパイル
+> cobj file1.cbl file2.cbl file3.cbl
+>
+> # ワイルドカードも使用可能
+> cobj *.cbl
+>
+> # 非推奨: ファイルごとに個別にコンパイル
+> cobj file1.cbl
+> cobj file2.cbl
+> cobj file3.cbl
+> ```
+
 ## ドキュメント
 
 * [ランタイムライブラリ`libcobj.jar`のAPIリファレンス](https://opensourcecobol.github.io/opensourcecobol4j/javadoc/libcobj/index.html)


### PR DESCRIPTION
## Summary
- Added a batch compilation tip to the Usage section of README.md and README_JP.md
- Explains that passing multiple files to a single `cobj` invocation can significantly reduce total compilation time
- Added a wildcard usage example (`cobj *.cbl`)