### PR TITLE
Fix Java code generation for `CALL` with `ADDRESS OF` arguments

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2849,12 +2849,14 @@ static void joutput_call(struct cb_call *p) {
         joutput_line("CobolDataStorage content_%d = new CobolDataStorage(8);",
                      (int)n);
       } else if (CB_CAST_P(x)) {
-        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);", (int)n);
+        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);",
+                     (int)n);
       }
       break;
     case CB_CALL_BY_CONTENT:
       if (CB_CAST_P(x)) {
-        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);", (int)n);
+        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);",
+                     (int)n);
       } else if (CB_TREE_TAG(x) != CB_TAG_INTRINSIC && x != cb_null &&
                  !(CB_CAST_P(x))) {
         joutput_prefix();

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2954,8 +2954,11 @@ static void joutput_call(struct cb_call *p) {
         break;
       }
       break;
-    default:
+    case CB_TAG_CAST:
       joutput("(AbstractCobolField) null");
+      break;
+    default:
+      joutput("null");
       break;
     }
     if (CB_CHAIN(l)) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -2849,12 +2849,12 @@ static void joutput_call(struct cb_call *p) {
         joutput_line("CobolDataStorage content_%d = new CobolDataStorage(8);",
                      (int)n);
       } else if (CB_CAST_P(x)) {
-        joutput_line("void *ptr_%d;", (int)n);
+        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);", (int)n);
       }
       break;
     case CB_CALL_BY_CONTENT:
       if (CB_CAST_P(x)) {
-        joutput_line("void *ptr_%d;", (int)n);
+        joutput_line("CobolDataStorage ptr_%d = new CobolDataStorage(8);", (int)n);
       } else if (CB_TREE_TAG(x) != CB_TAG_INTRINSIC && x != cb_null &&
                  !(CB_CAST_P(x))) {
         joutput_prefix();
@@ -2890,17 +2890,17 @@ static void joutput_call(struct cb_call *p) {
         joutput("L);\n");
       } else if (CB_CAST_P(x)) {
         joutput_prefix();
-        joutput("ptr_%d = ", (int)n);
+        joutput("ptr_%d.set(", (int)n);
         joutput_integer(x);
-        joutput(";\n");
+        joutput(");\n");
       }
       break;
     case CB_CALL_BY_CONTENT:
       if (CB_CAST_P(x)) {
         joutput_prefix();
-        joutput("ptr_%d = ", (int)n);
+        joutput("ptr_%d.set(", (int)n);
         joutput_integer(x);
-        joutput(";\n");
+        joutput(");\n");
       } else if (CB_TREE_TAG(x) != CB_TAG_INTRINSIC) {
         if (CB_NUMERIC_LITERAL_P(x)) {
           joutput_prefix();
@@ -2953,7 +2953,7 @@ static void joutput_call(struct cb_call *p) {
       }
       break;
     default:
-      joutput("null");
+      joutput("(AbstractCobolField) null");
       break;
     }
     if (CB_CHAIN(l)) {
@@ -3061,7 +3061,7 @@ static void joutput_call(struct cb_call *p) {
       } else if (CB_REFERENCE_P(x) && CB_FILE_P(cb_ref(x))) {
         joutput_param(cb_ref(x), -1);
       } else if (CB_CAST_P(x)) {
-        joutput("&ptr_%d", (int)n);
+        joutput("ptr_%d", (int)n);
       } else {
         int tmp_param_wrap_string_flag = param_wrap_string_flag;
         param_wrap_string_flag = 1;
@@ -3072,7 +3072,7 @@ static void joutput_call(struct cb_call *p) {
     case CB_CALL_BY_CONTENT:
       if (CB_TREE_TAG(x) != CB_TAG_INTRINSIC && x != cb_null) {
         if (CB_CAST_P(x)) {
-          joutput("&ptr_%d", (int)n);
+          joutput("ptr_%d", (int)n);
         } else {
           joutput("content_%d", (int)n);
         }

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -825,14 +825,34 @@ static int is_call_parameter(const struct cb_field *f) {
   return 0;
 }
 
+static int is_dangling_linkage(const struct cb_field *f) {
+  struct cb_field *lf;
+  cb_tree p;
+  for (lf = current_prog->linkage_storage; lf; lf = lf->sister) {
+    if (f == lf) {
+      for (p = current_prog->parameter_list; p; p = CB_CHAIN(p)) {
+        if (f == cb_field(CB_VALUE(p))) {
+          return 0;
+        }
+      }
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int is_runtime_resolved_parent(const struct cb_field *f) {
+  return is_call_parameter(f) || is_dangling_linkage(f);
+}
+
 static int joutput_field_storage(struct cb_field *f, struct cb_field *top) {
-  int flag_call_parameter = is_call_parameter(top);
-  if (flag_call_parameter ||
+  int flag_runtime_resolved = is_runtime_resolved_parent(top);
+  if (flag_runtime_resolved ||
       (f->offset == 0 && strcmp(f->name, top->name) == 0)) {
     char *base_name = get_java_identifier_base(top);
     joutput(base_name);
     free(base_name);
-    return flag_call_parameter;
+    return flag_runtime_resolved;
   } else {
     char *base_name = get_java_identifier_base(f);
     joutput(base_name);
@@ -5354,7 +5374,7 @@ static void joutput_init_method(struct cb_program *prog) {
     int i;
     for (i = 0; i < data_storage_cache_count; ++i) {
       struct data_storage_list *entry = sorted_data_storage_cache[i];
-      if (is_call_parameter(entry->top) && entry->f != entry->top) {
+      if (is_runtime_resolved_parent(entry->top) && entry->f != entry->top) {
         continue;
       }
       joutput_prefix();
@@ -5839,7 +5859,7 @@ static void joutput_declare_member_variables(struct cb_program *prog,
 
     for (i = 0; i < data_storage_cache_count; ++i) {
       struct data_storage_list *entry = sorted_data_storage_cache[i];
-      if (is_call_parameter(entry->top) && entry->f != entry->top) {
+      if (is_runtime_resolved_parent(entry->top) && entry->f != entry->top) {
         continue;
       }
       joutput_prefix();

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -853,6 +853,62 @@ AT_CHECK([java caller], [0],
 AT_CLEANUP
 
 
+AT_SETUP([CALL with mixed BY REFERENCE and BY CONTENT ADDRESS OF])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR-1         USAGE POINTER.
+       01 PTR-2         USAGE POINTER.
+       01 Y1            PIC X(5).
+       01 Y2            PIC X(3).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR-1, PTR-2.
+           SET ADDRESS OF Y1 TO PTR-1.
+           SET ADDRESS OF Y2 TO PTR-2.
+           DISPLAY Y1
+           END-DISPLAY.
+           DISPLAY Y2
+           END-DISPLAY.
+           SET PTR-2 TO ADDRESS OF Y1.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X1            PIC X(5) VALUE "HELLO".
+       01 X2            PIC X(3) VALUE "ABC".
+       01 PTR-BAK       USAGE POINTER VALUE NULL.
+       LINKAGE          SECTION.
+       01 Y             PIC X(3).
+       PROCEDURE        DIVISION.
+           SET PTR-BAK TO ADDRESS OF X2.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X1,
+               BY CONTENT ADDRESS OF X2
+           END-CALL.
+           SET ADDRESS OF Y TO PTR-BAK.
+           DISPLAY Y
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[HELLO
+ABC
+ABC
+])
+
+AT_CLEANUP
+
+
 AT_SETUP([Nested CALL with POINTER])
 
 AT_DATA([sub2.cob], [

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -390,6 +390,469 @@ HELLO
 AT_CLEANUP
 
 
+AT_SETUP([CALL BY REFERENCE ADDRESS OF])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "HELLO".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[HELLO
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY CONTENT ADDRESS OF])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X-SUB         PIC X(5) VALUE "OTHER".
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y
+           END-DISPLAY.
+           SET PTR TO ADDRESS OF X-SUB.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "WORLD".
+       01 PTR-1         USAGE POINTER VALUE NULL.
+       LINKAGE          SECTION.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION.
+           SET PTR-1 TO ADDRESS OF X.
+           CALL "callee" USING
+               BY CONTENT ADDRESS OF X
+           END-CALL.
+           SET ADDRESS OF Y TO PTR-1.
+           DISPLAY Y
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[WORLD
+WORLD
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY CONTENT ADDRESS OF with data modification])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           MOVE "WORLD" TO Y.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "HELLO".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY CONTENT ADDRESS OF X
+           END-CALL.
+           DISPLAY X
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[WORLD
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL with ADDRESS OF and field arguments])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Z             PIC X(3).
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR, Z.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y
+           END-DISPLAY.
+           DISPLAY Z
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "HELLO".
+       01 W             PIC X(3) VALUE "ABC".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X, W
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[HELLO
+ABC
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE ADDRESS OF with data modification])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           MOVE "WORLD" TO Y.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "HELLO".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X
+           END-CALL.
+           DISPLAY X
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[WORLD
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE with multiple ADDRESS OF arguments])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR-1         USAGE POINTER.
+       01 PTR-2         USAGE POINTER.
+       01 Y1            PIC X(5).
+       01 Y2            PIC X(3).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR-1, PTR-2.
+           SET ADDRESS OF Y1 TO PTR-1.
+           SET ADDRESS OF Y2 TO PTR-2.
+           DISPLAY Y1
+           END-DISPLAY.
+           DISPLAY Y2
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X1            PIC X(5) VALUE "FIRST".
+       01 X2            PIC X(3) VALUE "SEC".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X1,
+               ADDRESS OF X2
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[FIRST
+SEC
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE ADDRESS OF with group item])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y.
+         05 Y-1         PIC X(5).
+         05 Y-2         PIC X(3).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y-1
+           END-DISPLAY.
+           DISPLAY Y-2
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 GRP.
+         05 G-1         PIC X(5) VALUE "GROUP".
+         05 G-2         PIC X(3) VALUE "ITM".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF GRP
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[GROUP
+ITM
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE ADDRESS OF with nested CALL])
+
+AT_DATA([sub2.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      sub2.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC X(5).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([sub1.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      sub1.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           CALL "sub2" USING BY REFERENCE PTR
+           END-CALL.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(5) VALUE "CHAIN".
+       PROCEDURE        DIVISION.
+           CALL "sub1" USING
+               BY REFERENCE ADDRESS OF X
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} sub1.cob])
+AT_CHECK([${COMPILE_MODULE} sub2.cob])
+AT_CHECK([java caller], [0],
+[CHAIN
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE ADDRESS OF with multiple dangling linkage fields])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR-1         USAGE POINTER.
+       01 PTR-2         USAGE POINTER.
+       01 REC-1.
+         05 R1-F1       PIC X(3).
+         05 R1-F2       PIC 9(4).
+       01 REC-2.
+         05 R2-F1       PIC X(5).
+         05 R2-F2       PIC X(2).
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR-1, PTR-2.
+           SET ADDRESS OF REC-1 TO PTR-1.
+           SET ADDRESS OF REC-2 TO PTR-2.
+           DISPLAY R1-F1
+           END-DISPLAY.
+           DISPLAY R1-F2
+           END-DISPLAY.
+           DISPLAY R2-F1
+           END-DISPLAY.
+           DISPLAY R2-F2
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 GRP-1.
+         05 G1-F1       PIC X(3) VALUE "ABC".
+         05 G1-F2       PIC 9(4) VALUE 1234.
+       01 GRP-2.
+         05 G2-F1       PIC X(5) VALUE "HELLO".
+         05 G2-F2       PIC X(2) VALUE "XY".
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF GRP-1,
+               ADDRESS OF GRP-2
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[ABC
+1234
+HELLO
+XY
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY REFERENCE ADDRESS OF with numeric item])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PTR           USAGE POINTER.
+       01 Y             PIC 9(8) COMP.
+       PROCEDURE        DIVISION
+           USING BY REFERENCE PTR.
+           SET ADDRESS OF Y TO PTR.
+           DISPLAY Y
+           END-DISPLAY.
+           ADD 1 TO Y.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC 9(8) COMP VALUE 12345.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY REFERENCE ADDRESS OF X
+           END-CALL.
+           DISPLAY X
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[00012345
+00012346
+])
+
+AT_CLEANUP
+
+
 AT_SETUP([Nested CALL with POINTER])
 
 AT_DATA([sub2.cob], [


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/785 に関する修正

# 概要

`CALL` 文で `ADDRESS OF` を引数として渡す際に、生成される Java コードが不正であった問題を修正した。

具体的には、以下のような COBOL コードをコンパイルした際に、正しく動作する Java コードが生成されるようになる。

```cobol
CALL "callee" USING BY REFERENCE ADDRESS OF X
CALL "callee" USING BY CONTENT ADDRESS OF X
```

# 変更点

## 1. `ADDRESS OF` 引数のポインタ変数の型を修正

生成される Java コードで C 言語の型 `void *ptr_N;` が出力されていた問題を修正し、`CobolDataStorage ptr_N = new CobolDataStorage(8);` を出力するようにした。

## 2. ポインタへの値セットの構文を修正

C 風の代入文 `ptr_N = <value>;` が出力されていた問題を修正し、Java のメソッド呼び出し `ptr_N.set(<value>);` を出力するようにした。

## 3. CALL 引数として渡す際の不正なアドレス演算子を除去

C のアドレス演算子 `&ptr_N` が出力されていた問題を修正し、`ptr_N` を出力するようにした。

## 4. `setParameters` における `CB_TAG_CAST` のハンドリングを追加

`ADDRESS OF` は内部的に `CB_TAG_CAST` として表現されるが、`setParameters` の switch 文で処理されていなかったため、default の `"null"` が出力されていた。`(AbstractCobolField) null` を出力するよう修正した。

## 5. 非パラメータ LINKAGE フィールド（dangling linkage）のサポート

呼び出し先で `SET ADDRESS OF Y TO PTR` のように、パラメータリストに含まれない LINKAGE セクションのフィールドにアドレスを設定するパターンに対応した。

- 新関数 `is_dangling_linkage()`: LINKAGE SECTION にあるがパラメータリストにないフィールドを検出する
- 新関数 `is_runtime_resolved_parent()`: `is_call_parameter()` または `is_dangling_linkage()` のいずれかに該当するかを判定する
- メンバ変数宣言 (`joutput_declare_member_variables`) と初期化メソッド (`joutput_init_method`) で、これらのフィールドの子フィールドをスキップする処理を拡張した

# テスト

以下の 11 パターンのテストケースを `tests/run.src/extensions.at` に追加した。

| テストケース名 | 内容 |
|---|---|
| `CALL BY REFERENCE ADDRESS OF` | 基本的な参照渡し |
| `CALL BY CONTENT ADDRESS OF` | 内容渡し |
| `CALL BY CONTENT ADDRESS OF with data modification` | 内容渡しでのデータ変更 |
| `CALL with ADDRESS OF and field arguments` | ADDRESS OF と通常フィールドの混在 |
| `CALL BY REFERENCE ADDRESS OF with data modification` | 参照渡しでのデータ変更 |
| `CALL BY REFERENCE with multiple ADDRESS OF arguments` | 複数の ADDRESS OF 引数 |
| `CALL BY REFERENCE ADDRESS OF with group item` | グループ項目 |
| `CALL BY REFERENCE ADDRESS OF with nested CALL` | ネストした CALL |
| `CALL BY REFERENCE ADDRESS OF with multiple dangling linkage fields` | 複数の非パラメータ LINKAGE フィールド |
| `CALL BY REFERENCE ADDRESS OF with numeric item` | 数値項目 |
| `CALL with mixed BY REFERENCE and BY CONTENT ADDRESS OF` | BY REFERENCE と BY CONTENT の混在 |

# その他

- 変更対象ファイル: `cobj/codegen.c`, `tests/run.src/extensions.at`
- 本修正は Java コード生成 (`codegen.c`) のみの変更であり、ランタイムライブラリへの変更はない。

