### PR TITLE
Update Javadoc for libcobj/ui

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
@@ -1,32 +1,36 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/**
+ * CALL文の結果を保持するための基底クラス<br>
+ * サブクラスで保持する型に対応するgetメソッドをオーバーライドする。
+ * 対応しない型のgetメソッドを呼び出した場合は{@link CobolResultSetException}がスローされる。
+ */
 public class CobolCallResult {
     /**
-     * TODO: 準備中
+     * 結果をint型として取得する。
      *
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @return int型の結果値
+     * @throws CobolResultSetException 結果の型がintでない場合
      */
     public int getInt() throws CobolResultSetException {
         throw new CobolResultSetException("The result type is not 'int'");
     }
 
     /**
-     * TODO: 準備中
+     * 結果をdouble型として取得する。
      *
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @return double型の結果値
+     * @throws CobolResultSetException 結果の型がdoubleでない場合
      */
     public double getDouble() throws CobolResultSetException {
         throw new CobolResultSetException("The result type is not 'double'");
     }
 
     /**
-     * TODO: 準備中
+     * 結果をString型として取得する。
      *
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @return String型の結果値
+     * @throws CobolResultSetException 結果の型がStringでない場合
      */
     public String getString() throws CobolResultSetException {
         throw new CobolResultSetException("The result type is not 'String'");

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultDouble.java
@@ -1,19 +1,19 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/** double型のCALL文の結果を保持する{@link CobolCallResult}のサブクラス */
 public class CobolResultDouble extends CobolCallResult {
     private double value;
 
     /**
-     * TODO: 準備中
+     * 指定されたdouble値を保持するCobolResultDoubleを生成する。
      *
-     * @param d TODO: 準備中
+     * @param d 保持するdouble値
      */
     public CobolResultDouble(double d) {
         this.value = d;
     }
 
-    /** TODO: 準備中 */
+    /** {@inheritDoc} */
     @Override
     public double getDouble() throws CobolResultSetException {
         return this.value;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultInt.java
@@ -1,19 +1,19 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/** int型のCALL文の結果を保持する{@link CobolCallResult}のサブクラス */
 public class CobolResultInt extends CobolCallResult {
     private int value;
 
     /**
-     * TODO: 準備中
+     * 指定されたint値を保持するCobolResultIntを生成する。
      *
-     * @param i TODO: 準備中
+     * @param i 保持するint値
      */
     public CobolResultInt(int i) {
         this.value = i;
     }
 
-    /** TODO: 準備中 */
+    /** {@inheritDoc} */
     @Override
     public int getInt() throws CobolResultSetException {
         return this.value;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultSet.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultSet.java
@@ -1,15 +1,19 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/**
+ * CALL文の実行結果をまとめて保持するクラス<br>
+ * リターンコードと複数の{@link CobolCallResult}を保持し、インデックス指定で各結果にアクセスできる。
+ * インデックスは1始まりで指定する。
+ */
 public class CobolResultSet {
     private CobolCallResult results[];
     private int returnCode;
 
     /**
-     * TODO: 準備中
+     * 指定されたリターンコードと結果の配列を持つCobolResultSetを生成する。
      *
-     * @param returnCode TODO: 準備中
-     * @param results TODO: 準備中
+     * @param returnCode CALL文のリターンコード
+     * @param results CALL文の結果の配列
      */
     public CobolResultSet(int returnCode, CobolCallResult... results) {
         this.returnCode = returnCode;
@@ -23,20 +27,20 @@ public class CobolResultSet {
     }
 
     /**
-     * TODO: 準備中
+     * CALL文のリターンコードを取得する。
      *
-     * @return TODO: 準備中
+     * @return リターンコード
      */
     public int getReturnCode() {
         return this.returnCode;
     }
 
     /**
-     * TODO: 準備中
+     * 指定されたインデックスの結果をString型として取得する。
      *
-     * @param index TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @param index 結果のインデックス(1始まり)
+     * @return String型の結果値
+     * @throws CobolResultSetException インデックスが範囲外の場合、または結果の型がStringでない場合
      */
     public String getString(int index) throws CobolResultSetException {
         this.checkIndexInValidRange(index);
@@ -44,11 +48,11 @@ public class CobolResultSet {
     }
 
     /**
-     * TODO: 準備中
+     * 指定されたインデックスの結果をint型として取得する。
      *
-     * @param index TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @param index 結果のインデックス(1始まり)
+     * @return int型の結果値
+     * @throws CobolResultSetException インデックスが範囲外の場合、または結果の型がintでない場合
      */
     public int getInt(int index) throws CobolResultSetException {
         this.checkIndexInValidRange(index);
@@ -56,11 +60,11 @@ public class CobolResultSet {
     }
 
     /**
-     * TODO: 準備中
+     * 指定されたインデックスの結果をdouble型として取得する。
      *
-     * @param index TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolResultSetException TODO: 準備中
+     * @param index 結果のインデックス(1始まり)
+     * @return double型の結果値
+     * @throws CobolResultSetException インデックスが範囲外の場合、または結果の型がdoubleでない場合
      */
     public double getDouble(int index) throws CobolResultSetException {
         this.checkIndexInValidRange(index);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultSetException.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultSetException.java
@@ -1,11 +1,11 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/** {@link CobolResultSet}や{@link CobolCallResult}の操作で不正なアクセスが行われた場合にスローされる例外 */
 public class CobolResultSetException extends Exception {
     /**
-     * TODO: 準備中
+     * 指定されたメッセージを持つCobolResultSetExceptionを生成する。
      *
-     * @param message TODO: 準備中
+     * @param message 例外の詳細メッセージ
      */
     public CobolResultSetException(String message) {
         super(message);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolResultString.java
@@ -1,19 +1,19 @@
 package jp.osscons.opensourcecobol.libcobj.ui;
 
-/** TODO: 準備中 */
+/** String型のCALL文の結果を保持する{@link CobolCallResult}のサブクラス */
 public class CobolResultString extends CobolCallResult {
     private String value;
 
     /**
-     * TODO: 準備中
+     * 指定されたString値を保持するCobolResultStringを生成する。
      *
-     * @param s TODO: 準備中
+     * @param s 保持するString値
      */
     public CobolResultString(String s) {
         this.value = s;
     }
 
-    /** TODO: 準備中 */
+    /** {@inheritDoc} */
     @Override
     public String getString() throws CobolResultSetException {
         return this.value;


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/787 に関する修正

# 概要

`libcobj/ui` パッケージのJavadocを整備した。
`TODO: 準備中` となっていた各クラス・メソッドのJavadocを、実装内容に基づいた具体的な説明に置き換えた。

# 変更点

## CobolCallResult.java
- クラスのJavadocを追加（CALL文の結果を保持する基底クラスであること、サブクラスでのオーバーライドの仕組み、対応しない型へのアクセス時の例外スローについて記載）
- `getInt()`, `getDouble()`, `getString()` の `@return`, `@throws` を具体化

## CobolResultInt.java
- クラスのJavadocを追加（int型の結果を保持するサブクラスである旨を記載）
- コンストラクタの `@param` を具体化
- オーバーライドメソッドに `{@inheritDoc}` を適用

## CobolResultDouble.java
- クラスのJavadocを追加（double型の結果を保持するサブクラスである旨を記載）
- コンストラクタの `@param` を具体化
- オーバーライドメソッドに `{@inheritDoc}` を適用

## CobolResultString.java
- クラスのJavadocを追加（String型の結果を保持するサブクラスである旨を記載）
- コンストラクタの `@param` を具体化
- オーバーライドメソッドに `{@inheritDoc}` を適用

## CobolResultSet.java
- クラスのJavadocを追加（リターンコードと複数の結果を保持し、1始まりのインデックスでアクセスできる旨を記載）
- コンストラクタの `@param` を具体化
- `getReturnCode()` の `@return` を具体化
- `getString(int)`, `getInt(int)`, `getDouble(int)` の `@param`, `@return`, `@throws` を具体化（インデックスの範囲外と型の不一致の両方の例外条件を記載）

## CobolResultSetException.java
- クラスのJavadocを追加（不正なアクセス時にスローされる例外である旨を記載）
- コンストラクタの `@param` を具体化

# その他

- 既存のコードの動作に変更はない。
