### PR TITLE
ci: add -j option to autotest for parallel execution

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,11 @@ jobs:
         run: |
           tests=("command-line-options" "data-rep" "i18n_sjis" "jp-compat" "run" "syntax" "cobj-idx" "file-lock" "file-lock2" "misc")
           for test in "${tests[@]}"; do
-            ./"$test" -j || true
+            if [ "$test" = "file-lock" ] || [ "$test" = "file-lock2" ] || [ "$test" = "cobj-idx" ]; then
+              ./"$test" || true
+            else
+              ./"$test" -j || true
+            fi
           done
 
       - name: Generate a coverage report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           tests=("command-line-options" "data-rep" "i18n_sjis" "jp-compat" "run" "syntax" "cobj-idx" "file-lock" "file-lock2" "misc")
           for test in "${tests[@]}"; do
-            ./"$test" || true
+            ./"$test" -j || true
           done
 
       - name: Generate a coverage report

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests ${{ inputs.test-name }}
         working-directory: tests/
         run:
-          ./${{ inputs.test-name }}
+          ./${{ inputs.test-name }} -j
       
       - name: Upload log files if tests fail
         if: failure()

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -75,8 +75,12 @@ jobs:
       
       - name: Run tests ${{ inputs.test-name }}
         working-directory: tests/
-        run:
-          ./${{ inputs.test-name }} -j
+        run: |
+          if [ "${{ inputs.test-name }}" = "file-lock" ] || [ "${{ inputs.test-name }}" = "file-lock2" ] || [ "${{ inputs.test-name }}" = "cobj-idx" ]; then
+            ./${{ inputs.test-name }}
+          else
+            ./${{ inputs.test-name }} -j
+          fi
       
       - name: Upload log files if tests fail
         if: failure()


### PR DESCRIPTION
## 概要
- CIワークフロー（`test-other.yml`, `coverage.yml`）のautotestベースのテストスクリプトに `-j` オプションを追加し、テストを並列実行するようにした
- `file-lock`, `file-lock2`, `cobj-idx` は並列実行時に競合が発生するため除外
  - この問題はのちにIssueにする

## ベンチマーク（テストステップの実行時間）

- 変更前: https://github.com/opensourcecobol/opensourcecobol4j/actions/runs/23829552948
- 変更後: https://github.com/yutaro-sakamoto/opensourcecobol4j/actions/runs/24137687244

| テスト | 変更前 (秒) | 変更後 (秒) | 変化 |
|------|-----------|----------|--------|
| syntax | 13 | 10 | -23% |
| data-rep | 22 | 16 | -27% |
| command-line-options | 60 | 52 | -13% |
| misc | 66 | 51 | -23% |
| i18n_sjis | 78 | 62 | -21% |
| jp-compat | 85 | 68 | -20% |
| run | 239 | 209 | -13% |

対象テストの実行時間が平均約20%短縮された。