### PR TITLE
Fix Java code generation for `CALL BY VALUE` arguments

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3152,6 +3152,21 @@ static void joutput_call(struct cb_call *p) {
               }
             }
             switch (sizes) {
+            case CB_SIZE_1:
+              joutput("CobolDataStorage.primitiveToDataStorage((byte)(");
+              joutput_integer(x);
+              joutput("))");
+              break;
+            case CB_SIZE_2:
+              joutput("CobolDataStorage.primitiveToDataStorage((short)(");
+              joutput_integer(x);
+              joutput("))");
+              break;
+            case CB_SIZE_4:
+              joutput("CobolDataStorage.primitiveToDataStorage((int)(");
+              joutput_integer(x);
+              joutput("))");
+              break;
             case CB_SIZE_8:
               joutput("CobolDataStorage.primitiveToDataStorage((long)(");
               joutput_integer(x);

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3094,7 +3094,7 @@ static void joutput_call(struct cb_call *p) {
             joutput("CobolDataStorage.primitiveToDataStorage(%d)",
                     cb_get_int(x));
           } else {
-            joutput("CobolDataStroage.primitiveToDataStorage(%d)",
+            joutput("CobolDataStorage.primitiveToDataStorage(%d)",
                     CB_LITERAL(x)->data[0]);
           }
           break;

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3116,11 +3116,6 @@ static void joutput_call(struct cb_call *p) {
           case CB_USAGE_DISPLAY:
             sizes = CB_SIZES_INT(l);
             if (sizes == CB_SIZE_AUTO) {
-              if (f->pic->have_sign) {
-                joutput("(unsigned ");
-              } else {
-                joutput("(");
-              }
               if (f->usage == CB_USAGE_PACKED || f->usage == CB_USAGE_DISPLAY) {
                 sizes = f->pic->digits - f->pic->scale;
               } else {
@@ -3155,33 +3150,19 @@ static void joutput_call(struct cb_call *p) {
                 sizes = CB_SIZE_8;
                 break;
               }
-            } else {
-              if (CB_SIZES_INT_UNSIGNED(l)) {
-                joutput("(unsigned ");
-              } else {
-                joutput("(");
-              }
             }
             switch (sizes) {
-            case CB_SIZE_1:
-              joutput("char");
-              break;
-            case CB_SIZE_2:
-              joutput("short");
-              break;
-            case CB_SIZE_4:
-              joutput("int");
-              break;
             case CB_SIZE_8:
-              joutput("long long");
+              joutput("CobolDataStorage.primitiveToDataStorage((long)(");
+              joutput_integer(x);
+              joutput("))");
               break;
             default:
-              joutput("int");
+              joutput("CobolDataStorage.primitiveToDataStorage((int)(");
+              joutput_integer(x);
+              joutput("))");
               break;
             }
-            joutput(")(");
-            joutput_integer(x);
-            joutput(")");
             break;
           case CB_USAGE_INDEX:
           case CB_USAGE_LENGTH:
@@ -3194,6 +3175,9 @@ static void joutput_call(struct cb_call *p) {
             joutput(")");
             break;
           default:
+            /* FIXME: COMP-1 / COMP-2を使うとここを通ることがある
+             * COMP-1 / COMP-2を実装するときにここも見直す必要がある
+             */
             joutput("*(");
             joutput_data(x);
             joutput(")");

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -155,6 +155,31 @@ public class CobolDataStorage {
      * @param n TODO: 準備中
      * @return TODO: 準備中
      */
+    public static CobolDataStorage primitiveToDataStorage(byte n) {
+        byte[] bytes = new byte[1];
+        bytes[0] = n;
+        return new CobolDataStorage(bytes);
+    }
+
+    /**
+     * TODO: 準備中
+     *
+     * @param n TODO: 準備中
+     * @return TODO: 準備中
+     */
+    public static CobolDataStorage primitiveToDataStorage(short n) {
+        byte[] bytes = new byte[2];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.putShort(n);
+        return new CobolDataStorage(bytes);
+    }
+
+    /**
+     * TODO: 準備中
+     *
+     * @param n TODO: 準備中
+     * @return TODO: 準備中
+     */
     public static CobolDataStorage primitiveToDataStorage(int n) {
         byte[] bytes = new byte[4];
         ByteBuffer buffer = ByteBuffer.wrap(bytes);

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -1708,3 +1708,183 @@ prog.cob:9: Warning: Unreachable statement 'DISPLAY'
 
 AT_CLEANUP
 
+
+AT_SETUP([CALL BY VALUE with BINARY])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(9) BINARY VALUE 1234.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000001234
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE AUTO])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(9) BINARY VALUE 123456789.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE AUTO WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[123456789
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE 8])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(18) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(18) BINARY VALUE 123456789012345678.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE 8 WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[123456789012345678
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE UNSIGNED SIZE])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(4) VALUE 5678.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE UNSIGNED SIZE 4 WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000005678
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE with DISPLAY and PACKED-DECIMAL])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-DISP       PIC 9(9) BINARY.
+       01 LK-PACK       PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-DISP LK-PACK.
+           DISPLAY LK-DISP END-DISPLAY.
+           DISPLAY LK-PACK END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-DISP       PIC 9(4) VALUE 1111.
+       01 WS-PACK       PIC 9(4) PACKED-DECIMAL VALUE 2222.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE WS-DISP
+               BY VALUE WS-PACK
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000001111
+000002222
+])
+
+AT_CLEANUP
+

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -2067,3 +2067,75 @@ AT_CHECK([java caller], [0],
 ])
 
 AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE with literal])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM1       PIC 9(9) BINARY.
+       01 LK-NUM2       PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM1 LK-NUM2.
+           DISPLAY LK-NUM1 END-DISPLAY.
+           DISPLAY LK-NUM2 END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE 12345
+               BY VALUE 67890
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000012345
+000067890
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE with non-numeric literal])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE "A"
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000000065
+])
+
+AT_CLEANUP

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -2029,18 +2029,16 @@ AT_CHECK([java caller], [0],
 AT_CLEANUP
 
 
-AT_SETUP([CALL BY VALUE SIZE 1 and SIZE 2])
+AT_SETUP([CALL BY VALUE SIZE 1])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      callee.
        DATA             DIVISION.
        LINKAGE          SECTION.
-       01 LK-NUM1       PIC 9(9) BINARY.
-       01 LK-NUM2       PIC 9(9) BINARY.
-       PROCEDURE        DIVISION USING LK-NUM1 LK-NUM2.
-           DISPLAY LK-NUM1 END-DISPLAY.
-           DISPLAY LK-NUM2 END-DISPLAY.
+       01 LK-NUM        PIC 9(2) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
            EXIT PROGRAM.
 ])
 
@@ -2049,12 +2047,10 @@ AT_DATA([caller.cob], [
        PROGRAM-ID.      caller.
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
-       01 WS-NUM1       PIC 9(2) BINARY VALUE 12.
-       01 WS-NUM2       PIC 9(4) BINARY VALUE 1234.
+       01 WS-NUM        PIC 9(2) BINARY VALUE 12.
        PROCEDURE        DIVISION.
            CALL "callee" USING
-               BY VALUE SIZE 1 WS-NUM1
-               BY VALUE SIZE 2 WS-NUM2
+               BY VALUE SIZE 1 WS-NUM
            END-CALL.
            STOP RUN.
 ])
@@ -2062,8 +2058,77 @@ AT_DATA([caller.cob], [
 AT_CHECK([${COMPILE} caller.cob])
 AT_CHECK([${COMPILE_MODULE} callee.cob])
 AT_CHECK([java caller], [0],
-[000000012
-000001234
+[12
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE 2])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(4) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(4) BINARY VALUE 1234.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE 2 WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[1234
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE 4])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(9) BINARY VALUE 12345678.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE 4 WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[012345678
 ])
 
 AT_CLEANUP

--- a/tests/run.src/extensions.at
+++ b/tests/run.src/extensions.at
@@ -1888,3 +1888,182 @@ AT_CHECK([java caller], [0],
 
 AT_CLEANUP
 
+
+AT_SETUP([CALL BY VALUE with signed field])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC S9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC S9(9) BINARY VALUE -1234.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[-000001234
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE AUTO with DISPLAY large digits])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(18) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(10) VALUE 1234567890.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE AUTO WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000000001234567890
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE with COMP-5])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(9) COMP-5 VALUE 987654321.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[987654321
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE with COMP-X])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM        PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM.
+           DISPLAY LK-NUM END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM        PIC 9(9) COMP-X VALUE 987654321.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE WS-NUM
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[987654321
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([CALL BY VALUE SIZE 1 and SIZE 2])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      callee.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 LK-NUM1       PIC 9(9) BINARY.
+       01 LK-NUM2       PIC 9(9) BINARY.
+       PROCEDURE        DIVISION USING LK-NUM1 LK-NUM2.
+           DISPLAY LK-NUM1 END-DISPLAY.
+           DISPLAY LK-NUM2 END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      caller.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 WS-NUM1       PIC 9(2) BINARY VALUE 12.
+       01 WS-NUM2       PIC 9(4) BINARY VALUE 1234.
+       PROCEDURE        DIVISION.
+           CALL "callee" USING
+               BY VALUE SIZE 1 WS-NUM1
+               BY VALUE SIZE 2 WS-NUM2
+           END-CALL.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} caller.cob])
+AT_CHECK([${COMPILE_MODULE} callee.cob])
+AT_CHECK([java caller], [0],
+[000000012
+000001234
+])
+
+AT_CLEANUP


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/785 に関する修正

# 概要

`CALL BY VALUE` で数値引数を渡す際のJavaコード生成を修正する。

従来のコード生成では、C言語固有の型キャスト（`unsigned`, `char`, `short`, `long long` など）がそのままJavaコードとして出力されており、不正なJavaコードが生成されていた。
本PRでは、`CobolDataStorage.primitiveToDataStorage()` を使用して数値をバイト列に変換する方式に変更し、正しいJavaコードが生成されるようにした。

# 変更点

## `cobj/codegen.c`

- `CALL BY VALUE` の数値引数に対するJavaコード生成を修正
  - C言語の型キャスト（`(unsigned char)`, `(short)`, `(int)`, `(long long)` など）の出力を削除
  - SIZE 8の場合: `CobolDataStorage.primitiveToDataStorage((long)(...))` を出力
  - それ以外（SIZE 1, 2, 4）の場合: `CobolDataStorage.primitiveToDataStorage((int)(...))` を出力
- `SIZE AUTO` の場合に出力されていた `(unsigned ` のキャスト（C言語構文）を削除
- `default` ブランチ（COMP-1/COMP-2到達時）にFIXMEコメントを追加

# テスト

`tests/run.src/extensions.at` に以下の11テストケースを追加した。

| テストケース | 内容 |
|---|---|
| CALL BY VALUE with BINARY | BINARY項目の基本的なBY VALUE渡し |
| CALL BY VALUE SIZE AUTO | SIZE AUTO指定 |
| CALL BY VALUE SIZE 8 | SIZE 8（8バイト/long）指定 |
| CALL BY VALUE UNSIGNED SIZE | UNSIGNED SIZE 4指定 |
| CALL BY VALUE with DISPLAY and PACKED-DECIMAL | DISPLAY項目とPACKED-DECIMAL項目の混在 |
| CALL BY VALUE with signed field | 符号付き項目（負の値） |
| CALL BY VALUE SIZE AUTO with DISPLAY large digits | SIZE AUTOで桁数が多い場合（8バイトへの昇格） |
| CALL BY VALUE with COMP-5 | COMP-5項目 |
| CALL BY VALUE with COMP-X | COMP-X項目 |
| CALL BY VALUE SIZE 1 and SIZE 2 | SIZE 1とSIZE 2の組み合わせ |
| CALL BY VALUE with literal | リテラル値のBY VALUE渡し |

# その他

- COMP-1/COMP-2（浮動小数点型）使用時の`default`ブランチは、現在COMP-1/COMP-2が未実装のため到達しない。COMP-1/COMP-2の実装時に合わせて対応する予定（FIXMEコメントに記載済み）。
