### PR TITLE
Fix null-termination bug in package_name_to_path causing flaky CI

### DIFF
--- a/cobj/cobj.c
+++ b/cobj/cobj.c
@@ -1839,6 +1839,7 @@ static void package_name_to_path(char *buff, char *package_name) {
       *b_p = *p_p;
     }
   }
+  *b_p = '\0';
 }
 
 static int process_compile_all(void) {


### PR DESCRIPTION
## Summary
- `package_name_to_path()` にヌル終端を追加し、`-java-package` と `-single-jar`
を組み合わせた際にスタック上のゴミデータがパスに混入する問題を修正

## Details                                                                                                                   
`package_name_to_path()` はパッケージ名(例: `com.abc`)をパス(例: `com/abc`)に変換する関数だが、                              
出力バッファにヌル終端(`'\0'`)を書き込んでいなかった

呼び出し元(`process_compile_all`, `process_build_single_jar`)では未初期化のスタックバッファを渡しているため、                
変換後のパスにスタック上の残存データが付加され、不正なシェルコマンドが生成されていた。                                       

**実際のCIエラー例**:
失敗していたのは以下のコマンドの実行
https://github.com/opensourcecobol/opensourcecobol4j/blob/775e2ec13b2b50981fcb990be45123ad5075ad75/tests/command-line-options.src/jar.at#L82

以下はCIのエラー
https://github.com/opensourcecobol/opensourcecobol4j/actions/runs/23729852572/job/69121257341?pr=818#logs

CIでは失敗時にエラーログをアーティファクトとしてダウンロードできるようにしている。
以下にそのエラーログを示す。
```
#                             -*- compilation -*-
35. jar.at:1: testing -jar, -single-jar and -o ...
./jar.at:28: ${COBJ} --help | grep ' [-]jar' > /dev/null
./jar.at:29: ${COBJ} --help | grep '[-]single[-]jar' > /dev/null
./jar.at:31: mkdir tmp
./jar.at:33: cobj -jar prog.cbl sub.cbl
./jar.at:34: java -cp $CLASSPATH:./* prog
./jar.at:39: rm -rf *.jar com tmp/*
./jar.at:40: cobj -java-package=com.abc -jar prog.cbl sub.cbl
./jar.at:41: java -cp $CLASSPATH:./* com.abc.prog
./jar.at:46: rm -rf *.jar com tmp/*
./jar.at:47: cobj -single-jar=hello.jar prog.cbl sub.cbl
./jar.at:48: java -cp $CLASSPATH:./* prog
./jar.at:53: rm -rf *.jar com tmp/*
./jar.at:54: cobj -single-jar=hello.jar -java-package=com.abc prog.cbl sub.cbl
./jar.at:55: java -cp $CLASSPATH:./* com.abc.prog
./jar.at:60: rm -rf *.jar com tmp/*
./jar.at:61: cobj -o tmp -jar prog.cbl sub.cbl
./jar.at:62: java -cp $CLASSPATH:tmp/* prog
./jar.at:67: rm -rf *.jar com tmp/*
./jar.at:68: cobj -o tmp -single-jar=hello.jar prog.cbl sub.cbl
./jar.at:69: java -cp $CLASSPATH:tmp/* prog
./jar.at:74: rm -rf *.jar com tmp/*
./jar.at:75: cobj -o tmp -jar -java-package=com.abc prog.cbl sub.cbl
./jar.at:76: java -cp $CLASSPATH:tmp/* com.abc.prog
./jar.at:81: rm -rf *.jar com tmp/*
./jar.at:82: cobj -o tmp -single-jar=hello.jar -java-package=com.abc prog.cbl sub.cbl
--- /dev/null	2026-03-30 05:50:58.410891413 +0000
+++ /__w/opensourcecobol4j/opensourcecobol4j/tests/command-line-options.dir/at-groups/35/stderr	2026-03-30 05:52:14.972740463 +0000
@@ -0,0 +1 @@
+com/abc-no-mnemonic/*.class : no such file or directory
35. jar.at:1: 35. -jar, -single-jar and -o (jar.at:1): FAILED (jar.at:82)
```

上記のログのうち`com/abc-no-mnemonic/*.class`というメッセージがある。
コマンドラインオプションで`-java-package=com.abc`を指定しているため、-これは本来`com/abc/*.class`となるべきである。
今回のPRは、この不具合の修正を試みるもの。

初期化されていない領域の中身は不定のため、確率的にテストが失敗する(flaky)挙動となっていたと考えられる。