### PR TITLE
fix: strip trailing spaces and NULs when setting environment variables from COBOL

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -636,6 +636,9 @@ public class CobolUtil {
      *     bytes are stripped to match libcob's {@code cob_field_to_string} behavior.
      */
     public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {
+        // Name side uses String#trim() to drop both leading and trailing spaces, matching the
+        // behavior documented above. Value side uses fieldToString so only trailing spaces/NULs
+        // are stripped (leading spaces are meaningful in an environment value).
         CobolUtil.envVarTable.setProperty(
                 envVarName.getString().trim(),
                 envVarValue.fieldToString(AbstractCobolField.charSetSJIS));

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -632,10 +632,13 @@ public class CobolUtil {
      *
      * @param envVarName the name of an environment variable. The leading and trailing spaces are
      *     ignored.
-     * @param envVarValue the value of an environment variable to be set.
+     * @param envVarValue the value of an environment variable to be set. Trailing spaces and NUL
+     *     bytes are stripped to match libcob's {@code cob_field_to_string} behavior.
      */
     public static void setEnv(AbstractCobolField envVarName, AbstractCobolField envVarValue) {
-        CobolUtil.envVarTable.setProperty(envVarName.getString().trim(), envVarValue.getString());
+        CobolUtil.envVarTable.setProperty(
+                envVarName.getString().trim(),
+                envVarValue.fieldToString(AbstractCobolField.charSetSJIS));
     }
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/AbstractCobolField.java
@@ -1025,6 +1025,25 @@ public abstract class AbstractCobolField {
     }
 
     /**
+     * 末尾の空白とNULバイトを取り除いたうえで指定されたcharsetでデコードして文字列として返す.
+     * 本家CのopensourceCOBOLにおける{@code cob_field_to_string}と同等の処理を行う.
+     *
+     * @param charset デコードに使用するcharset
+     * @return 末尾の空白/NULを取り除いた文字列
+     */
+    public String fieldToString(Charset charset) {
+        CobolDataStorage data = this.getDataStorage();
+        int end;
+        for (end = this.getSize(); end > 0; --end) {
+            byte b = data.getByte(end - 1);
+            if (b != ' ' && b != 0) {
+                break;
+            }
+        }
+        return new String(data.getByteArray(0, end), charset);
+    }
+
+    /**
      * TODO: 準備中
      *
      * @param n TODO: 準備中

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -259,7 +259,10 @@ public class CobolTerminal {
             CobolExceptionInfo.setException(CobolExceptionId.COB_EC_IMP_DISPLAY);
             return;
         }
-        CobolUtil.setEnv(CobolUtil.cobLocalEnv, f.getString());
+        // Strip trailing spaces and NULs so that PIC X(n) source fields do not
+        // leak padding into the environment variable value. Matches libcob's
+        // cob_field_to_string used by cob_display_env_value.
+        CobolUtil.setEnv(CobolUtil.cobLocalEnv, f.fieldToString(AbstractCobolField.charSetSJIS));
     }
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -252,6 +252,10 @@ public class CobolTerminal {
      * で設定された環境変数名に対して値を設定する. 環境変数名が未設定または空文字列の場合は{@link
      * CobolExceptionId#COB_EC_IMP_DISPLAY}例外を設定する.
      *
+     * <p>COBOL変数{@code f}の値は{@link AbstractCobolField#fieldToString(java.nio.charset.Charset)}
+     * によって末尾の空白とNULバイトが取り除かれてから環境変数値として設定される. これは本家CのopensourceCOBOLが
+     * {@code cob_display_env_value}内で{@code cob_field_to_string}を使用する挙動と一致する.
+     *
      * @param f 設定する環境変数の値を保持するCOBOL変数
      */
     public static void displayEnvValue(AbstractCobolField f) {

--- a/tests/jp-compat.src/special-names.at
+++ b/tests/jp-compat.src/special-names.at
@@ -145,6 +145,42 @@ AT_CHECK([export TESTENV=envvalue && java prog], [0], [envvalue:newvalue])
 
 AT_CLEANUP
 
+AT_SETUP([DISPLAY ENVIRONMENT-VALUE strips trailing spaces])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       ENVIRONMENT      DIVISION.
+       INPUT-OUTPUT     SECTION.
+       FILE-CONTROL.
+           SELECT OUT-FILE ASSIGN OUTPATH
+                  ORGANIZATION IS LINE SEQUENTIAL.
+       DATA             DIVISION.
+       FILE             SECTION.
+       FD OUT-FILE.
+       01 OUT-REC       PIC X(5).
+       WORKING-STORAGE  SECTION.
+       01 WK-PATH       PIC X(32).
+       PROCEDURE        DIVISION.
+           MOVE SPACE         TO WK-PATH.
+           STRING 'hello.txt' DELIMITED BY SIZE
+                  INTO WK-PATH.
+           DISPLAY 'OUTPATH'  UPON ENVIRONMENT-NAME.
+           DISPLAY WK-PATH    UPON ENVIRONMENT-VALUE.
+           OPEN OUTPUT OUT-FILE.
+           MOVE 'HELLO'       TO OUT-REC.
+           WRITE OUT-REC.
+           CLOSE OUT-FILE.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob], [0])
+AT_CHECK([java prog], [0])
+AT_CHECK([test -f hello.txt && cat hello.txt], [0], [HELLO
+])
+
+AT_CLEANUP
+
 AT_SETUP([SPECIAL NAMES unterminated])
 
 AT_DATA([prog.cob], [

--- a/tests/jp-compat.src/special-names.at
+++ b/tests/jp-compat.src/special-names.at
@@ -181,6 +181,41 @@ AT_CHECK([test -f hello.txt && cat hello.txt], [0], [HELLO
 
 AT_CLEANUP
 
+AT_SETUP([SET ENVIRONMENT strips trailing spaces])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       ENVIRONMENT      DIVISION.
+       INPUT-OUTPUT     SECTION.
+       FILE-CONTROL.
+           SELECT OUT-FILE ASSIGN OUTPATH2
+                  ORGANIZATION IS LINE SEQUENTIAL.
+       DATA             DIVISION.
+       FILE             SECTION.
+       FD OUT-FILE.
+       01 OUT-REC       PIC X(5).
+       WORKING-STORAGE  SECTION.
+       01 WK-PATH       PIC X(32).
+       PROCEDURE        DIVISION.
+           MOVE SPACE         TO WK-PATH.
+           STRING 'world.txt' DELIMITED BY SIZE
+                  INTO WK-PATH.
+           SET ENVIRONMENT 'OUTPATH2' TO WK-PATH.
+           OPEN OUTPUT OUT-FILE.
+           MOVE 'WORLD'       TO OUT-REC.
+           WRITE OUT-REC.
+           CLOSE OUT-FILE.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE_JP_COMPAT} prog.cob], [0])
+AT_CHECK([java prog], [0])
+AT_CHECK([test -f world.txt && cat world.txt], [0], [WORLD
+])
+
+AT_CLEANUP
+
 AT_SETUP([SPECIAL NAMES unterminated])
 
 AT_DATA([prog.cob], [


### PR DESCRIPTION
## Summary

Fixes a bug where `DISPLAY ... UPON ENVIRONMENT-VALUE` and `SET ENVIRONMENT x TO y` leaked trailing space padding from the source `PIC X(n)` field into the environment variable value. When such an env var was later resolved as a filename via `SELECT ... ASSIGN`, the file was created with trailing spaces embedded in its name.

The C original (opensource-cobol) feeds these values through `cob_field_to_string`, which strips trailing spaces and NUL bytes before calling `setenv`. The Java port did not match this behavior.

## Changes

- Added `AbstractCobolField#fieldToString(Charset)` — a shared helper that strips trailing spaces/NULs (matching libcob's `cob_field_to_string`) and decodes with an explicit charset.
- `CobolTerminal#displayEnvValue` now uses the new helper with SJIS, so `DISPLAY ... UPON ENVIRONMENT-VALUE` stores a trimmed value.
- `CobolUtil#setEnv(AbstractCobolField, AbstractCobolField)` (invoked by `SET ENVIRONMENT x TO y`) now strips trailing spaces/NULs from the value as well. Javadoc and a code comment explain why the name side uses `String#trim()` while the value side strips only trailing padding.
- Added regression tests in `tests/jp-compat.src/special-names.at` covering both the `DISPLAY ... UPON ENVIRONMENT-VALUE` and `SET ENVIRONMENT` paths via `ASSIGN`-based file open.

## Reproducer

Before this fix, a COBOL program like the following:

~~~cobol
01 WK-PATH PIC X(256).
...
MOVE SPACE TO WK-PATH.
STRING '/tmp/out.txt' DELIMITED BY SIZE INTO WK-PATH.
DISPLAY 'MYPATH' UPON ENVIRONMENT-NAME.
DISPLAY WK-PATH  UPON ENVIRONMENT-VALUE.
~~~

would set the env var `MYPATH` to `/tmp/out.txt` followed by ~244 spaces, so any `SELECT ... ASSIGN MYPATH` file open created a file whose name literally contained those trailing spaces.

## Test plan

- [x] Local reproducer confirmed the bug before the fix and its disappearance after the fix.
- [x] `./gradlew test` passes locally.
- [x] Integration tests green on CI for the fix commit.
- [ ] CI green for the follow-up commit that adds the `SET ENVIRONMENT` regression test and Javadoc clarifications.

---

## 概要 (日本語訳)

`DISPLAY ... UPON ENVIRONMENT-VALUE` および `SET ENVIRONMENT x TO y` において、ソース側の `PIC X(n)` フィールドの末尾空白がそのまま環境変数値に流れ込んでいたバグの修正です。その結果、`SELECT ... ASSIGN` 経由で環境変数をファイル名として解決すると、末尾空白を含んだファイル名でファイルが作成されてしまっていました。

本家C実装の opensource-cobol は `cob_field_to_string` を介して末尾の空白およびNULバイトを削ぎ落としてから `setenv` を呼び出しています。Java版はこの挙動に追従できていませんでした。

## 変更内容

- `AbstractCobolField#fieldToString(Charset)` を新規追加。末尾の空白/NULを削ぎ落として指定charsetでデコードする共通ヘルパーです (libcob の `cob_field_to_string` と同等の挙動)。
- `CobolTerminal#displayEnvValue` を上記ヘルパー (SJIS指定) 経由に変更。`DISPLAY ... UPON ENVIRONMENT-VALUE` は末尾トリム済みの値を格納するようになります。
- `CobolUtil#setEnv(AbstractCobolField, AbstractCobolField)` (`SET ENVIRONMENT x TO y` から呼び出される) でも値側の末尾空白/NULをトリムするように変更。環境変数名側が `String#trim()` (先頭/末尾双方) で値側が末尾のみという非対称性の理由を Javadoc とコード内コメントで明記。
- `tests/jp-compat.src/special-names.at` に、`DISPLAY ... UPON ENVIRONMENT-VALUE` と `SET ENVIRONMENT` の両方のパスについて、`ASSIGN` 経由のファイルオープンで回帰が起きないことを確認する統合テストを追加。

## 再現コード

本修正前は、以下のようなCOBOLプログラム:

~~~cobol
01 WK-PATH PIC X(256).
...
MOVE SPACE TO WK-PATH.
STRING '/tmp/out.txt' DELIMITED BY SIZE INTO WK-PATH.
DISPLAY 'MYPATH' UPON ENVIRONMENT-NAME.
DISPLAY WK-PATH  UPON ENVIRONMENT-VALUE.
~~~

で、環境変数 `MYPATH` の値が `/tmp/out.txt` の後に約244文字の空白が続いた文字列となり、`SELECT ... ASSIGN MYPATH` でのファイルオープンが末尾空白込みのファイル名でファイルを作成していました。

## テスト計画

- [x] ローカル再現コードで修正前にバグが発生し、修正後に解消することを確認
- [x] `./gradlew test` ローカルでPASS
- [x] 修正本体のコミットについて統合テストCIグリーン
- [ ] `SET ENVIRONMENT` 回帰テスト・Javadoc追記のフォローアップコミットについてCIグリーン