### PR TITLE
Update Javadoc for libcobj/common

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
@@ -18,8 +18,12 @@
  */
 package jp.osscons.opensourcecobol.libcobj.common;
 
-/** TODO: 準備中 */
+/**
+ * CALL文で呼び出されたプログラムに渡された引数の個数を保持するクラス<br>
+ * libcobのcob_call_paramsに対応し、USING句で渡された実引数の個数を表す。<br>
+ * 呼び出されたプログラム側でこの値を参照することで、省略された引数の判定などに利用する。
+ */
 public class CobolCallParams {
-    /** TODO: 準備中 */
+    /** CALL文で渡された引数の個数 */
     public static int callParams = 0;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -24,17 +24,22 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * COBOLの実行時境界チェックを行うクラス<br>
+ * 表(OCCURS)の添字や、OCCURS DEPENDING ONの可変回数が範囲内にあるかを検査する。<br>
+ * 範囲外の場合は{@link CobolExceptionId#COB_EC_BOUND_SUBSCRIPT}を設定し、実行時エラーを出力して実行を中止する。
+ */
 public class CobolCheck {
     /**
-     * TODO: 準備中
+     * 表の添字が指定された範囲内にあるかを検査する。<br>
+     * 範囲外の場合は例外を設定し、実行時エラーメッセージを出力して実行を中止する。
      *
-     * @param i TODO: 準備中
-     * @param min TODO: 準備中
-     * @param max TODO: 準備中
-     * @param name TODO: 準備中
-     * @param len TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param i 検査対象の添字の値
+     * @param min 添字の下限値
+     * @param max 添字の上限値
+     * @param name 表として参照しているデータ項目の名前(SJISのバイト列)
+     * @param len データ項目名のバイト数
+     * @throws CobolStopRunException 添字が範囲外で実行が中止された場合
      */
     public static void checkSubscript(int i, int min, int max, byte[] name, int len)
             throws CobolStopRunException {
@@ -49,14 +54,15 @@ public class CobolCheck {
     }
 
     /**
-     * TODO: 準備中
+     * 表の添字が指定された範囲内にあるかを検査する({@code long}型の添字を受け取るオーバーロード)。<br>
+     * 添字をint型に変換した上で{@link #checkSubscript(int, int, int, byte[], int)}に委譲する。
      *
-     * @param i TODO: 準備中
-     * @param min TODO: 準備中
-     * @param max TODO: 準備中
-     * @param name TODO: 準備中
-     * @param len TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param i 検査対象の添字の値
+     * @param min 添字の下限値
+     * @param max 添字の上限値
+     * @param name 表として参照しているデータ項目の名前(SJISのバイト列)
+     * @param len データ項目名のバイト数
+     * @throws CobolStopRunException 添字が範囲外で実行が中止された場合
      */
     public static void checkSubscript(long i, int min, int max, byte[] name, int len)
             throws CobolStopRunException {
@@ -64,14 +70,15 @@ public class CobolCheck {
     }
 
     /**
-     * TODO: 準備中
+     * 表の添字が指定された範囲内にあるかを検査する({@link CobolDataStorage}で名前を受け取るオーバーロード)。<br>
+     * データ項目名をバイト列として取り出した上で{@link #checkSubscript(int, int, int, byte[], int)}に委譲する。
      *
-     * @param i TODO: 準備中
-     * @param min TODO: 準備中
-     * @param max TODO: 準備中
-     * @param name TODO: 準備中
-     * @param len TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param i 検査対象の添字の値
+     * @param min 添字の下限値
+     * @param max 添字の上限値
+     * @param name 表として参照しているデータ項目の名前を保持する記憶領域
+     * @param len データ項目名のバイト数
+     * @throws CobolStopRunException 添字が範囲外で実行が中止された場合
      */
     public static void checkSubscript(long i, int min, int max, CobolDataStorage name, int len)
             throws CobolStopRunException {
@@ -79,13 +86,14 @@ public class CobolCheck {
     }
 
     /**
-     * TODO: 準備中
+     * OCCURS DEPENDING ONの可変回数が指定された範囲内にあるかを検査する。<br>
+     * 範囲外の場合は例外を設定し、実行時エラーメッセージを出力して実行を中止する。
      *
-     * @param i TODO: 準備中
-     * @param min TODO: 準備中
-     * @param max TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param i 検査対象の可変回数の値
+     * @param min 可変回数の下限値
+     * @param max 可変回数の上限値
+     * @param name OCCURS DEPENDING ONの対象となるデータ項目の名前
+     * @throws CobolStopRunException 可変回数が範囲外で実行が中止された場合
      */
     public static void checkOdo(int i, int min, int max, String name) throws CobolStopRunException {
         if (i < min || max < i) {
@@ -97,13 +105,14 @@ public class CobolCheck {
     }
 
     /**
-     * TODO: 準備中
+     * OCCURS DEPENDING ONの可変回数が指定された範囲内にあるかを検査する(名前をバイト列で受け取るオーバーロード)。<br>
+     * データ項目名をSJISの文字列に変換した上で{@link #checkOdo(int, int, int, String)}に委譲する。
      *
-     * @param i TODO: 準備中
-     * @param min TODO: 準備中
-     * @param max TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param i 検査対象の可変回数の値
+     * @param min 可変回数の下限値
+     * @param max 可変回数の上限値
+     * @param name OCCURS DEPENDING ONの対象となるデータ項目の名前(SJISのバイト列)
+     * @throws CobolStopRunException 可変回数が範囲外で実行が中止された場合
      */
     public static void checkOdo(int i, int min, int max, byte[] name) throws CobolStopRunException {
         CobolCheck.checkOdo(i, min, max, new String(name, AbstractCobolField.charSetSJIS));

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
@@ -23,90 +23,94 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
 
-/** TODO: 準備中 */
+/**
+ * COBOLの定数値(figurative constant)および実行時に用いる各種定数を保持するクラス<br>
+ * ZERO・SPACE・HIGH-VALUE・LOW-VALUE・QUOTEなどの形象定数や、それらの全角(ZEN)版、
+ * 各種バッファサイズ、10のべき乗表などをまとめて定義する。
+ */
 public class CobolConstant {
-    /** TODO: 準備中 */
+    /** 英数字のALL定数(SPACE・ZEROなどの形象定数)に用いる属性 */
     public static final CobolFieldAttribute allAttr =
             new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL, 0, 0, 0, null);
 
-    /** TODO: 準備中 */
+    /** 数字定数1に用いる属性(1桁の数字項目) */
     public static final CobolFieldAttribute oneAttr =
             new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_NUMERIC, 1, 0, 0, null);
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角ゼロ「０」のバイト列 */
     public static final byte[] SJZERO = {(byte) 0x82, (byte) 0x4f};
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角空白「　」のバイト列 */
     public static final byte[] SJSPC = {(byte) 0x81, (byte) 0x40};
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角空白(BLANK)のバイト列 */
     public static final byte[] SJBLK = {(byte) 0x81, (byte) 0x40};
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角引用符「”」のバイト列 */
     public static final byte[] SJQUOT = {(byte) 0x81, (byte) 0x68};
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角スラッシュ「／」のバイト列 */
     public static final byte[] SJSLAS = {(byte) 0x81, (byte) 0x5e};
 
-    /** TODO: 準備中 */
+    /** Shift_JISの全角文字1文字あたりのバイト数 */
     public static final int SJCSIZ = 2;
 
-    /** TODO: 準備中 */
+    /** 全角ゼロのバイト列({@link #SJZERO}の別名) */
     public static final byte[] ZENZERO = SJZERO;
 
-    /** TODO: 準備中 */
+    /** 全角空白のバイト列({@link #SJSPC}の別名) */
     public static final byte[] ZENSPC = SJSPC;
 
-    /** TODO: 準備中 */
+    /** 全角空白(BLANK)のバイト列({@link #SJBLK}の別名) */
     public static final byte[] ZENBLK = SJBLK;
 
-    /** TODO: 準備中 */
+    /** 全角引用符のバイト列({@link #SJQUOT}の別名) */
     public static final byte[] ZENQUOT = SJQUOT;
 
-    /** TODO: 準備中 */
+    /** 全角スラッシュのバイト列({@link #SJSLAS}の別名) */
     public static final byte[] ZENSLAS = SJSLAS;
 
-    /** TODO: 準備中 */
+    /** 全角文字1文字あたりのバイト数({@link #SJCSIZ}の別名) */
     public static final int ZENCSIZ = SJCSIZ;
 
-    /** TODO: 準備中 */
+    /** 形象定数ZEROを表すフィールド */
     public static final AbstractCobolField zero = CobolFieldFactory.makeCobolField(1, "0", allAttr);
 
-    /** TODO: 準備中 */
+    /** 形象定数SPACEを表すフィールド */
     public static final AbstractCobolField space =
             CobolFieldFactory.makeCobolField(1, " ", allAttr);
 
-    /** TODO: 準備中 */
+    /** 形象定数BLANKを表すフィールド */
     public static final AbstractCobolField blank =
             CobolFieldFactory.makeCobolField(1, " ", allAttr);
 
-    /** TODO: 準備中 */
+    /** 形象定数HIGH-VALUE(0xFF)を表すフィールド */
     public static final AbstractCobolField high =
             CobolFieldFactory.makeCobolField(1, CobolConstant.get0xFFStorage(), allAttr);
 
-    /** TODO: 準備中 */
+    /** 形象定数LOW-VALUE(0x00)を表すフィールド */
     public static final AbstractCobolField low = CobolFieldFactory.makeCobolField(1, "\0", allAttr);
 
-    /** TODO: 準備中 */
+    /** 形象定数QUOTEを表すフィールド */
     public static final AbstractCobolField quote =
             CobolFieldFactory.makeCobolField(1, "\"", allAttr);
 
-    /** TODO: 準備中 */
+    /** 数字定数1を表すフィールド */
     public static final AbstractCobolField one = CobolFieldFactory.makeCobolField(1, "1", oneAttr);
 
-    /** TODO: 準備中 */
+    /** 全角の形象定数ZEROを表すフィールド */
     public static final AbstractCobolField zenZero =
             CobolFieldFactory.makeCobolField(ZENCSIZ, new CobolDataStorage(ZENZERO), allAttr);
 
-    /** TODO: 準備中 */
+    /** 全角の形象定数SPACEを表すフィールド */
     public static final AbstractCobolField zenSpace =
             CobolFieldFactory.makeCobolField(ZENCSIZ, new CobolDataStorage(ZENSPC), allAttr);
 
-    /** TODO: 準備中 */
+    /** 全角の形象定数BLANKを表すフィールド */
     public static final AbstractCobolField zenBlank =
             CobolFieldFactory.makeCobolField(ZENCSIZ, new CobolDataStorage(ZENBLK), allAttr);
 
-    /** TODO: 準備中 */
+    /** 全角の形象定数QUOTEを表すフィールド */
     public static final AbstractCobolField zenQuote =
             CobolFieldFactory.makeCobolField(ZENCSIZ, new CobolDataStorage(ZENQUOT), allAttr);
 
@@ -116,7 +120,7 @@ public class CobolConstant {
         return new CobolDataStorage(bytes);
     }
 
-    /** TODO: 準備中 */
+    /** 10のべき乗の表(添字が指数に対応する。10^0〜10^18) */
     public static final long[] exp10LL = {
         1L,
         10L,
@@ -139,52 +143,52 @@ public class CobolConstant {
         1000000000000000000L
     };
 
-    /** TODO: 準備中 */
+    /** 最小サイズのバッファのバイト数 */
     static final int COB_MINI_BUFF = 256;
 
-    /** TODO: 準備中 */
+    /** 小サイズのバッファのバイト数 */
     static final int COB_SMALL_BUFF = 1024;
 
-    /** TODO: 準備中 */
+    /** 標準サイズのバッファのバイト数 */
     static final int COB_NORMAL_BUFF = 2048;
 
-    /** TODO: 準備中 */
+    /** 中サイズのバッファのバイト数 */
     static final int COB_MEDIUM_BUFF = 8192;
 
-    /** TODO: 準備中 */
+    /** 大サイズのバッファのバイト数 */
     static final int COB_LARGE_BUFF = 16384;
 
-    /** TODO: 準備中 */
+    /** 最小サイズのバッファに格納できる最大文字数(終端分を除いた値) */
     static final int COB_MINI_MAX = COB_MINI_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 小サイズのバッファに格納できる最大文字数(終端分を除いた値) */
     static final int COB_SMALL_MAX = COB_SMALL_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 標準サイズのバッファに格納できる最大文字数(終端分を除いた値) */
     static final int COB_NORMAL_MAX = COB_NORMAL_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 中サイズのバッファに格納できる最大文字数(終端分を除いた値) */
     static final int COB_MEDIUM_MAX = COB_MEDIUM_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 大サイズのバッファに格納できる最大文字数(終端分を除いた値) */
     static final int COB_LARGE_MAX = COB_LARGE_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 1つのフィールドに指定できる引数の最大数 */
     static final int COB_MAX_FIELD_PARAMS = 64;
 
-    /** TODO: 準備中 */
+    /** 初期化に関する致命的エラーを表すエラーコード */
     static final int COB_FERROR_INITIALIZED = 0;
 
-    /** TODO: 準備中 */
+    /** コンパイル対象のソースファイル名 */
     static final String COB_SOURCE_FILE = null;
 
-    /** TODO: 準備中 */
+    /** パッケージのバージョン番号 */
     static final int COB_PACKAGE_VERSION = 0;
 
-    /** TODO: 準備中 */
+    /** パッチレベル */
     static final int COB_PATCH_LEVEL = 0;
 
     // TODO 標準パスの設定
-    /** TODO: 準備中 */
+    /** ライブラリの検索パス */
     public static final String COB_LIBRARY_PATH = "";
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
@@ -22,43 +22,47 @@ import java.util.Optional;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * COBOLの手続き部における制御の流れ(PERFORM文・GO TO文)を表現する抽象クラス<br>
+ * 各段落・節を1つのCobolControlとして表し、{@link #run()}でその単位を実行する。<br>
+ * {@link #run()}は実行後に続けて実行すべき次の制御を返すことで、段落の連続実行(フォールスルー)を表現する。
+ */
 public abstract class CobolControl {
-    /** TODO: 準備中 */
+    /** 制御単位の種別(段落か節か)を表す列挙型 */
     public enum LabelType {
-        /** TODO: 準備中 */
+        /** 段落(paragraph)を表す */
         label,
-        /** TODO: 準備中 */
+        /** 節(section)を表す */
         section,
     }
 
     /**
-     * TODO: 準備中
+     * この制御単位を実行する。
      *
-     * @return TODO: 準備中
-     * @throws CobolRuntimeException TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @return 続けて実行すべき次の制御。続きがない場合は空の{@link Optional}
+     * @throws CobolRuntimeException 実行中に実行時例外が発生した場合
+     * @throws CobolStopRunException 実行中にSTOP RUNが実行された場合
      */
     public abstract Optional<CobolControl> run()
             throws CobolRuntimeException, CobolStopRunException;
 
-    /** TODO: 準備中 */
+    /** この制御単位を識別するID(段落・節の通し番号)。未設定の場合は-1 */
     public int contId = -1;
 
-    /** TODO: 準備中 */
+    /** この制御単位の種別(段落か節か) */
     public LabelType type = LabelType.label;
 
-    /** TODO: 準備中 */
+    /** 既定値(ID:-1、種別:段落)で制御単位を生成する。 */
     public CobolControl() {
         this.contId = -1;
         this.type = LabelType.label;
     }
 
     /**
-     * TODO: 準備中
+     * 指定されたIDと種別で制御単位を生成する。
      *
-     * @param contId TODO: 準備中
-     * @param type TODO: 準備中
+     * @param contId 制御単位を識別するID
+     * @param type 制御単位の種別(段落か節か)
      */
     public CobolControl(int contId, LabelType type) {
         this.contId = contId;
@@ -66,9 +70,9 @@ public abstract class CobolControl {
     }
 
     /**
-     * TODO: 準備中
+     * 何も実行せず、続きの制御も持たない空の制御単位を生成する。
      *
-     * @return TODO: 準備中
+     * @return 何も行わない制御単位
      */
     public static CobolControl pure() {
         return new CobolControl() {
@@ -81,10 +85,10 @@ public abstract class CobolControl {
     }
 
     /**
-     * TODO: 準備中
+     * GO TO文に相当し、指定された制御単位へ制御を移す制御単位を生成する。
      *
-     * @param cont TODO: 準備中
-     * @return TODO: 準備中
+     * @param cont 制御の移行先となる制御単位
+     * @return 移行先を実行する制御単位
      */
     public static CobolControl goTo(CobolControl cont) {
         return new CobolControl() {
@@ -97,12 +101,13 @@ public abstract class CobolControl {
     }
 
     /**
-     * TODO: 準備中
+     * PERFORM ... THRU ...文に相当し、begin番目からend番目までの制御単位を順に実行する制御単位を生成する。<br>
+     * 終端が節の場合は、後続の段落も含めて節の終わりまで実行する。
      *
-     * @param contList TODO: 準備中
-     * @param begin TODO: 準備中
-     * @param end TODO: 準備中
-     * @return TODO: 準備中
+     * @param contList 段落・節を格納した制御単位の配列
+     * @param begin 実行を開始する制御単位のインデックス
+     * @param end 実行を終了する制御単位のインデックス
+     * @return 指定範囲を実行する制御単位
      */
     public static CobolControl performThrough(CobolControl[] contList, int begin, int end) {
         return new CobolControl() {
@@ -130,11 +135,11 @@ public abstract class CobolControl {
     }
 
     /**
-     * TODO: 準備中
+     * PERFORM文に相当し、指定された単一の段落・節を実行する制御単位を生成する。
      *
-     * @param contList TODO: 準備中
-     * @param labelId TODO: 準備中
-     * @return TODO: 準備中
+     * @param contList 段落・節を格納した制御単位の配列
+     * @param labelId 実行する制御単位のインデックス
+     * @return 指定された制御単位を実行する制御単位
      */
     public static CobolControl perform(CobolControl[] contList, int labelId) {
         return CobolControl.performThrough(contList, labelId, labelId);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolExternal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolExternal.java
@@ -23,28 +23,48 @@ import java.util.HashMap;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
-/** TODO: 準備中 */
+/**
+ * EXTERNAL属性を持つデータ項目およびファイルを管理するクラス<br>
+ * libcobのcob_externalに対応する。名前をキーとして領域を一元管理し、複数のプログラム間で
+ * 同一の実体(ファイルやデータ領域)を共有できるようにする。
+ */
 public final class CobolExternal {
 
+    /** このインスタンスが保持するEXTERNALファイルの実体 */
     private CobolFile extAllocFile;
+
+    /** このインスタンスが保持するEXTERNALデータ領域の実体 */
     private CobolDataStorage extAllocStorage;
 
+    /** EXTERNAL名から対応する{@link CobolExternal}インスタンスへの対応表 */
     private static AbstractMap<String, CobolExternal> externalMap =
             new HashMap<String, CobolExternal>();
 
+    /**
+     * EXTERNALファイルを保持するインスタンスを生成する。
+     *
+     * @param file 共有するファイルの実体
+     */
     private CobolExternal(CobolFile file) {
         this.extAllocFile = file;
     }
 
+    /**
+     * EXTERNALデータ領域を保持するインスタンスを生成する。
+     *
+     * @param storage 共有するデータ領域の実体
+     * @param size データ領域のサイズ(バイト数)
+     */
     private CobolExternal(CobolDataStorage storage, int size) {
         this.extAllocStorage = storage;
     }
 
     /**
-     * TODO: 準備中
+     * 指定された名前に対応するEXTERNALファイルを取得する。<br>
+     * 既に登録されていればその実体を返し、未登録の場合は新たに生成して登録した上で返す。
      *
-     * @param name TODO: 準備中
-     * @return TODO: 準備中
+     * @param name EXTERNALファイルの名前
+     * @return 名前に対応する共有ファイル
      */
     public static CobolFile getFileAddress(String name) {
         if (externalMap.containsKey(name)) {
@@ -58,11 +78,12 @@ public final class CobolExternal {
     }
 
     /**
-     * TODO: 準備中
+     * 指定された名前に対応するEXTERNALデータ領域を取得する。<br>
+     * 既に登録されていればその実体を返し、未登録の場合は指定サイズの領域を新たに生成して登録した上で返す。
      *
-     * @param name TODO: 準備中
-     * @param size TODO: 準備中
-     * @return TODO: 準備中
+     * @param name EXTERNALデータ領域の名前
+     * @param size 新規生成する場合のデータ領域のサイズ(バイト数)
+     * @return 名前に対応する共有データ領域
      */
     public static CobolDataStorage getStorageAddress(String name, int size) {
         if (externalMap.containsKey(name)) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -26,24 +26,66 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * COBOLのINSPECT文を実装するクラス<br>
+ * libcob/strings.cのcob_inspect_*系の関数に対応する。<br>
+ * TALLYING(文字の計数)・REPLACING(文字の置換)・CONVERTING(文字の変換)の各機能を提供する。<br>
+ * INSPECT文は{@link #init(AbstractCobolField, int)}で対象を設定し、{@link #start()}や
+ * {@link #before(AbstractCobolField)}・{@link #after(AbstractCobolField)}で走査範囲(BEFORE/AFTER)を限定した上で、
+ * {@link #all(AbstractCobolField, AbstractCobolField)}などで計数・置換を行い、最後に{@link #finish()}で確定する
+ * という手順で実行する。
+ */
 public class CobolInspect {
+    /** 一致する文字をすべて対象とする(INSPECT ... ALLに対応) */
     private static final int INSPECT_ALL = 0;
+
+    /** 先頭から連続する一致のみを対象とする(INSPECT ... LEADINGに対応) */
     private static final int INSPECT_LEADING = 1;
+
+    /** 最初に一致した1箇所のみを対象とする(INSPECT ... FIRSTに対応) */
     private static final int INSPECT_FIRST = 2;
+
+    /** 末尾から連続する一致のみを対象とする(INSPECT ... TRAILINGに対応) */
     private static final int INSPECT_TRAILING = 3;
 
+    /** INSPECTの対象となるフィールド */
     private static AbstractCobolField inspectVar;
+
+    /** INSPECTの対象フィールドの記憶領域 */
     private static CobolDataStorage inspectData;
+
+    /** 走査範囲の開始位置(0始まり) */
     private static int inspectStart;
+
+    /** 走査範囲の終了位置(この位置は含まない) */
     private static int inspectEnd;
+
+    /** 各バイトの処理状況を保持する配列(-1:未処理、1:計数済み、その他:置換後のバイト値) */
     private static int[] inspectMark = null;
+
+    /** {@link #inspectMark}として確保済みの領域サイズ */
     private static int lastsize = 0;
+
+    /** INSPECTの対象フィールドのサイズ(バイト数) */
     private static int inspectSize;
+
+    /** REPLACING(置換)モードかどうかを表す(0以外で置換、0で計数) */
     private static int inspectReplacing;
+
+    /** 対象フィールドの元の符号(処理後に復元するために退避する) */
     private static int inspectSign;
+
+    /** INSPECTの対象フィールドの控え */
     private static AbstractCobolField inspectVarCopy;
 
+    /**
+     * 形象定数f1を、対象f2のサイズに合わせて繰り返し展開したフィールドを生成する。<br>
+     * REPLACINGでALL形象定数を置換文字として用いる場合に、長さを一致させるために使用する。
+     *
+     * @param f1 展開元となる形象定数のフィールド
+     * @param f2 展開後の長さの基準となるフィールド
+     * @return f2と同じサイズに展開された英数字フィールド
+     */
     private static AbstractCobolField figurative(AbstractCobolField f1, AbstractCobolField f2) {
         int size1 = 0;
         int size2 = f2.getSize();
@@ -62,6 +104,16 @@ public class CobolInspect {
                 new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null));
     }
 
+    /**
+     * ALL/LEADING/FIRST/TRAILINGに共通する、文字列の照合・計数・置換処理を行う。<br>
+     * 指定された種別に応じて走査範囲内でf2を検索し、計数モードでは出現回数をf1に加算し、
+     * 置換モードでは{@link #inspectMark}に置換後のバイト値を記録する。
+     *
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @param f2 検索対象となる文字または文字列を表すフィールド
+     * @param type 照合の種別({@link #INSPECT_ALL}・{@link #INSPECT_LEADING}・{@link #INSPECT_FIRST}・{@link #INSPECT_TRAILING})
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
+     */
     private static void common(AbstractCobolField f1, AbstractCobolField f2, int type)
             throws CobolStopRunException {
         if (f1 == null) {
@@ -161,10 +213,11 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_initの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_initの実装。<br>
+     * INSPECT文の処理を開始し、対象フィールドや処理状況を記録する各種状態を初期化する。
      *
-     * @param var TODO: 準備中
-     * @param replacing TODO: 準備中
+     * @param var INSPECTの対象となるフィールド
+     * @param replacing REPLACING(置換)を行う場合は0以外、TALLYING(計数)の場合は0
      */
     public static void init(AbstractCobolField var, int replacing) {
         CobolInspect.inspectVarCopy = var;
@@ -190,16 +243,20 @@ public class CobolInspect {
         CobolRuntimeException.setException(0);
     }
 
-    /** libcob/strings.cのcob_inspect_startの実装 */
+    /**
+     * libcob/strings.cのcob_inspect_startの実装。<br>
+     * 走査範囲を対象フィールドの全体(先頭から末尾まで)に設定する。
+     */
     public static void start() {
         inspectStart = 0;
         inspectEnd = inspectSize;
     }
 
     /**
-     * libcob/strings.cのcob_inspect_beforeの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_beforeの実装。<br>
+     * BEFORE INITIAL句に対応し、指定された区切り文字が最初に現れる位置で走査範囲の終了位置を制限する。
      *
-     * @param str TODO: 準備中
+     * @param str 走査範囲の終端を定める区切り文字(BEFORE INITIALの基準)を表すフィールド
      */
     public static void before(AbstractCobolField str) {
         CobolDataStorage p2 = null;
@@ -242,9 +299,10 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_afterの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_afterの実装。<br>
+     * AFTER INITIAL句に対応し、指定された区切り文字が最初に現れる位置の直後から走査範囲の開始位置を制限する。
      *
-     * @param str TODO: 準備中
+     * @param str 走査範囲の始端を定める区切り文字(AFTER INITIALの基準)を表すフィールド
      */
     public static void after(AbstractCobolField str) {
         CobolDataStorage data = str.getDataStorage();
@@ -259,10 +317,12 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_charactersの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_charactersの実装。<br>
+     * INSPECT ... CHARACTERS句に対応し、走査範囲内の未処理のすべての文字を対象とする。<br>
+     * 計数モードでは対象文字数をf1に加算し、置換モードでは各文字をf1の文字で置き換える。
      *
-     * @param f1 TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     public static void characters(AbstractCobolField f1) throws CobolStopRunException {
         int mark = inspectStart;
@@ -297,11 +357,12 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_allの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_allの実装。<br>
+     * INSPECT ... ALL句に対応し、走査範囲内に現れるf2のすべての出現を対象に計数または置換を行う。
      *
-     * @param f1 TODO: 準備中
-     * @param f2 TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @param f2 検索対象となる文字または文字列を表すフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     public static void all(AbstractCobolField f1, AbstractCobolField f2)
             throws CobolStopRunException {
@@ -309,11 +370,12 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_leadingの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_leadingの実装。<br>
+     * INSPECT ... LEADING句に対応し、走査範囲の先頭から連続して現れるf2のみを対象に計数または置換を行う。
      *
-     * @param f1 TODO: 準備中
-     * @param f2 TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @param f2 検索対象となる文字または文字列を表すフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     public static void leading(AbstractCobolField f1, AbstractCobolField f2)
             throws CobolStopRunException {
@@ -321,11 +383,12 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_firstの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_firstの実装。<br>
+     * INSPECT ... FIRST句に対応し、走査範囲内で最初に現れたf2の1箇所のみを対象に計数または置換を行う。
      *
-     * @param f1 TODO: 準備中
-     * @param f2 TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @param f2 検索対象となる文字または文字列を表すフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     public static void first(AbstractCobolField f1, AbstractCobolField f2)
             throws CobolStopRunException {
@@ -333,11 +396,12 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_trailingの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_trailingの実装。<br>
+     * INSPECT ... TRAILING句に対応し、走査範囲の末尾から連続して現れるf2のみを対象に計数または置換を行う。
      *
-     * @param f1 TODO: 準備中
-     * @param f2 TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
+     * @param f2 検索対象となる文字または文字列を表すフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     public static void trailing(AbstractCobolField f1, AbstractCobolField f2)
             throws CobolStopRunException {
@@ -345,10 +409,11 @@ public class CobolInspect {
     }
 
     /**
-     * libcob/strings.cのcob_inspect_convertingの実装。詳しい説明はTODO: 準備中。
+     * libcob/strings.cのcob_inspect_convertingの実装。<br>
+     * INSPECT ... CONVERTING句に対応し、走査範囲内でf1に含まれる各文字を、対応するf2の文字に変換する。
      *
-     * @param f1 TODO: 準備中
-     * @param f2 TODO: 準備中
+     * @param f1 変換元となる文字の集合を表すフィールド
+     * @param f2 変換先となる文字の集合を表すフィールド
      */
     public static void converting(AbstractCobolField f1, AbstractCobolField f2) {
         int type1 = f1.getAttribute().getType();
@@ -400,7 +465,11 @@ public class CobolInspect {
         }
     }
 
-    /** libcob/strings.cのcob_inspect_finishの実装。詳しい説明はTODO: 準備中。 */
+    /**
+     * libcob/strings.cのcob_inspect_finishの実装。<br>
+     * INSPECT文の処理を確定する。置換モードの場合は{@link #inspectMark}に記録した置換結果を対象フィールドへ書き戻し、
+     * 退避していた符号を復元する。
+     */
     public static void finish() {
         if (inspectReplacing != 0) {
             for (int i = 0; i < inspectSize; ++i) {
@@ -412,7 +481,7 @@ public class CobolInspect {
         inspectVar.putSign(inspectSign);
     }
 
-    /** TODO: 準備中 */
+    /** 処理状況を記録する{@link #inspectMark}を既定サイズ({@link CobolConstant#COB_MEDIUM_BUFF})で初期化する。 */
     public static void initString() {
         CobolInspect.inspectMark = new int[CobolConstant.COB_MEDIUM_BUFF];
         lastsize = CobolConstant.COB_MEDIUM_BUFF;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -319,7 +319,7 @@ public class CobolInspect {
     /**
      * libcob/strings.cのcob_inspect_charactersの実装。<br>
      * INSPECT ... CHARACTERS句に対応し、走査範囲内の未処理のすべての文字を対象とする。<br>
-     * 計数モードでは対象文字数をf1に加算し、置換モードでは各文字をf1の文字で置き換える。
+     * 計数モードでは対象文字数をf1に加算し、置換モードでは対象範囲をf1の内容で置き換える。
      *
      * @param f1 計数モードでは計数結果を加算するフィールド、置換モードでは置換後の文字を表すフィールド
      * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -38,23 +38,56 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
-/** TODO: 準備中 */
+/**
+ * COBOLの組み込み関数(FUNCTION ...)を実装するクラス。<br>
+ * GnuCOBOL/opensource COBOLのランタイムライブラリlibcobのintrinsic.cに対応する。<br>
+ * ABS、MOD、FACTORIAL、SUM、MAX、MIN、NUMVAL、CURRENT-DATE、UPPER-CASE、LOWER-CASEなどの
+ * 各組み込み関数を、{@code funcXxx}という名前の静的メソッドとして提供する。<br>
+ * 各メソッドは計算結果を{@link AbstractCobolField}として返す。
+ */
 public class CobolIntrinsic {
 
+    /** 各月初日までの通日(非うるう年)。インデックスは月(0〜12)。 */
     private static int[] normalDays = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+
+    /** 各月初日までの通日(うるう年)。インデックスは月(0〜12)。 */
     private static int[] leapDays = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
+
+    /** 各月の日数(非うるう年)。インデックスは月(0〜12)。 */
     private static int[] normalMonthDays = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    /** 各月の日数(うるう年)。インデックスは月(0〜12)。 */
     private static int[] leapMonthDays = {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    /** 計算結果を保持する内部フィールドの個数(リングバッファの深さ)。 */
     private static final int DEPTH_LEVEL = 8;
+
+    /** double型1個分のバイト数。 */
     private static final int sizeOfDouble = 8;
+
+    /** 次に使用する{@link #calcField}のインデックス。 */
     private static int currEntry = 0;
+
+    /** 直近に生成した計算結果フィールド。 */
     private static AbstractCobolField currField = null;
+
+    /** 計算結果を保持する内部フィールドのリングバッファ。 */
     private static AbstractCobolField[] calcField = new AbstractCobolField[DEPTH_LEVEL];
+
+    /** FUNCTION RANDOMで使用する擬似乱数生成器。 */
     private static Random random = new Random();
+
+    /** ロケール関連の文字列を一時的に保持するバッファ。 */
     private static byte[] localeBuff;
+
+    /** 文字列"00"のSJISバイト列(ファイルステータスの初期値などに使用)。 */
     private static final byte[] byteArray00 = "00".getBytes(AbstractCobolField.charSetSJIS);
 
-    /** libcob/intrinsicのmake_double_entryの実装 */
+    /**
+     * libcob/intrinsicのmake_double_entryの実装。<br>
+     * double型(COB_TYPE_NUMERIC_DOUBLE)の計算結果フィールドを新たに生成し、
+     * {@link #currField}に設定する。
+     */
     private static void makeDoubleEntry() {
         CobolDataStorage s = new CobolDataStorage(sizeOfDouble + 1);
 
@@ -75,7 +108,13 @@ public class CobolIntrinsic {
         }
     }
 
-    /** libcob/intrinsicのmake_field_entryの実装 */
+    /**
+     * libcob/intrinsicのmake_field_entryの実装。<br>
+     * 指定したフィールドと同じサイズ・属性を持つ計算結果フィールドを新たに生成し、
+     * {@link #currField}に設定する。
+     *
+     * @param f 生成するフィールドのサイズと属性の基となるフィールド
+     */
     private static void makeFieldEntry(AbstractCobolField f) {
         AbstractCobolField newField =
                 CobolFieldFactory.makeCobolField(
@@ -90,17 +129,20 @@ public class CobolIntrinsic {
     }
 
     /**
-     * libcob/intrinsicのcob_intr_ordの実装
+     * 指定した西暦年がうるう年かどうかを判定する。
      *
-     * @param year TODO: 準備中
-     * @return TODO: 準備中
+     * @param year 判定対象の西暦年
+     * @return うるう年であればtrue、そうでなければfalse
      */
     private static boolean isLeapYear(int year) {
         return ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0));
     }
 
     // libcob/intrinsicのcob_init_intrinsicの実装
-    /** TODO: 準備中 */
+    /**
+     * 組み込み関数の計算結果フィールド用バッファを初期化する。<br>
+     * {@link #calcField}の各要素に英数字型の256バイトフィールドを割り当てる。
+     */
     public static void init() {
         CobolFieldAttribute attr =
                 new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null);
@@ -111,10 +153,10 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_get_doubleの実装
     /**
-     * TODO: 準備中
+     * {@link CobolDecimal}の値を、その位取り(scale)を反映したdouble値に変換する。
      *
-     * @param d
-     * @return
+     * @param d 変換元の十進数値
+     * @return 位取りを反映したdouble値
      */
     private static double intrGetDouble(CobolDecimal d) {
         double v = d.getValue().doubleValue();
@@ -130,11 +172,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * 部分参照(reference modification)を計算結果フィールドに適用する。<br>
+     * 指定した開始位置offset(1始まり)と長さlengthに従ってフィールドの内容を切り出し、
+     * フィールドのサイズとデータを更新する。
      *
-     * @param f TODO: 準備中
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
+     * @param f 部分参照を適用するフィールド
+     * @param offset 切り出し開始位置(1始まり)
+     * @param length 切り出す長さ。0以下の場合は開始位置以降の全体を対象とする
      */
     private static void calcRefMod(AbstractCobolField f, int offset, int length) {
         if (offset <= f.getSize()) {
@@ -153,13 +197,14 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * 2つのフィールドに対して二項算術演算を行い、その結果をフィールドとして返す。<br>
+     * COBOLの算術式の評価に対応する。
      *
-     * @param f1 TODO: 準備中
-     * @param op TODO: 準備中
-     * @param f2 TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f1 左辺のフィールド
+     * @param op 演算子を表す文字コード('+'、'-'、'*'、'/'、'^'のいずれか)
+     * @param f2 右辺のフィールド
+     * @return 演算結果を保持するフィールド
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField intrBinop(AbstractCobolField f1, int op, AbstractCobolField f2)
             throws CobolStopRunException {
@@ -214,10 +259,11 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LENGTHに対応する。<br>
+     * 引数のフィールドのバイト数を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 長さを求める対象のフィールド
+     * @return フィールドのバイト数を保持する数値フィールド
      */
     public static AbstractCobolField funcLength(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -230,10 +276,11 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION INTEGERに対応する。<br>
+     * 引数の値を超えない最大の整数(負方向への切り捨て、すなわち床関数)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 床関数の結果を保持する整数フィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcInteger(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -283,10 +330,11 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION INTEGER-PARTに対応する。<br>
+     * 引数の整数部(小数点以下を0方向へ切り捨てた値)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 整数部を保持する整数フィールド
      */
     public static AbstractCobolField funcIntegerPart(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -305,12 +353,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION UPPER-CASEに対応する。<br>
+     * 引数の文字列中の小文字を大文字に変換した結果を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcfield 変換対象の文字列フィールド
+     * @return 大文字に変換した結果を保持するフィールド
      */
     public static AbstractCobolField funcUpperCase(
             int offset, int length, AbstractCobolField srcfield) {
@@ -328,12 +377,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOWER-CASEに対応する。<br>
+     * 引数の文字列中の大文字を小文字に変換した結果を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcfield 変換対象の文字列フィールド
+     * @return 小文字に変換した結果を保持するフィールド
      */
     public static AbstractCobolField funcLowerCase(
             int offset, int length, AbstractCobolField srcfield) {
@@ -351,12 +401,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION REVERSEに対応する。<br>
+     * 引数の文字列を逆順に並べ替えた結果を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcfield 反転対象の文字列フィールド
+     * @return 文字順を反転した結果を保持するフィールド
      */
     public static AbstractCobolField funcReverse(
             int offset, int length, AbstractCobolField srcfield) {
@@ -374,12 +425,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION WHEN-COMPILEDに対応する。<br>
+     * コンパイル日時を表すフィールドの内容をそのまま返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param f TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param f コンパイル日時を保持するフィールド
+     * @return コンパイル日時を保持するフィールド
      */
     public static AbstractCobolField funcWhenCompiled(
             int offset, int length, AbstractCobolField f) {
@@ -392,11 +444,12 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION CURRENT-DATEに対応する。<br>
+     * 現在の日付と時刻を「YYYYMMDDhhmmsshh+ZZZZ」形式の21文字の文字列として返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @return 現在日時を表す文字列フィールド
      */
     public static AbstractCobolField funcCurrentDate(int offset, int length) {
         CobolFieldAttribute attr =
@@ -425,10 +478,11 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION CHARに対応する。<br>
+     * 引数の整数値(1始まりの順序位置)に対応する1文字を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 文字の順序位置を表す数値フィールド
+     * @return 対応する1文字を保持するフィールド
      */
     public static AbstractCobolField funcChar(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -448,10 +502,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_ordの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ORDに対応する。<br>
+     * 引数の文字の照合順序上の位置(1始まり)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の1文字を保持するフィールド
+     * @return 文字の順序位置を保持する数値フィールド
      */
     public static AbstractCobolField funcOrd(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -466,10 +521,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_date_of_integerの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION DATE-OF-INTEGERに対応する。<br>
+     * 基準日(1601年1月1日を1とする通日)から、対応する日付を「YYYYMMDD」形式で返す。<br>
+     * 引数が有効範囲(1〜3067671)外の場合は例外を設定し、結果を"00000000"とする。
      *
-     * @param srcdays TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcdays 通日(整数)を保持するフィールド
+     * @return 日付を表す8桁の数値フィールド
      */
     public static AbstractCobolField funcDateOfInteger(AbstractCobolField srcdays) {
         CobolFieldAttribute attr =
@@ -520,10 +577,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_day_of_integerの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION DAY-OF-INTEGERに対応する。<br>
+     * 基準日(1601年1月1日を1とする通日)から、対応する日付を年間通日形式「YYYYDDD」で返す。<br>
+     * 引数が有効範囲(1〜3067671)外の場合は例外を設定する。
      *
-     * @param srcdays TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcdays 通日(整数)を保持するフィールド
+     * @return 年間通日を表す7桁の数値フィールド
      */
     public static AbstractCobolField funcDayOfInteger(AbstractCobolField srcdays) {
         CobolFieldAttribute attr =
@@ -560,10 +619,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_integer_of_dateの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION INTEGER-OF-DATEに対応する。<br>
+     * 「YYYYMMDD」形式の日付を、1601年1月1日を1とする通日(整数)に変換する。<br>
+     * 年・月・日のいずれかが有効範囲外の場合は例外を設定し、0を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 「YYYYMMDD」形式の日付を保持するフィールド
+     * @return 通日を表す数値フィールド
      */
     public static AbstractCobolField funcIntegerOfDate(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -631,10 +692,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_integer_of_dayの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION INTEGER-OF-DAYに対応する。<br>
+     * 年間通日形式「YYYYDDD」の日付を、1601年1月1日を1とする通日(整数)に変換する。<br>
+     * 年または日が有効範囲外の場合は例外を設定し、0を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 「YYYYDDD」形式の日付を保持するフィールド
+     * @return 通日を表す数値フィールド
      */
     public static AbstractCobolField funcIntegerOfDay(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -672,12 +735,14 @@ public class CobolIntrinsic {
         return currField;
     }
 
-    // libcob/intrinsicのcob_intr_integer_of_dayの実装
+    // libcob/intrinsicのcob_intr_factorialの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION FACTORIALに対応する。<br>
+     * 引数の非負整数の階乗を返す。<br>
+     * 引数が負の場合は例外を設定し、0を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 階乗を求める非負整数を保持するフィールド
+     * @return 階乗の値を保持する数値フィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcFactorial(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -706,6 +771,13 @@ public class CobolIntrinsic {
         return currField;
     }
 
+    /**
+     * 三角関数・逆三角関数系の組み込み関数の前処理。<br>
+     * 引数から{@link CobolDecimal}を生成し、結果格納用の数値フィールドを準備する。
+     *
+     * @param srcfield 対象の数値フィールド
+     * @return 引数の値を保持する十進数値
+     */
     private static CobolDecimal mathFunctionBefore1(AbstractCobolField srcfield) {
         CobolDecimal d1 = new CobolDecimal();
         CobolFieldAttribute attr =
@@ -722,6 +794,13 @@ public class CobolIntrinsic {
         return d1;
     }
 
+    /**
+     * 指数・対数・平方根系の組み込み関数の前処理。<br>
+     * 引数から{@link CobolDecimal}を生成し、結果格納用のdouble型フィールドを準備する。
+     *
+     * @param srcfield 対象の数値フィールド
+     * @return 引数の値を保持する十進数値
+     */
     private static CobolDecimal mathFunctionBefore2(AbstractCobolField srcfield) {
         CobolDecimal d1 = new CobolDecimal();
         d1.setField(srcfield);
@@ -729,6 +808,14 @@ public class CobolIntrinsic {
         return d1;
     }
 
+    /**
+     * {@link #mathFunctionBefore1(AbstractCobolField)}と対になる後処理。<br>
+     * 計算したdouble値を、位取り17桁の数値フィールドに格納して返す。<br>
+     * 値がNaNまたは無限大の場合は0を格納する。
+     *
+     * @param mathd2 数学関数の計算結果
+     * @return 結果を保持する数値フィールド
+     */
     private static AbstractCobolField mathFunctionAfter1(double mathd2) {
         if (Double.isNaN(mathd2)
                 || mathd2 == Double.POSITIVE_INFINITY
@@ -749,6 +836,14 @@ public class CobolIntrinsic {
         return currField;
     }
 
+    /**
+     * {@link #mathFunctionBefore2(AbstractCobolField)}と対になる後処理。<br>
+     * 計算したdouble値を、double型のフィールドに格納して返す。<br>
+     * 値がNaNまたは無限大の場合は0を格納する。
+     *
+     * @param mathd2 数学関数の計算結果
+     * @return 結果を保持するdouble型フィールド
+     */
     private static AbstractCobolField mathFunctionAfter2(double mathd2) {
         if (Double.isNaN(mathd2)
                 || mathd2 == Double.POSITIVE_INFINITY
@@ -762,10 +857,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_expの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXPに対応する。<br>
+     * ネイピア数eを底とする指数関数(e のsrcfield乗)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 指数を保持する数値フィールド
+     * @return 計算結果を保持するdouble型フィールド
      */
     public static AbstractCobolField funcExp(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -775,10 +871,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_exp10の実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXP10に対応する。<br>
+     * 10を底とする指数関数(10 のsrcfield乗)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 指数を保持する数値フィールド
+     * @return 計算結果を保持するdouble型フィールド
      */
     public static AbstractCobolField funcExp10(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -788,10 +885,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_absの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ABSに対応する。<br>
+     * 引数の絶対値を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 絶対値を保持するフィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcAbs(AbstractCobolField srcfield) {
         makeFieldEntry(srcfield);
@@ -807,10 +905,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_acosの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ACOSに対応する。<br>
+     * 引数の逆余弦(アークコサイン、単位はラジアン)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 逆余弦の値を保持するフィールド
      */
     public static AbstractCobolField funcAcos(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore1(srcfield);
@@ -820,10 +919,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_asinの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ASINに対応する。<br>
+     * 引数の逆正弦(アークサイン、単位はラジアン)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 逆正弦の値を保持するフィールド
      */
     public static AbstractCobolField funcAsin(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore1(srcfield);
@@ -833,10 +933,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_atanの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ATANに対応する。<br>
+     * 引数の逆正接(アークタンジェント、単位はラジアン)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 逆正接の値を保持するフィールド
      */
     public static AbstractCobolField funcAtan(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore1(srcfield);
@@ -846,10 +947,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_cosの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION COSに対応する。<br>
+     * 引数(ラジアン)の余弦(コサイン)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 角度(ラジアン)を保持する数値フィールド
+     * @return 余弦の値を保持するフィールド
      */
     public static AbstractCobolField funcCos(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore1(srcfield);
@@ -859,10 +961,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_logの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOGに対応する。<br>
+     * 引数の自然対数(底はネイピア数e)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 自然対数の値を保持するdouble型フィールド
      */
     public static AbstractCobolField funcLog(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -872,10 +975,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_log10の実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOG10に対応する。<br>
+     * 引数の常用対数(底は10)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 常用対数の値を保持するdouble型フィールド
      */
     public static AbstractCobolField funcLog10(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -885,10 +989,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_sinの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SINに対応する。<br>
+     * 引数(ラジアン)の正弦(サイン)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 角度(ラジアン)を保持する数値フィールド
+     * @return 正弦の値を保持するフィールド
      */
     public static AbstractCobolField funcSin(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore1(srcfield);
@@ -898,10 +1003,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_sqrtの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SQRTに対応する。<br>
+     * 引数の平方根を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 平方根の値を保持するdouble型フィールド
      */
     public static AbstractCobolField funcSqrt(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -911,10 +1017,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_tanの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION TANに対応する。<br>
+     * 引数(ラジアン)の正接(タンジェント)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 角度(ラジアン)を保持する数値フィールド
+     * @return 正接の値を保持するdouble型フィールド
      */
     public static AbstractCobolField funcTan(AbstractCobolField srcfield) {
         CobolDecimal d1 = mathFunctionBefore2(srcfield);
@@ -924,10 +1031,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_numvalの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION NUMVALに対応する。<br>
+     * 数字を表す文字列(符号、小数点、CR/DBなどを含む)を解析し、対応する数値に変換して返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 数字を表す文字列フィールド
+     * @return 変換した数値を保持するフィールド
      */
     public static AbstractCobolField funcNumval(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -1012,11 +1120,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_numval_cの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION NUMVAL-Cに対応する。<br>
+     * 通貨記号やカンマを含む金額文字列を解析し、対応する数値に変換して返す。
      *
-     * @param srcfield TODO: 準備中
-     * @param currency TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 金額を表す文字列フィールド
+     * @param currency 通貨記号を表すフィールド。nullの場合はモジュールの通貨記号設定を用いる
+     * @return 変換した数値を保持するフィールド
      */
     public static AbstractCobolField funcNumvalC(
             AbstractCobolField srcfield, AbstractCobolField currency) {
@@ -1120,11 +1229,13 @@ public class CobolIntrinsic {
     }
 
     /**
-     * このメソッドは未実装
+     * COBOLの組み込み関数FUNCTION NUMVAL-Cに対応するオーバーロードのうち、第1引数が数値リテラルとして
+     * 渡された呼び出しに対応するスタブ。<br>
+     * このメソッドは未実装であり、常にnullを返す。
      *
-     * @param n このメソッドは未実装
-     * @param currency このメソッドは未実装
-     * @return null
+     * @param n 金額を表す数値(未使用)
+     * @param currency 通貨記号を表すフィールド(未使用)
+     * @return 常にnull
      */
     public static AbstractCobolField funcNumvalC(int n, AbstractCobolField currency) {
         // TODO
@@ -1132,22 +1243,26 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION NUMVAL-Cに対応するオーバーロード。<br>
+     * 通貨記号の指定を省略した呼び出しに対応し、通貨記号なしで
+     * {@link #funcNumvalC(AbstractCobolField, AbstractCobolField)}を実行する。
      *
-     * @param srcfield TODO: 準備中
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 金額を表す文字列フィールド
+     * @param n 通貨記号フィールドが指定されなかったことを表すダミー引数
+     * @return 変換した数値を保持するフィールド
      */
     public static AbstractCobolField funcNumvalC(AbstractCobolField srcfield, int n) {
         return funcNumvalC(srcfield, null);
     }
 
     /**
-     * このメソッドは未実装
+     * COBOLの組み込み関数FUNCTION NUMVAL-Cに対応するオーバーロードのうち、両引数が数値リテラルとして
+     * 渡された呼び出しに対応するスタブ。<br>
+     * このメソッドは未実装であり、常にnullを返す。
      *
-     * @param n このメソッドは未実装
-     * @param m このメソッドは未実装
-     * @return null
+     * @param n 金額を表す数値(未使用)
+     * @param m 通貨記号を表す数値(未使用)
+     * @return 常にnull
      */
     public static AbstractCobolField funcNumvalC(int n, int m) {
         // TODO
@@ -1156,11 +1271,13 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_annuityの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ANNUITYに対応する。<br>
+     * 利率srcfield1と期間数srcfield2から、元本1に対する年金係数(期ごとの返済額)を返す。<br>
+     * 利率が0の場合は期間数の逆数を返す。
      *
-     * @param srcfield1 TODO: 準備中
-     * @param srcfield2 TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield1 期あたりの利率を保持するフィールド
+     * @param srcfield2 期間数を保持するフィールド
+     * @return 年金係数を保持するdouble型フィールド
      */
     public static AbstractCobolField funcAnnuity(
             AbstractCobolField srcfield1, AbstractCobolField srcfield2) {
@@ -1183,6 +1300,13 @@ public class CobolIntrinsic {
         return currField;
     }
 
+    /**
+     * 値の整数部の桁数を返す。<br>
+     * 符号と小数部を除いた、10進数表記での整数部の桁数を求める。
+     *
+     * @param d1 対象の十進数値
+     * @return 整数部の桁数
+     */
     private static int sizeInBase10(BigDecimal d1) {
         String s = d1.toPlainString();
         int begin = s.charAt(0) == '-' ? 0 : -1;
@@ -1193,11 +1317,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_sumの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SUMに対応する。<br>
+     * 引数として与えられたすべての数値の総和を返す。位取りは各引数のうち最大のものに合わせる。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 合計の対象となる数値フィールドの並び
+     * @return 総和を保持する数値フィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcSum(int params, AbstractCobolField... fields) {
         CobolDecimal d1 = new CobolDecimal();
@@ -1251,11 +1376,13 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_ord_minの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ORD-MINに対応する。<br>
+     * 引数の並びの中で最小の値を持つ要素の順序位置(1始まり)を返す。<br>
+     * 引数が1個以下の場合は0を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 比較対象となるフィールドの並び
+     * @return 最小値を持つ要素の順序位置を保持する数値フィールド
      */
     public static AbstractCobolField funcOrdMin(int params, AbstractCobolField... fields) {
         CobolFieldAttribute attr =
@@ -1286,11 +1413,13 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_ord_maxの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION ORD-MAXに対応する。<br>
+     * 引数の並びの中で最大の値を持つ要素の順序位置(1始まり)を返す。<br>
+     * 引数が1個以下の場合は0を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 比較対象となるフィールドの並び
+     * @return 最大値を持つ要素の順序位置を保持する数値フィールド
      */
     public static AbstractCobolField funcOrdMax(int params, AbstractCobolField... fields) {
         CobolFieldAttribute attr =
@@ -1321,11 +1450,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_minの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MINに対応する。<br>
+     * 引数の並びの中で最小の値を持つフィールドを返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 比較対象となるフィールドの並び
+     * @return 最小値を持つフィールド
      */
     public static AbstractCobolField funcMin(int params, AbstractCobolField... fields) {
         AbstractCobolField beasef = fields[0];
@@ -1341,11 +1471,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_maxの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MAXに対応する。<br>
+     * 引数の並びの中で最大の値を持つフィールドを返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 比較対象となるフィールドの並び
+     * @return 最大値を持つフィールド
      */
     public static AbstractCobolField funcMax(int params, AbstractCobolField... fields) {
         AbstractCobolField beasef = fields[0];
@@ -1361,11 +1492,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_midrangeの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MIDRANGEに対応する。<br>
+     * 引数の並びの中の最小値と最大値の平均((最小値 + 最大値) / 2)を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 比較対象となる数値フィールドの並び
+     * @return 最小値と最大値の中間値を保持するdouble型フィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcMidrange(int params, AbstractCobolField... fields) {
         makeDoubleEntry();
@@ -1398,11 +1530,13 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_medianの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MEDIANに対応する。<br>
+     * 引数を昇順に整列したときの中央値を返す。引数の個数が奇数の場合は中央の要素を、
+     * 偶数の場合は中央の2要素の平均を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 中央値を求める対象となる数値フィールドの並び
+     * @return 中央値を保持するフィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcMedian(int params, AbstractCobolField... fields) {
         if (fields.length == 1) {
@@ -1439,11 +1573,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_medianの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MEANに対応する。<br>
+     * 引数として与えられたすべての数値の算術平均(総和を要素数で割った値)を返す。
      *
-     * @param pramas TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param pramas 引数の個数
+     * @param fields 平均を求める対象となる数値フィールドの並び
+     * @return 算術平均を保持する数値フィールド。処理中にエラーが発生した場合はnull
      */
     public static AbstractCobolField funcMean(int pramas, AbstractCobolField... fields) {
         CobolFieldAttribute attr =
@@ -1498,12 +1633,14 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_modの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION MODに対応する。<br>
+     * srcfield1をsrcfield2で割った剰余(srcfield1 - srcfield2 * FUNCTION INTEGER(srcfield1 / srcfield2))を返す。
+     * 結果の符号は除数srcfield2と一致する。
      *
-     * @param srcfield1 TODO: 準備中
-     * @param srcfield2 TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param srcfield1 被除数を保持するフィールド
+     * @param srcfield2 除数を保持するフィールド
+     * @return 剰余を保持する数値フィールド。処理中にエラーが発生した場合はnull
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcMod(
             AbstractCobolField srcfield1, AbstractCobolField srcfield2)
@@ -1537,12 +1674,13 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_rangeの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION RANGEに対応する。<br>
+     * 引数の並びの中の最大値から最小値を引いた値(値の範囲)を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 範囲を求める対象となる数値フィールドの並び
+     * @return 最大値と最小値の差を保持する数値フィールド
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcRange(int params, AbstractCobolField... fields)
             throws CobolStopRunException {
@@ -1584,12 +1722,14 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_remの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION REMに対応する。<br>
+     * srcfield1をsrcfield2で割った剰余(srcfield1 - srcfield2 * FUNCTION INTEGER-PART(srcfield1 / srcfield2))を返す。
+     * 商の整数部を0方向へ切り捨てて算出するため、結果の符号は被除数srcfield1と一致する。
      *
-     * @param srcfield1 TODO: 準備中
-     * @param srcfield2 TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param srcfield1 被除数を保持するフィールド
+     * @param srcfield2 除数を保持するフィールド
+     * @return 剰余を保持する数値フィールド
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcRem(
             AbstractCobolField srcfield1, AbstractCobolField srcfield2)
@@ -1624,11 +1764,12 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_randomの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION RANDOMに対応する。<br>
+     * 0以上1未満の擬似乱数を返す。引数が与えられた場合はその値を乱数の種(シード)として用いる。
      *
-     * @param prams TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param prams 引数の個数
+     * @param fields シードを保持するフィールドの並び(省略可能)。指定された場合は先頭要素をシードとして用いる
+     * @return 擬似乱数を保持する数値フィールド
      */
     public static AbstractCobolField funcRandom(int prams, AbstractCobolField... fields) {
         CobolFieldAttribute attr =
@@ -1671,12 +1812,14 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_varianceの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION VARIANCEに対応する。<br>
+     * 引数として与えられた数値の母分散(平均との差の二乗の平均)を返す。<br>
+     * 引数が1個の場合は0を返す。
      *
-     * @param prams TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param prams 引数の個数
+     * @param fields 分散を求める対象となる数値フィールドの並び
+     * @return 母分散を保持する数値フィールド。処理中にエラーが発生した場合はnull
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcVariance(int prams, AbstractCobolField... fields)
             throws CobolStopRunException {
@@ -1746,12 +1889,14 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_standard_deviationの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION STANDARD-DEVIATIONに対応する。<br>
+     * 引数として与えられた数値の母標準偏差(母分散の平方根)を返す。<br>
+     * 引数が1個の場合は0を返す。
      *
-     * @param prams TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param prams 引数の個数
+     * @param fields 標準偏差を求める対象となる数値フィールドの並び
+     * @return 母標準偏差を保持する数値フィールド。処理中にエラーが発生した場合はnull
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcStandardDeviation(int prams, AbstractCobolField... fields)
             throws CobolStopRunException {
@@ -1810,12 +1955,14 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_present_valueの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION PRESENT-VALUEに対応する。<br>
+     * 第1引数を割引率とし、第2引数以降を将来の各期の収支とみなして、それらの現在価値の合計を返す。<br>
+     * 引数が2個未満の場合はエラーメッセージを出力し0を返す。
      *
-     * @param prams TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param prams 引数の個数
+     * @param fields 先頭が割引率、それ以降が各期の収支を表す数値フィールドの並び
+     * @return 現在価値の合計を保持するdouble型フィールド
+     * @throws CobolStopRunException 演算処理中にランタイムエラーが発生した場合
      */
     public static AbstractCobolField funcPresentValue(int prams, AbstractCobolField... fields)
             throws CobolStopRunException {
@@ -1851,10 +1998,11 @@ public class CobolIntrinsic {
 
     // libcob/intrinsicのcob_intr_nationalの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION NATIONALに対応する。<br>
+     * 引数の半角文字(英数字)を全角の日本語文字(各国文字)に変換した結果を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 変換対象の文字列フィールド
+     * @return 各国文字に変換した結果を保持するフィールド
      */
     public static AbstractCobolField funcNational(AbstractCobolField srcfield) {
         int size = srcfield.getSize();
@@ -1873,11 +2021,15 @@ public class CobolIntrinsic {
 
     // cob_intr_combined_datetimeの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION COMBINED-DATETIMEに対応する。<br>
+     * 通日(整数日付)と時刻(0時からの経過秒数)を結合し、「DDDDDDDttttt」形式の
+     * 12桁の数値(整数部7桁が通日、小数部5桁が時刻)を返す。<br>
+     * 通日が有効範囲(1〜3067671)外、または時刻が有効範囲(1〜86400)外の場合は
+     * 例外を設定し、結果を0とする。
      *
-     * @param srcdays TODO: 準備中
-     * @param srctime TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcdays 通日(整数)を保持するフィールド
+     * @param srctime 0時からの経過秒数を保持するフィールド
+     * @return 通日と時刻を結合した数値フィールド
      */
     public static AbstractCobolField funcCombinedDatetime(
             AbstractCobolField srcdays, AbstractCobolField srctime) {
@@ -1917,13 +2069,14 @@ public class CobolIntrinsic {
 
     // cob_intr_concatenateの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION CONCATENATEに対応する。<br>
+     * 引数として与えられたすべての文字列フィールドを順に連結した結果を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param params 連結対象の引数の個数
+     * @param fields 連結する文字列フィールドの並び
+     * @return 連結した結果を保持するフィールド
      */
     public static AbstractCobolField funcConcatenate(
             int offset, int length, int params, AbstractCobolField... fields) {
@@ -1957,11 +2110,14 @@ public class CobolIntrinsic {
 
     // cob_intr_date_to_yyyymmddの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION DATE-TO-YYYYMMDDに対応する。<br>
+     * 2桁年の日付「YYMMDD」を、ウィンドウ方式(基準年と区間)により4桁年の日付「YYYYMMDD」に変換して返す。<br>
+     * 第2引数で区間(省略時は50)、第3引数で実行年(省略時はシステム日付)を指定できる。<br>
+     * 引数が有効範囲外の場合は例外を設定し、0を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 先頭が「YYMMDD」形式の日付、第2要素が区間、第3要素が実行年を表す数値フィールドの並び
+     * @return 4桁年の日付「YYYYMMDD」を保持する数値フィールド
      */
     public static AbstractCobolField funcDateToYyyymmdd(int params, AbstractCobolField... fields) {
         int year;
@@ -2019,11 +2175,14 @@ public class CobolIntrinsic {
 
     // cob_intr_day_to_yyyydddの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION DAY-TO-YYYYDDDに対応する。<br>
+     * 2桁年の年間通日「YYDDD」を、ウィンドウ方式(基準年と区間)により4桁年の年間通日「YYYYDDD」に変換して返す。<br>
+     * 第2引数で区間(省略時は50)、第3引数で実行年(省略時はシステム日付)を指定できる。<br>
+     * 引数が有効範囲外の場合は例外を設定し、0を返す。
      *
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param params 引数の個数
+     * @param fields 先頭が「YYDDD」形式の年間通日、第2要素が区間、第3要素が実行年を表す数値フィールドの並び
+     * @return 4桁年の年間通日「YYYYDDD」を保持する数値フィールド
      */
     public static AbstractCobolField funcDayToYyyyddd(int params, AbstractCobolField... fields) {
         int year;
@@ -2082,9 +2241,11 @@ public class CobolIntrinsic {
 
     // cob_intr_exception_fileの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXCEPTION-FILEに対応する。<br>
+     * 直近に発生した入出力例外に関するファイル情報(2桁のファイルステータスと、続くファイル名)を返す。<br>
+     * 入出力例外が発生していない場合はファイルステータス"00"のみを返す。
      *
-     * @return TODO: 準備中
+     * @return ファイルステータスとファイル名を保持する文字列フィールド
      */
     public static AbstractCobolField funcExceptionFile() {
         int flen;
@@ -2118,9 +2279,12 @@ public class CobolIntrinsic {
 
     // cob_intr_exception_locationの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXCEPTION-LOCATIONに対応する。<br>
+     * 直近に発生した例外の発生箇所(プログラムID、節・段落名、行番号)を
+     * 「プログラムID; 段落 OF 節; 行番号」などの形式の文字列として返す。<br>
+     * 例外が発生していない場合は空白1文字を返す。
      *
-     * @return TODO: 準備中
+     * @return 例外発生箇所を表す文字列フィールド
      */
     public static AbstractCobolField funcExceptionLocation() {
         String buff;
@@ -2175,9 +2339,11 @@ public class CobolIntrinsic {
 
     // cob_intr_exception_statementの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXCEPTION-STATEMENTに対応する。<br>
+     * 直近に発生した例外を引き起こした文(STATEMENT)の名前を、31桁に左詰めした文字列として返す。<br>
+     * 該当する文が無い場合は空白を返す。
      *
-     * @return TODO: 準備中
+     * @return 例外を引き起こした文の名前を表す31桁の文字列フィールド
      */
     public static AbstractCobolField funcExceptionStatement() {
         CobolFieldAttribute attr =
@@ -2198,14 +2364,17 @@ public class CobolIntrinsic {
         return currField;
     }
 
+    /** 例外名が取得できなかった場合に用いる既定の例外名"EXCEPTION-OBJECT"のSJISバイト列。 */
     private static final byte[] CONST_STRING_EXCEPTION_OBJECT =
             "EXCEPTION-OBJECT".getBytes(AbstractCobolField.charSetSJIS);
 
     // cob_intr_exception_statusの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION EXCEPTION-STATUSに対応する。<br>
+     * 直近に発生した例外の名前を、31桁に左詰めした文字列として返す。<br>
+     * 例外が発生していない場合は空白を返す。
      *
-     * @return TODO: 準備中
+     * @return 例外の名前を表す31桁の文字列フィールド
      */
     public static AbstractCobolField funcExceptionStatus() {
         byte[] exceptName;
@@ -2233,10 +2402,11 @@ public class CobolIntrinsic {
 
     // cob_intr_fraction_partの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION FRACTION-PARTに対応する。<br>
+     * 引数の小数部(整数部を除いた値)を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 小数部を保持する数値フィールド
      */
     public static AbstractCobolField funcFractionPart(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -2256,11 +2426,14 @@ public class CobolIntrinsic {
 
     // cob_intr_seconds_from_formatted_timeの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SECONDS-FROM-FORMATTED-TIMEに対応する。<br>
+     * 時刻書式文字列(時を"hh"、分を"mm"、秒を"ss"で表す)に従ってvalueを解析し、
+     * その時刻を0時からの経過秒数に変換して返す。<br>
+     * 時・分・秒のいずれかが書式中に現れない場合は例外を設定し、0を返す。
      *
-     * @param format TODO: 準備中
-     * @param value TODO: 準備中
-     * @return TODO: 準備中
+     * @param format 時刻の書式を表すフィールド("hh"、"mm"、"ss"を含む)
+     * @param value 書式に従った時刻文字列を保持するフィールド
+     * @return 0時からの経過秒数を保持する数値フィールド
      */
     public static AbstractCobolField funcSecondsFromFormattedTime(
             AbstractCobolField format, AbstractCobolField value) {
@@ -2336,9 +2509,10 @@ public class CobolIntrinsic {
 
     // cob_intr_seconds_past_midnightの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SECONDS-PAST-MIDNIGHTに対応する。<br>
+     * 現在時刻の、0時からの経過秒数(時 * 3600 + 分 * 60 + 秒)を返す。
      *
-     * @return TODO: 準備中
+     * @return 0時からの経過秒数を保持する数値フィールド
      */
     public static AbstractCobolField funcSecondsPastMidnight() {
         int seconds;
@@ -2355,10 +2529,11 @@ public class CobolIntrinsic {
 
     // cob_intr_signの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SIGNに対応する。<br>
+     * 引数の符号に応じて、負の場合は-1、0の場合は0、正の場合は1を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の数値フィールド
+     * @return 符号を表す数値フィールド(-1、0、または1)
      */
     public static AbstractCobolField funcSign(AbstractCobolField srcfield) {
         CobolFieldAttribute attr =
@@ -2384,10 +2559,11 @@ public class CobolIntrinsic {
 
     // cob_intr_stored_char_lengthの実装
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION STORED-CHAR-LENGTHに対応する。<br>
+     * 引数の文字列から末尾の空白を取り除いた、実質的な格納文字数を返す。
      *
-     * @param srcfield TODO: 準備中
-     * @return TODO: 準備中
+     * @param srcfield 対象の文字列フィールド
+     * @return 末尾の空白を除いた文字数を保持する数値フィールド
      */
     public static AbstractCobolField funcStoredCharLength(AbstractCobolField srcfield) {
         int count;
@@ -2410,13 +2586,16 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SUBSTITUTEに対応する。<br>
+     * 先頭の引数を対象文字列とし、続く引数を(検索文字列, 置換文字列)の組として、
+     * 対象文字列中に出現する各検索文字列を対応する置換文字列に置き換えた結果を返す。<br>
+     * 大文字・小文字を区別して比較する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param params 引数の個数(先頭の対象文字列と、それに続く検索・置換の組)
+     * @param fields 先頭が対象文字列、それ以降が検索文字列と置換文字列を交互に並べたフィールドの並び
+     * @return 置換した結果を保持するフィールド
      */
     public static AbstractCobolField funcSubstitute(
             int offset, int length, int params, AbstractCobolField... fields) {
@@ -2473,13 +2652,16 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION SUBSTITUTE-CASEに対応する。<br>
+     * 先頭の引数を対象文字列とし、続く引数を(検索文字列, 置換文字列)の組として、
+     * 対象文字列中に出現する各検索文字列を対応する置換文字列に置き換えた結果を返す。<br>
+     * 大文字・小文字を区別せずに比較する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param params TODO: 準備中
-     * @param fields TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param params 引数の個数(先頭の対象文字列と、それに続く検索・置換の組)
+     * @param fields 先頭が対象文字列、それ以降が検索文字列と置換文字列を交互に並べたフィールドの並び
+     * @return 置換した結果を保持するフィールド
      */
     public static AbstractCobolField funcSubstituteCase(
             int offset, int length, int params, AbstractCobolField... fields) {
@@ -2539,13 +2721,15 @@ public class CobolIntrinsic {
 
     // Equivalent to cob_intr_trim
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION TRIMに対応する。<br>
+     * 引数の文字列の前後の空白を取り除いた結果を返す。directionにより、取り除く位置を切り替える。<br>
+     * 文字列が空白のみの場合は空白1文字を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param direction TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 空白を取り除く対象の文字列フィールド
+     * @param direction 取り除く位置の指定。1は先頭の空白のみ、2は末尾の空白のみ、それ以外は前後両方の空白を取り除く
+     * @return 空白を取り除いた結果を保持するフィールド
      */
     public static AbstractCobolField funcTrim(
             int offset, int length, AbstractCobolField srcField, int direction) {
@@ -2587,13 +2771,15 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-DATEに対応するオーバーロード。<br>
+     * ロケールの指定が省略された呼び出しに対応し、既定のロケールで
+     * {@link #funcLocaleDate(int, int, AbstractCobolField, AbstractCobolField)}を実行する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 「YYYYMMDD」形式の日付を保持するフィールド
+     * @param localeField ロケールフィールドが指定されなかったことを表すダミー引数
+     * @return ロケールに従って整形した日付文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleDate(
             int offset, int length, AbstractCobolField srcField, int localeField) {
@@ -2601,13 +2787,16 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-DATEに対応する。<br>
+     * 「YYYYMMDD」形式の日付を、指定されたロケール(省略時は既定のロケール)の書式に従って整形した
+     * 日付文字列に変換して返す。<br>
+     * 日付の各要素が有効範囲外の場合は例外を設定し、"0000000000"を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 「YYYYMMDD」形式の日付を保持するフィールド(数値・文字列いずれも可)
+     * @param localeField ロケール名を保持するフィールド。nullの場合は既定のロケールを用いる
+     * @return ロケールに従って整形した日付文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleDate(
             int offset, int length, AbstractCobolField srcField, AbstractCobolField localeField) {
@@ -2688,6 +2877,13 @@ public class CobolIntrinsic {
         return currField;
     }
 
+    /**
+     * {@link #funcLocaleDate}や{@link #funcLocaleTime}などの引数が不正な場合のエラー処理。<br>
+     * 結果フィールドを10桁の"0"で埋め、引数エラーの例外を設定して返す。
+     *
+     * @param field エラー結果を格納するフィールド
+     * @return "0000000000"を保持する結果フィールド
+     */
     private static AbstractCobolField errorFuncLocaleDate(AbstractCobolField field) {
         field.setSize(10);
         makeFieldEntry(field);
@@ -2697,13 +2893,15 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-TIMEに対応するオーバーロード。<br>
+     * ロケールの指定が省略された呼び出しに対応し、既定のロケールで
+     * {@link #funcLocaleTime(int, int, AbstractCobolField, AbstractCobolField)}を実行する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 「hhmmss」形式の時刻を保持するフィールド
+     * @param localeField ロケールフィールドが指定されなかったことを表すダミー引数
+     * @return ロケールに従って整形した時刻文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleTime(
             int offset, int length, AbstractCobolField srcField, int localeField) {
@@ -2711,13 +2909,16 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-TIMEに対応する。<br>
+     * 「hhmmss」形式の時刻を、指定されたロケール(省略時は既定のロケール)の書式に従って整形した
+     * 時刻文字列に変換して返す。<br>
+     * 時・分・秒のいずれかが有効範囲外の場合は例外を設定し、"0000000000"を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 「hhmmss」形式の時刻を保持するフィールド(数値・文字列いずれも可)
+     * @param localeField ロケール名を保持するフィールド。nullの場合は既定のロケールを用いる
+     * @return ロケールに従って整形した時刻文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleTime(
             int offset, int length, AbstractCobolField srcField, AbstractCobolField localeField) {
@@ -2789,13 +2990,14 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-TIME-FROM-SECONDSに対応するオーバーロード。<br>
+     * ロケールの指定が省略された呼び出しに対応し、既定のロケールで処理を実行する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 0時からの経過秒数を保持するフィールド
+     * @param localeField ロケールフィールドが指定されなかったことを表すダミー引数
+     * @return ロケールに従って整形した時刻文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleTimeFromSeconds(
             int offset, int length, AbstractCobolField srcField, int localeField) {
@@ -2803,13 +3005,16 @@ public class CobolIntrinsic {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLの組み込み関数FUNCTION LOCALE-TIME-FROM-SECONDSに対応する。<br>
+     * 0時からの経過秒数を時・分・秒に変換し、指定されたロケール(省略時は既定のロケール)の書式に従って
+     * 整形した時刻文字列に変換して返す。<br>
+     * 引数が数値でない場合は例外を設定し、"0000000000"を返す。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param srcField TODO: 準備中
-     * @param localeField TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
+     * @param length 結果に対する部分参照の長さ
+     * @param srcField 0時からの経過秒数を保持するフィールド
+     * @param localeField ロケール名を保持するフィールド。nullの場合は既定のロケールを用いる
+     * @return ロケールに従って整形した時刻文字列を保持するフィールド
      */
     public static AbstractCobolField funcLocaleTimeFromSeconds(
             int offset, int length, AbstractCobolField srcField, AbstractCobolField localeField) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -445,7 +445,9 @@ public class CobolIntrinsic {
 
     /**
      * COBOLの組み込み関数FUNCTION CURRENT-DATEに対応する。<br>
-     * 現在の日付と時刻を「YYYYMMDDhhmmsshh+ZZZZ」形式の21文字の文字列として返す。
+     * 現在の日付と時刻を「YYYYMMDDHHMMSScc+ZZZZ」形式の21文字の文字列として返す。<br>
+     * ここでccは1/100秒(ミリ秒の上位2桁)を表す。<br>
+     * なおタイムゾーンは未実装のため、末尾の「+ZZZZ」(GMTオフセット)は常にハードコードされた「00000」となる。
      *
      * @param offset 結果に対する部分参照の開始位置(1始まり)。0以下の場合は部分参照を行わない
      * @param length 結果に対する部分参照の長さ

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
@@ -23,16 +23,24 @@ import java.util.List;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
-/** libcob/common.hのcob_moduleに対応するクラス */
+/**
+ * libcob/common.hのcob_moduleに対応するクラス<br>
+ * 実行中のプログラム1つ分の実行時情報(照合順序、小数点文字、通貨記号、各種フラグ、
+ * プログラムID、手続き部の引数など)を保持する。<br>
+ * CALLによる呼び出しの入れ子をモジュールスタックで管理し、現在実行中のモジュールを追跡する。
+ */
 public class CobolModule {
 
+    /** モジュールの呼び出し階層を表すスタック */
     private static List<CobolModule> moduleStack = new ArrayList<CobolModule>();
+
+    /** 現在実行中のモジュール */
     private static CobolModule currentModule;
 
     /**
-     * TODO: 準備中
+     * 現在実行中のモジュールを取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在実行中のモジュール
      */
     public static CobolModule getCurrentModule() {
         return currentModule;
@@ -54,10 +62,12 @@ public class CobolModule {
     }
 
     /**
-     * TODO: 準備中
+     * 呼び出し元プログラムの名前(プログラムID)を指定された記憶領域へ書き込む。<br>
+     * C$NARGなどの呼び出し元情報を取得する機能に相当する。
      *
-     * @param data TODO: 準備中
-     * @return TODO: 準備中
+     * @param data 呼び出し元プログラム名の書き込み先となる記憶領域
+     * @return 呼び出し元の情報を書き込んだ場合は0、呼び出し元が存在しない場合は-1、
+     *     第1引数が存在しない場合は1
      */
     public static int calledBy(CobolDataStorage data) {
         AbstractCobolField param = CobolModule.getCurrentModule().cob_procedure_parameters.get(0);
@@ -80,68 +90,68 @@ public class CobolModule {
     /**
      * モジュールキューが空かどうか
      *
-     * @return TODO: 準備中
+     * @return モジュールスタックが空の場合はtrue、そうでない場合はfalse
      */
     public static boolean isQueueEmpty() {
         return moduleStack.isEmpty();
     }
 
-    /** TODO: 準備中 */
+    /** スタック上の次の(呼び出し元の)モジュール */
     // private CobolModule next;
-    /** TODO: 準備中 */
+    /** PROGRAM COLLATING SEQUENCEで指定された照合順序 */
     public CobolDataStorage collating_sequence;
 
-    /** TODO: 準備中 */
+    /** 画面入出力時のCRT STATUS */
     // private AbstractCobolField cut_status;
-    /** TODO: 準備中 */
+    /** 画面入出力時のカーソル位置 */
     // private AbstractCobolField cursor_pos;
-    /** TODO: 準備中 */
+    /** 符号の表示方法(DISPLAY SIGN) */
     public int display_sign;
 
-    /** TODO: 準備中 */
+    /** 小数点として用いる文字 */
     public char decimal_point;
 
-    /** TODO: 準備中 */
+    /** 通貨記号として用いる文字 */
     public char currency_symbol;
 
-    /** TODO: 準備中 */
+    /** 桁区切りとして用いる文字 */
     // private char numeric_separator;
-    /** TODO: 準備中 */
+    /** ファイル名のマッピングを行うかどうかのフラグ */
     public int flag_filename_mapping;
 
-    /** TODO: 準備中 */
+    /** 2進数項目の桁あふれを切り捨てるかどうかのフラグ */
     public int flag_binary_truncate;
 
-    /** TODO: 準備中 */
+    /** DISPLAY文の整形出力を行うかどうかのフラグ */
     public int flag_pretty_display;
 
-    /** TODO: 準備中 */
+    /** 予約領域 */
     // private int spare8;
-    /** TODO: 準備中 */
+    /** プログラムID(プログラム名) */
     private String program_id;
 
-    /** TODO: 準備中 */
+    /** プログラムのパッケージ名 */
     // private String packageName;
 
-    /** TODO: 準備中 */
+    /** 手続き部に渡された引数(USING句の引数)のリスト */
     public List<AbstractCobolField> cob_procedure_parameters;
 
     /**
      * コンストラクタ
      *
-     * @param next TODO: 準備中
-     * @param collatingSequence TODO: 準備中
-     * @param cutStatus TODO: 準備中
-     * @param cursorPos TODO: 準備中
-     * @param displaySign TODO: 準備中
-     * @param decimalPoint TODO: 準備中
-     * @param currencySymbol TODO: 準備中
-     * @param numericSeparator TODO: 準備中
-     * @param flagFilenameMapping TODO: 準備中
-     * @param flagBinaryTruncate TODO: 準備中
-     * @param flagPrettyDisplay TODO: 準備中
-     * @param spare8 TODO: 準備中
-     * @param programId TODO: 準備中
+     * @param next スタック上の次の(呼び出し元の)モジュール
+     * @param collatingSequence PROGRAM COLLATING SEQUENCEで指定された照合順序
+     * @param cutStatus 画面入出力時のCRT STATUS
+     * @param cursorPos 画面入出力時のカーソル位置
+     * @param displaySign 符号の表示方法(DISPLAY SIGN)
+     * @param decimalPoint 小数点として用いる文字
+     * @param currencySymbol 通貨記号として用いる文字
+     * @param numericSeparator 桁区切りとして用いる文字
+     * @param flagFilenameMapping ファイル名のマッピングを行うかどうかのフラグ
+     * @param flagBinaryTruncate 2進数項目の桁あふれを切り捨てるかどうかのフラグ
+     * @param flagPrettyDisplay DISPLAY文の整形出力を行うかどうかのフラグ
+     * @param spare8 予約領域
+     * @param programId プログラムID(プログラム名)
      */
     public CobolModule(
             CobolModule next,
@@ -175,9 +185,9 @@ public class CobolModule {
     }
 
     /**
-     * TODO 実装
+     * このモジュールのプログラムID(プログラム名)を設定する。
      *
-     * @param programName TODO: 準備中
+     * @param programName 設定するプログラム名
      */
     public void setProgramId(String programName) {
         if (this.program_id != null) {
@@ -187,9 +197,10 @@ public class CobolModule {
     }
 
     /**
-     * TODO: 準備中
+     * このモジュールの手続き部の引数(USING句の引数)を設定する。<br>
+     * 既存の引数をすべて消去した上で、指定された引数で置き換える。
      *
-     * @param field TODO: 準備中
+     * @param field 手続き部に渡す引数の並び
      */
     public void setParameters(AbstractCobolField... field) {
         cob_procedure_parameters.clear();
@@ -199,9 +210,9 @@ public class CobolModule {
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中のモジュールにおける小数点文字を取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在のモジュールの小数点文字
      */
     public static int getDecimalPoint() {
         return currentModule.decimal_point;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolModule.java
@@ -66,8 +66,9 @@ public class CobolModule {
      * C$NARGなどの呼び出し元情報を取得する機能に相当する。
      *
      * @param data 呼び出し元プログラム名の書き込み先となる記憶領域
-     * @return 呼び出し元の情報を書き込んだ場合は0、呼び出し元が存在しない場合は-1、
-     *     第1引数が存在しない場合は1
+     * @return 呼び出し元の情報を書き込んだ場合、または第1引数が存在しない場合は1、
+     *     呼び出し元が存在しない場合(空白を書き込んだ場合)は0、
+     *     呼び出し元のプログラムIDがnullの場合は-1
      */
     public static int calledBy(CobolDataStorage data) {
         AbstractCobolField param = CobolModule.getCurrentModule().cob_procedure_parameters.get(0);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -27,69 +27,120 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
+/** UNSTRING文で使用される1個の区切り文字(DELIMITED BY指定)を保持するクラス。 */
 class Dlm {
+    /** 区切り文字を表すフィールド。 */
     public AbstractCobolField dlm;
+
+    /** DELIMITED BY ALL指定の有無を表す値(0以外でALL指定あり)。 */
     public int all;
 }
 
-/** TODO: 準備中 */
+/**
+ * COBOLのSTRING文およびUNSTRING文の処理を実装するクラス。<br>
+ * libcobのstrings.cに対応する。<br>
+ * STRING文は{@code stringInit}→{@code stringDelimited}/{@code stringAppend}を繰り返し→{@code stringFinish}の順に、
+ * UNSTRING文は{@code unstringInit}→{@code unstringDelimited}/{@code unstringInto}を繰り返し→{@code unstringTallying}→{@code unstringFinish}の順に、
+ * それぞれ静的メソッドを呼び出すことで実行される。<br>
+ * 処理途中の状態(対象フィールド・オフセット・区切り文字など)はクラスの静的フィールドに保持される。
+ *
+ * @see AbstractCobolField
+ */
 public class CobolString {
+    /** UNSTRING文の区切り文字リストの既定の確保数。 */
     private static final int DLM_DEFAULT_NUM = 8;
 
+    /** 現在確保している区切り文字リスト({@link #dlmList})の要素数。 */
     private static int udlmCount = 0;
 
+    /** STRING文の連結先(INTO)フィールド。 */
     private static AbstractCobolField stringDst;
+
+    /** STRING文の文字位置(WITH POINTER)フィールド。指定されない場合はnull。 */
     private static AbstractCobolField stringPtr;
+
+    /** STRING文の現在の区切り文字(DELIMITED BY)フィールド。指定されない場合はnull。 */
     private static AbstractCobolField stringDlm;
+
+    /** STRING文の連結先フィールドの保持用コピー。 */
     private static AbstractCobolField stringDstCopy;
+
+    /** STRING文の文字位置フィールドの保持用コピー。 */
     private static AbstractCobolField stringPtrCopy;
+
+    /** STRING文の区切り文字フィールドの保持用コピー。 */
     private static AbstractCobolField stringDlmCopy;
+
+    /** STRING文で次に書き込む連結先フィールド内のオフセット(バイト単位)。 */
     private static int stringOffset;
 
+    /** UNSTRING文で使用する区切り文字(DELIMITED BY)のリスト。 */
     private static Dlm[] dlmList;
+
+    /** UNSTRING文の分解対象(送り出し元)フィールド。 */
     private static AbstractCobolField unstringSrc;
+
+    /** UNSTRING文の文字位置(WITH POINTER)フィールド。指定されない場合はnull。 */
     private static AbstractCobolField unstringPtr;
+
+    /** UNSTRING文の分解対象フィールドの保持用コピー。 */
     private static AbstractCobolField unstringSrcCopy;
+
+    /** UNSTRING文の文字位置フィールドの保持用コピー。 */
     private static AbstractCobolField unstringPtrCopy;
+
+    /** UNSTRING文で次に読み込む分解対象フィールド内のオフセット(バイト単位)。 */
     private static int unstringOffset;
+
+    /** UNSTRING文で分解した部分文字列の個数(TALLYING IN用のカウンタ)。 */
     private static int unstringCount;
+
+    /** UNSTRING文で現在登録されている区切り文字の個数。 */
     private static int unstringNdlms;
 
     /**
-     * TODO: 準備中
+     * STRING文の処理を開始する。連結先フィールドが省略された場合のオーバーロード。<br>
+     * 連結先(dst)が指定されない場合に、整数のダミー引数を受け取って{@link #stringInit(AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param ptr TODO: 準備中
+     * @param dst 連結先フィールドが省略されたことを表すダミー引数
+     * @param ptr 文字位置(WITH POINTER)フィールド
      */
     public static void stringInit(int dst, AbstractCobolField ptr) {
         stringInit(null, ptr);
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の処理を開始する。文字位置フィールドが省略された場合のオーバーロード。<br>
+     * 文字位置(ptr)が指定されない場合に、整数のダミー引数を受け取って{@link #stringInit(AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param ptr TODO: 準備中
+     * @param dst 連結先(INTO)フィールド
+     * @param ptr 文字位置フィールドが省略されたことを表すダミー引数
      */
     public static void stringInit(AbstractCobolField dst, int ptr) {
         stringInit(dst, null);
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の処理を開始する。連結先・文字位置の両フィールドが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #stringInit(AbstractCobolField, AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param ptr TODO: 準備中
+     * @param dst 連結先フィールドが省略されたことを表すダミー引数
+     * @param ptr 文字位置フィールドが省略されたことを表すダミー引数
      */
     public static void stringInit(int dst, int ptr) {
         stringInit(null, null);
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の処理を開始する。<br>
+     * 連結先フィールドと文字位置フィールドを保持して内部状態を初期化し、文字位置が指定されている場合は
+     * その値から書き込み開始オフセットを設定する。開始位置が連結先の範囲外であればオーバーフロー例外を設定する。<br>
+     * 連結先が日本語項目の場合はオフセットを2倍(バイト単位)に補正する。
      *
-     * @param dst TODO: 準備中
-     * @param ptr TODO: 準備中
+     * @param dst 連結先(INTO)フィールド
+     * @param ptr 文字位置(WITH POINTER)フィールド。省略時はnull
      */
     public static void stringInit(AbstractCobolField dst, AbstractCobolField ptr) {
         stringDstCopy = dst;
@@ -120,18 +171,21 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の区切り文字を設定する。区切り文字が省略された場合(DELIMITED BY SIZE相当)のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #stringDelimited(AbstractCobolField)}へ委譲する。
      *
-     * @param dlm TODO: 準備中
+     * @param dlm 区切り文字が省略されたことを表すダミー引数
      */
     public static void stringDelimited(int dlm) {
         stringDelimited(null);
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の区切り文字(DELIMITED BY)を設定する。<br>
+     * 以降の{@link #stringAppend(AbstractCobolField)}で連結する送り出し元から、この区切り文字までの部分を連結対象とする。<br>
+     * 連結先が日本語項目の場合は、引用符・空白・ゼロの定数を対応する全角の定数に置き換える。
      *
-     * @param dlm TODO: 準備中
+     * @param dlm 区切り文字フィールド。区切り文字を指定しない(全体を連結する)場合はnull
      */
     public static void stringDelimited(AbstractCobolField dlm) {
         switch (stringDst.getAttribute().getType()) {
@@ -156,18 +210,22 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の送り出し元を連結する。送り出し元が省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #stringAppend(AbstractCobolField)}へ委譲する。
      *
-     * @param src TODO: 準備中
+     * @param src 送り出し元フィールドが省略されたことを表すダミー引数
      */
     public static void stringAppend(int src) {
         stringAppend(null);
     }
 
     /**
-     * TODO: 準備中
+     * STRING文の送り出し元フィールドを連結先へ連結する。<br>
+     * 区切り文字({@link #stringDlm})が設定されている場合は、送り出し元の先頭から区切り文字が現れる手前までを連結対象とする。<br>
+     * 連結先の残り領域に収まらない場合は収まる分だけ連結し、オーバーフロー例外を設定する。<br>
+     * すでに例外が発生している場合は何も行わない。
      *
-     * @param src TODO: 準備中
+     * @param src 連結する送り出し元フィールド
      */
     public static void stringAppend(AbstractCobolField src) {
         if (CobolRuntimeException.code != 0) {
@@ -205,7 +263,11 @@ public class CobolString {
         }
     }
 
-    /** TODO: 準備中 */
+    /**
+     * STRING文の処理を終了する。<br>
+     * 連結先が日本語項目の場合は最終オフセットをバイト単位から文字単位に戻し、文字位置(WITH POINTER)フィールドが
+     * 指定されていれば、次の文字位置(オフセット+1)を書き戻す。
+     */
     public static void stringFinish() {
         int type = stringDst.getAttribute().getType();
         if (type == CobolFieldAttribute.COB_TYPE_NATIONAL
@@ -219,44 +281,53 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の処理を開始する。分解対象・文字位置の両フィールドが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #unstringInit(AbstractCobolField, AbstractCobolField, int)}へ委譲する。
      *
-     * @param src TODO: 準備中
-     * @param ptr TODO: 準備中
-     * @param numDlm TODO: 準備中
+     * @param src 分解対象フィールドが省略されたことを表すダミー引数
+     * @param ptr 文字位置フィールドが省略されたことを表すダミー引数
+     * @param numDlm 区切り文字の個数
      */
     public static void unstringInit(int src, int ptr, int numDlm) {
         unstringInit(null, null, numDlm);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の処理を開始する。文字位置フィールドが省略された場合のオーバーロード。<br>
+     * 文字位置(ptr)に整数のダミー引数を受け取って{@link #unstringInit(AbstractCobolField, AbstractCobolField,
+     * int)}へ委譲する。
      *
-     * @param src TODO: 準備中
-     * @param ptr TODO: 準備中
-     * @param numDlm TODO: 準備中
+     * @param src 分解対象(送り出し元)フィールド
+     * @param ptr 文字位置フィールドが省略されたことを表すダミー引数
+     * @param numDlm 区切り文字の個数
      */
     public static void unstringInit(AbstractCobolField src, int ptr, int numDlm) {
         unstringInit(src, null, numDlm);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の処理を開始する。分解対象フィールドが省略された場合のオーバーロード。<br>
+     * 分解対象(src)に整数のダミー引数を受け取って{@link #unstringInit(AbstractCobolField, AbstractCobolField,
+     * int)}へ委譲する。
      *
-     * @param src TODO: 準備中
-     * @param ptr TODO: 準備中
-     * @param numDlm TODO: 準備中
+     * @param src 分解対象フィールドが省略されたことを表すダミー引数
+     * @param ptr 文字位置(WITH POINTER)フィールド
+     * @param numDlm 区切り文字の個数
      */
     public static void unstringInit(int src, AbstractCobolField ptr, int numDlm) {
         unstringInit(null, ptr, numDlm);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の処理を開始する。<br>
+     * 分解対象フィールドと文字位置フィールドを保持して内部状態を初期化し、区切り文字を格納するリスト({@link #dlmList})を
+     * 必要な個数だけ確保する。文字位置が指定されている場合はその値から読み込み開始オフセットを設定し、
+     * 開始位置が分解対象の範囲外であればオーバーフロー例外を設定する。<br>
+     * 分解対象が日本語項目の場合はオフセットを2倍(バイト単位)に補正する。
      *
-     * @param src TODO: 準備中
-     * @param ptr TODO: 準備中
-     * @param numDlm TODO: 準備中
+     * @param src 分解対象(送り出し元)フィールド
+     * @param ptr 文字位置(WITH POINTER)フィールド。省略時はnull
+     * @param numDlm 区切り文字(DELIMITED BY)の個数
      */
     public static void unstringInit(AbstractCobolField src, AbstractCobolField ptr, int numDlm) {
         unstringSrcCopy = src;
@@ -309,20 +380,24 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の区切り文字を追加する。区切り文字が省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #unstringDelimited(AbstractCobolField, int)}へ委譲する。
      *
-     * @param dlm TODO: 準備中
-     * @param all TODO: 準備中
+     * @param dlm 区切り文字が省略されたことを表すダミー引数
+     * @param all DELIMITED BY ALL指定の有無を表す値
      */
     public static void unstringDelimited(int dlm, int all) {
         unstringDelimited(null, all);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の区切り文字(DELIMITED BY)を1個、区切り文字リストへ追加する。<br>
+     * 分解対象が日本語項目の場合は、引用符・空白・ゼロの定数を対応する全角の定数に置き換える。
+     * 全角空白の場合はさらに全角ブランクの区切り文字も追加する。<br>
+     * allが0以外の場合はDELIMITED BY ALL指定であり、連続する区切り文字をまとめて1個の区切りとして扱う。
      *
-     * @param dlm TODO: 準備中
-     * @param all TODO: 準備中
+     * @param dlm 区切り文字フィールド
+     * @param all DELIMITED BY ALL指定の有無を表す値
      */
     public static void unstringDelimited(AbstractCobolField dlm, int all) {
         AbstractCobolField addDlm = null;
@@ -355,88 +430,108 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。文字数(COUNT IN)が省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側(INTO)フィールド
+     * @param dlm 区切り文字を格納する(DELIMITER IN)フィールド
+     * @param cnt 文字数フィールドが省略されたことを表すダミー引数
      */
     public static void unstringInto(AbstractCobolField dst, AbstractCobolField dlm, int cnt) {
         unstringInto(dst, dlm, null);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。区切り文字格納フィールドが省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側(INTO)フィールド
+     * @param dlm 区切り文字格納フィールドが省略されたことを表すダミー引数
+     * @param cnt 文字数を格納する(COUNT IN)フィールド
      */
     public static void unstringInto(AbstractCobolField dst, int dlm, AbstractCobolField cnt) {
         unstringInto(dst, null, cnt);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。区切り文字格納・文字数の両フィールドが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側(INTO)フィールド
+     * @param dlm 区切り文字格納フィールドが省略されたことを表すダミー引数
+     * @param cnt 文字数フィールドが省略されたことを表すダミー引数
      */
     public static void unstringInto(AbstractCobolField dst, int dlm, int cnt) {
         unstringInto(dst, null, null);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。受け取り側・区切り文字格納・文字数のすべてが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側フィールドが省略されたことを表すダミー引数
+     * @param dlm 区切り文字格納フィールドが省略されたことを表すダミー引数
+     * @param cnt 文字数フィールドが省略されたことを表すダミー引数
      */
     public static void unstringInto(int dst, int dlm, int cnt) {
         unstringInto(null, null, null);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。受け取り側・文字数フィールドが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側フィールドが省略されたことを表すダミー引数
+     * @param dlm 区切り文字を格納する(DELIMITER IN)フィールド
+     * @param cnt 文字数フィールドが省略されたことを表すダミー引数
      */
     public static void unstringInto(int dst, AbstractCobolField dlm, int cnt) {
         unstringInto(null, dlm, null);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。受け取り側・区切り文字格納フィールドが省略された場合のオーバーロード。<br>
+     * いずれも整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側フィールドが省略されたことを表すダミー引数
+     * @param dlm 区切り文字格納フィールドが省略されたことを表すダミー引数
+     * @param cnt 文字数を格納する(COUNT IN)フィールド
      */
     public static void unstringInto(int dst, int dlm, AbstractCobolField cnt) {
         unstringInto(null, null, cnt);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を受け取り側へ格納する。受け取り側フィールドが省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取って{@link #unstringInto(AbstractCobolField, AbstractCobolField,
+     * AbstractCobolField)}へ委譲する。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側フィールドが省略されたことを表すダミー引数
+     * @param dlm 区切り文字を格納する(DELIMITER IN)フィールド
+     * @param cnt 文字数を格納する(COUNT IN)フィールド
      */
     public static void unstringInto(int dst, AbstractCobolField dlm, AbstractCobolField cnt) {
         unstringInto(null, dlm, cnt);
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文の分解結果を1個の受け取り側フィールドへ格納する。<br>
+     * 現在のオフセットから分解対象を走査し、登録された区切り文字のいずれかが見つかればその手前までを、
+     * 見つからなければ残り全体を受け取り側へ転記する。区切り文字が登録されていない場合は受け取り側の桁数分を転記する。<br>
+     * ALL指定の区切り文字では、連続する同一の区切り文字をまとめて読み飛ばす。<br>
+     * 区切り文字格納フィールドが指定されていれば、一致した区切り文字(なければ数字項目はゼロ、それ以外は空白)を転記する。<br>
+     * 文字数フィールドが指定されていれば、転記した文字数(日本語項目では文字単位に換算)を設定する。<br>
+     * すでに例外が発生している場合、または読み込み位置が分解対象の範囲外の場合は何も行わない。
      *
-     * @param dst TODO: 準備中
-     * @param dlm TODO: 準備中
-     * @param cnt TODO: 準備中
+     * @param dst 受け取り側(INTO)フィールド
+     * @param dlm 区切り文字を格納する(DELIMITER IN)フィールド。省略時はnull
+     * @param cnt 転記した文字数を格納する(COUNT IN)フィールド。省略時はnull
      */
     public static void unstringInto(
             AbstractCobolField dst, AbstractCobolField dlm, AbstractCobolField cnt) {
@@ -559,24 +654,31 @@ public class CobolString {
     }
 
     /**
-     * TODO: 準備中
+     * UNSTRING文のTALLYING IN処理。集計先フィールドが省略された場合のオーバーロード。<br>
+     * 整数のダミー引数を受け取り、何も行わない。
      *
-     * @param f TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f 集計先フィールドが省略されたことを表すダミー引数
+     * @throws CobolStopRunException 実行が停止された場合
      */
     public static void unstringTallying(int f) throws CobolStopRunException {}
 
     /**
-     * TODO: 準備中
+     * UNSTRING文のTALLYING IN処理を行う。<br>
+     * これまでに分解した部分文字列の個数({@link #unstringCount})を、集計先フィールドへ加算する。
      *
-     * @param f TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param f 分解した部分文字列の個数を加算する(TALLYING IN)フィールド
+     * @throws CobolStopRunException 実行が停止された場合
      */
     public static void unstringTallying(AbstractCobolField f) throws CobolStopRunException {
         f.addInt(unstringCount);
     }
 
-    /** TODO: 準備中 */
+    /**
+     * UNSTRING文の処理を終了する。<br>
+     * 分解対象にまだ読み込んでいない部分が残っている場合はオーバーフロー例外を設定する。<br>
+     * 分解対象が日本語項目の場合は最終オフセットをバイト単位から文字単位に戻し、文字位置(WITH POINTER)フィールドが
+     * 指定されていれば、次の文字位置(オフセット+1)を書き戻す。
+     */
     public static void unstringFinish() {
         if (unstringOffset < unstringSrc.getSize()) {
             CobolRuntimeException.setException(CobolExceptionId.COB_EC_OVERFLOW_UNSTRING);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -32,96 +32,120 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
 
-/** TDOD: 準備中 */
+/**
+ * COBOLランタイムの各種ユーティリティ機能を提供するクラス。<br>
+ * libcobのcommon.cに相当し、ランタイムの初期化、環境変数の取得・設定、コマンドライン引数(CHAINING)の処理、<br>
+ * ランタイムエラーの報告、SWITCHの設定・取得、参照修飾(reference modification)の境界チェック、<br>
+ * 文字列比較などのヘルパー処理をまとめて提供する。
+ */
 public class CobolUtil {
+    /** I/O操作でREWRITEを暗黙的に行うとみなすかどうかのフラグ(環境変数COB_IO_ASSUME_REWRITEで設定)。 */
     private static boolean cob_io_assume_rewrite = false;
+
+    /** 冗長出力を有効にするかどうかのフラグ(環境変数COB_VERBOSEで設定)。 */
     private static boolean cob_verbose = false;
+
+    /** ランタイムエラー発生時に呼び出されるハンドラのリストの先頭。 */
     private static HandlerList hdlrs = null;
+
+    /** ランタイムエラーメッセージの文字列。 */
     private static String runtime_err_str = null;
 
-    /** TDOD: 準備中 */
+    /** 環境変数COB_DATEで指定された固定日付を保持する。指定がない場合はnull。 */
     public static LocalDateTime cobLocalTm = null;
 
-    /** TDOD: 準備中 */
+    /** ロケール関連の環境変数の値を保持する。 */
     public static String cobLocalEnv = null;
 
-    /** TDOD: 準備中 */
+    /** プログラムに渡されたコマンドライン引数(プログラム名を含まない)。 */
     public static String[] commandLineArgs = null;
 
-    /** TDOD: 準備中 */
+    /** ACCEPT FROM ARGUMENT-VALUE等で参照される、現在のコマンドライン引数のインデックス(1始まり)。 */
     public static int currentArgIndex = 1;
 
-    /** TDOD: 準備中 */
+    /** 符号なし数値のニブル定数Cの扱いを制御するフラグ(環境変数COB_NIBBLE_C_UNSIGNEDで設定)。 */
     public static boolean nibbleCForUnsigned = false;
 
-    /** TDOD: 準備中 */
+    /** COBOLのプログラムスイッチ(SWITCH-1〜SWITCH-8)の状態。インデックス0が1番目に対応する。 */
     public static boolean[] cobSwitch = new boolean[8];
 
-    /** TDOD: 準備中 */
+    /** CALL文で呼び出された際に渡されたパラメータ数を保存する。 */
     public static int cobSaveCallParams = 0;
 
-    /** TDOD: 準備中 */
+    /** 冗長出力を有効にするかどうかのフラグ。 */
     public static boolean verbose = false;
 
-    /** TDOD: 準備中 */
+    /** プログラム終了時にエラーが発生したことを示すフラグ。 */
     public static boolean cobErrorOnExitFlag = false;
 
-    /** TDOD: 準備中 */
+    /** 現在日時を取得するためのCalendarインスタンス。 */
     public static Calendar cal;
 
-    /** TDOD: 準備中 */
+    /** 順編成ファイルへの書き込みバッファサイズ(環境変数COB_FILE_SEQ_WRITE_BUFFER_SIZEで設定)。 */
     public static int fileSeqWriteBufferSize = 10;
 
     /** DISPLAY/ACCEPT文によるデータ出力時のエンコーディング */
     public static CobolEncoding terminalEncoding = CobolEncoding.SHIFT_JIS;
 
+    /** 行トレース(READY TRACE)が有効かどうかのフラグ。 */
     private static boolean lineTrace = false;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中のソースファイル名。 */
     private static String sourceFile;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中のソース行番号。 */
     private static int sourceLine;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中のプログラムID。 */
     private static String currProgramId;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中のセクション名。 */
     private static String currSection;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中の段落(パラグラフ)名。 */
     private static String currParagraph;
 
-    /** TDOD: 準備中 */
+    /** 現在実行中の文(ステートメント)の名称。 */
     private static String sourceStatement;
 
+    /**
+     * ランタイムエラー発生時に呼び出されるハンドラを連結リストとして表す抽象クラス。<br>
+     * libcobのcob_runtime_error_handlerに相当する。
+     */
     abstract static class HandlerList {
+        /** リスト上の次のハンドラ。末尾の場合はnull。 */
         public HandlerList next = null;
 
+        /**
+         * エラーメッセージを処理する。
+         *
+         * @param s エラーメッセージ文字列
+         * @return ハンドラの処理結果
+         */
         public abstract int proc(String s);
     }
 
-    /** TDOD: 準備中 */
+    /** 致命的エラー種別: cob_init()が呼び出されていない。 */
     public static final int FERROR_INITIALIZED = 0;
 
-    /** TDOD: 準備中 */
+    /** 致命的エラー種別: コード生成エラー(報告が必要な内部エラー)。 */
     public static final int FERROR_CODEGEN = 1;
 
-    /** TDOD: 準備中 */
+    /** 致命的エラー種別: CHAININGプログラムの再帰呼び出し。 */
     public static final int FERROR_CHAINING = 2;
 
-    /** TDOD: 準備中 */
+    /** 致命的エラー種別: スタックオーバーフロー(PERFORMの入れ子が深すぎる等)。 */
     public static final int FERROR_STACK = 3;
 
     private static Properties envVarTable = new Properties();
 
     // libcob/common.cのcob_check_envの実装
     /**
-     * TODO: 準備中
+     * 指定した環境変数の値が、指定した値と一致するかどうかを判定する。
      *
-     * @param name TODO: 準備中
-     * @param value TODO: 準備中
-     * @return TODO: 準備中
+     * @param name 環境変数名
+     * @param value 比較対象の値
+     * @return 環境変数が存在し値が一致する場合は1、それ以外(引数がnullの場合を含む)は0
      */
     public static int checkEnv(String name, String value) {
         if (name == null || value == null) {
@@ -138,22 +162,23 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * I/O操作でREWRITEを暗黙的に行うとみなす設定が有効かどうかを返す。
      *
-     * @return TODO: 準備中
+     * @return 暗黙のREWRITEが有効な場合はtrue、そうでない場合はfalse
      */
     public static boolean cob_io_rewwrite_assumed() {
         return cob_io_assume_rewrite;
     }
 
     /**
-     * TODO: 準備中
+     * 日本語項目(NATIONAL)に対する参照修飾の境界チェックを行う。<br>
+     * 1文字が2バイトであることを考慮し、各値を文字単位に換算してから境界チェックを実行する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(バイト単位、1始まり)
+     * @param length 参照修飾の長さ(バイト単位)
+     * @param size 対象項目の全体サイズ(バイト単位)
+     * @param name 対象項目の名前(バイト配列)
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefModNational(int offset, long length, int size, byte[] name)
             throws CobolStopRunException {
@@ -161,13 +186,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 日本語項目(NATIONAL)に対する参照修飾の境界チェックを行う。<br>
+     * 1文字が2バイトであることを考慮し、各値を文字単位に換算してから境界チェックを実行する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(バイト単位、1始まり)
+     * @param length 参照修飾の長さ(バイト単位)
+     * @param size 対象項目の全体サイズ(バイト単位)
+     * @param name 対象項目の名前
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefModNational(int offset, long length, int size, String name)
             throws CobolStopRunException {
@@ -175,14 +201,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 参照修飾の境界チェックを行う。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @param nameLen TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(1始まり)
+     * @param length 参照修飾の長さ
+     * @param size 対象項目の全体サイズ
+     * @param name 対象項目の名前を保持するデータストレージ
+     * @param nameLen 対象項目の名前の長さ(バイト数)
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefMod(
             int offset, long length, int size, CobolDataStorage name, int nameLen)
@@ -191,14 +217,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 参照修飾の境界チェックを行う。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @param nameLen TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(1始まり)
+     * @param length 参照修飾の長さ
+     * @param size 対象項目の全体サイズ
+     * @param name 対象項目の名前(バイト配列)
+     * @param nameLen 対象項目の名前の長さ(バイト数)
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefMod(int offset, long length, int size, byte[] name, int nameLen)
             throws CobolStopRunException {
@@ -206,13 +232,13 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 参照修飾の境界チェックを行う。バイト配列の名前をSHIFT_JISの文字列に変換して処理する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(1始まり)
+     * @param length 参照修飾の長さ
+     * @param size 対象項目の全体サイズ
+     * @param name 対象項目の名前(バイト配列)
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefMod(int offset, long length, int size, byte[] name)
             throws CobolStopRunException {
@@ -221,14 +247,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 参照修飾の境界チェックを行う。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @param nameLen TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(1始まり)
+     * @param length 参照修飾の長さ
+     * @param size 対象項目の全体サイズ
+     * @param name 対象項目の名前
+     * @param nameLen 対象項目の名前の長さ(バイト数)
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefMod(int offset, long length, int size, String name, int nameLen)
             throws CobolStopRunException {
@@ -236,13 +262,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 参照修飾(reference modification)の開始位置と長さが項目の境界内に収まっているかをチェックする。<br>
+     * 境界外の場合はCOB_EC_BOUND_REF_MOD例外を設定し、ランタイムエラーを出力して実行を停止する。
      *
-     * @param offset TODO: 準備中
-     * @param length TODO: 準備中
-     * @param size TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param offset 参照修飾の開始位置(1始まり)
+     * @param length 参照修飾の長さ
+     * @param size 対象項目の全体サイズ
+     * @param name 対象項目の名前
+     * @throws CobolStopRunException 参照修飾が境界外でランタイムを停止する場合
      */
     public static void cobCheckRefMod(int offset, long length, int size, String name)
             throws CobolStopRunException {
@@ -262,11 +289,12 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * BASED項目またはLINKAGE項目が有効なアドレス(非null)を持つかをチェックする。<br>
+     * アドレスがnullの場合はランタイムエラーを出力して実行を停止する。
      *
-     * @param x TODO: 準備中
-     * @param name TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param x チェック対象の項目を指すデータストレージ
+     * @param name 対象項目の名前(バイト配列)
+     * @throws CobolStopRunException アドレスがnullでランタイムを停止する場合
      */
     public static void cobCheckBased(CobolDataStorage x, byte[] name) throws CobolStopRunException {
         if (x == null) {
@@ -276,10 +304,14 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * COBOLランタイムを初期化する。<br>
+     * 未初期化の場合は、コマンドライン引数の保存、各サブシステム(INSPECT/ファイルI/O/組み込み関数)の初期化、<br>
+     * およびCOB_SWITCH_1〜COB_SWITCH_8環境変数によるスイッチ設定を行う。<br>
+     * その後、COB_DATE、COB_VERBOSE、COB_IO_ASSUME_REWRITE、COB_NIBBLE_C_UNSIGNED、<br>
+     * COB_FILE_SEQ_WRITE_BUFFER_SIZE、COB_TERMINAL_ENCODINGなどの環境変数を読み込んでランタイム設定を反映する。
      *
-     * @param argv TODO: 準備中
-     * @param cobInitialized TODO: 準備中
+     * @param argv コマンドライン引数(プログラム名を含まない)
+     * @param cobInitialized すでに初期化済みかどうか。trueの場合はサブシステムの初期化をスキップする
      */
     public static void cob_init(String[] argv, boolean cobInitialized) {
         // TODO 未完成
@@ -366,9 +398,11 @@ public class CobolUtil {
 
     // libcob/common.cとcob_localtime
     /**
-     * TODO: 準備中
+     * 現在のローカル日時を取得する。<br>
+     * 環境変数COB_DATEで固定日付({@link #cobLocalTm})が指定されている場合は、その日付に現在の時刻(時・分・秒)を<br>
+     * 反映した日時を返す。指定がない場合はシステムの現在日時を返す。
      *
-     * @return TODO: 準備中
+     * @return 取得したローカル日時
      */
     public static LocalDateTime localtime() {
         LocalDateTime rt = LocalDateTime.now();
@@ -385,9 +419,10 @@ public class CobolUtil {
 
     // libcob/cob_verbose_outputの実装
     /**
-     * TODO: 準備中
+     * 冗長出力が有効な場合に、メッセージを標準出力へ出力する。<br>
+     * 出力時には先頭に"libcobj: "が付加される。
      *
-     * @param s TODO cob_verboseの初期化
+     * @param s 出力するメッセージ
      */
     public static void verboseOutput(String s) {
         if (cob_verbose) {
@@ -397,9 +432,12 @@ public class CobolUtil {
 
     // libcob/fileio.cのcob_rintime_errorの実装
     /**
-     * TODO: 準備中
+     * ランタイムエラーメッセージを出力する。<br>
+     * 登録済みのエラーハンドラ({@link HandlerList})がある場合は順に呼び出した上で解放し、<br>
+     * ソースファイル名と行番号(判明している場合)を前置して、先頭に"libcobj: "を付けたメッセージを<br>
+     * SHIFT_JISエンコードで標準エラー出力へ書き込む。
      *
-     * @param s TODO: 準備中
+     * @param s 出力するエラーメッセージ
      */
     public static void runtimeError(String s) {
         if (hdlrs != null) {
@@ -431,10 +469,11 @@ public class CobolUtil {
 
     // libcob/common.c cob_get_environment
     /**
-     * TODO: 準備中
+     * 環境変数の値を取得し、指定したフィールドへ格納する。<br>
+     * 指定した名前の環境変数が存在しない場合はCOB_EC_IMP_ACCEPT例外を設定し、空白を格納する。
      *
-     * @param envname TODO: 準備中
-     * @param envval TODO: 準備中
+     * @param envname 取得する環境変数名を保持するフィールド
+     * @param envval 取得した値を格納するフィールド
      */
     public static void getEnvironment(AbstractCobolField envname, AbstractCobolField envval) {
         String p = CobolUtil.getEnv(envname.fieldToString());
@@ -447,19 +486,20 @@ public class CobolUtil {
 
     // libcob/common.cのCOB_CHK_PARMSの実装
     /**
-     * TODO: 準備中
+     * サブルーチン呼び出し時に渡されたパラメータ数を検査する(libcobのCOB_CHK_PARMSに相当)。<br>
+     * 現状の実装では検査処理は行わない。
      *
-     * @param funcName TODO: 準備中
-     * @param numParams TODO: 準備中
+     * @param funcName 検査対象の関数(サブルーチン)名
+     * @param numParams 期待されるパラメータ数
      */
     public static void COB_CHK_PARMS(String funcName, int numParams) {}
 
     // libcob/common.cのcob_get_switchの実装
     /**
-     * TODO: 準備中
+     * 指定したプログラムスイッチの状態を取得する。
      *
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param n スイッチのインデックス(0始まり、SWITCH-1が0に対応する)
+     * @return スイッチがONの場合はtrue、OFFの場合はfalse
      */
     public static boolean getSwitch(int n) {
         return CobolUtil.cobSwitch[n];
@@ -467,10 +507,10 @@ public class CobolUtil {
 
     // libcob/common.cのcob_set_switchの実装
     /**
-     * TODO: 準備中
+     * 指定したプログラムスイッチの状態を設定する。
      *
-     * @param n TODO: 準備中
-     * @param flag TODO: 準備中
+     * @param n スイッチのインデックス(0始まり、SWITCH-1が0に対応する)
+     * @param flag 設定する値。0でOFF、1でONに設定する(それ以外の値の場合は変更しない)
      */
     public static void setSwitch(int n, int flag) {
         if (flag == 0) {
@@ -482,13 +522,14 @@ public class CobolUtil {
 
     // libcob/common.cのalnum_cmpsの実装
     /**
-     * TODO: 準備中
+     * 2つの英数字データを指定したバイト数だけ比較する。<br>
+     * 照合順序(collating sequence)が指定されている場合は、その変換表を適用してから各バイトを比較する。
      *
-     * @param s1 TODO: 準備中
-     * @param s2 TODO: 準備中
-     * @param size TODO: 準備中
-     * @param col TODO: 準備中
-     * @return TODO: 準備中
+     * @param s1 比較対象の1つ目のデータストレージ
+     * @param s2 比較対象の2つ目のデータストレージ
+     * @param size 比較するバイト数
+     * @param col 照合順序の変換表。nullの場合は変換せずバイト値で比較する
+     * @return s1がs2より小さい場合は負、等しい場合は0、大きい場合は正の値
      */
     public static int alnumCmps(
             CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
@@ -514,13 +555,14 @@ public class CobolUtil {
 
     // libcob/common.cのnational_cmpsの実装
     /**
-     * TODO: 準備中
+     * 2つの日本語(NATIONAL)データを指定したバイト数だけ比較する。<br>
+     * 2バイトを1文字として上位バイト・下位バイトを結合した値同士で比較する。
      *
-     * @param s1 TODO: 準備中
-     * @param s2 TODO: 準備中
-     * @param size TODO: 準備中
-     * @param col TODO: 準備中
-     * @return TODO: 準備中
+     * @param s1 比較対象の1つ目のデータストレージ
+     * @param s2 比較対象の2つ目のデータストレージ
+     * @param size 比較するバイト数
+     * @param col 照合順序の変換表(現状の実装では使用しない)
+     * @return s1がs2より小さい場合は負、等しい場合は0、大きい場合は正の値
      */
     public static int nationalCmps(
             CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
@@ -535,21 +577,23 @@ public class CobolUtil {
         return ret;
     }
 
-    /** TODO: 準備中 */
+    /** 行トレース(READY TRACE)を有効にする。以降の実行位置がトレース出力される。 */
     public static void readyTrace() {
         CobolUtil.lineTrace = true;
     }
 
-    /** TODO: 準備中 */
+    /** 行トレース(RESET TRACE)を無効にする。 */
     public static void resetTrace() {
         CobolUtil.lineTrace = false;
     }
 
     /**
-     * TODO: 準備中
+     * 致命的エラーを報告し、ランタイムの実行を停止する。<br>
+     * 指定されたエラー種別に応じたメッセージをランタイムエラーとして出力した後、実行を停止する。
      *
-     * @param fatalError TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param fatalError 致命的エラーの種別。{@link #FERROR_INITIALIZED}、{@link #FERROR_CODEGEN}、{@link
+     *     #FERROR_CHAINING}、{@link #FERROR_STACK}のいずれか
+     * @throws CobolStopRunException 常にランタイムを停止するためにスローされる
      */
     public static void fatalError(int fatalError) throws CobolStopRunException {
         switch (fatalError) {
@@ -573,14 +617,16 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 現在の実行位置(プログラムID、ソースファイル、行番号、セクション、段落、文)を設定する。<br>
+     * これらの情報はランタイムエラー出力やトレースに利用される。<br>
+     * 行トレースが有効な場合は、プログラムID・行番号・文をトレースとして標準エラー出力へ出力する。
      *
-     * @param progId TODO: 準備中
-     * @param sfile TODO: 準備中
-     * @param sline TODO: 準備中
-     * @param csect TODO: 準備中
-     * @param cpara TODO: 準備中
-     * @param cstatement TODO: 準備中
+     * @param progId 現在のプログラムID
+     * @param sfile 現在のソースファイル名
+     * @param sline 現在のソース行番号
+     * @param csect 現在のセクション名
+     * @param cpara 現在の段落(パラグラフ)名
+     * @param cstatement 現在の文(ステートメント)の名称。nullの場合は更新しない
      */
     public static void setLocation(
             String progId, String sfile, int sline, String csect, String cpara, String cstatement) {
@@ -603,10 +649,11 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 環境変数の値を取得する。<br>
+     * まず{@link #setEnv}で設定された内部テーブルを参照し、存在しない場合はシステムの環境変数を参照する。
      *
-     * @param envVarName TODO: 準備中
-     * @return TODO: 準備中
+     * @param envVarName 取得する環境変数名
+     * @return 環境変数の値。存在しない場合はnull
      */
     public static String getEnv(String envVarName) {
         String envVarInTable = CobolUtil.envVarTable.getProperty(envVarName);
@@ -639,65 +686,65 @@ public class CobolUtil {
     }
 
     /**
-     * TODO: 準備中
+     * 文字列をSHIFT_JISエンコードのバイト配列に変換する。
      *
-     * @param s TODO: 準備中
-     * @return TODO: 準備中
+     * @param s 変換する文字列
+     * @return SHIFT_JISでエンコードしたバイト配列
      */
     public static byte[] stringToBytes(String s) {
         return s.getBytes(AbstractCobolField.charSetSJIS);
     }
 
     /**
-     * TODO: 準備中
+     * 可変長引数で渡されたバイト列をバイト配列として返す。
      *
-     * @param bytes TODO: 準備中
-     * @return TODO: 準備中
+     * @param bytes バイト配列に変換するバイト列
+     * @return 渡されたバイト列からなるバイト配列
      */
     public static byte[] toBytes(byte... bytes) {
         return bytes;
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中のプログラムIDを取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在のプログラムID
      */
     public static String getCurrProgramId() {
         return currProgramId;
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中のセクション名を取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在のセクション名
      */
     public static String getCurrSection() {
         return currSection;
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中の段落(パラグラフ)名を取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在の段落名
      */
     public static String getCurrParagraph() {
         return currParagraph;
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中のソース行番号を取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在のソース行番号
      */
     public static int getSourceLine() {
         return sourceLine;
     }
 
     /**
-     * TODO: 準備中
+     * 現在実行中の文(ステートメント)の名称を取得する。
      *
-     * @return TODO: 準備中
+     * @return 現在の文の名称
      */
     public static String getSourceStatement() {
         return sourceStatement;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/GetAbstractCobolField.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/GetAbstractCobolField.java
@@ -21,13 +21,16 @@ package jp.osscons.opensourcecobol.libcobj.common;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * {@link AbstractCobolField}を返す処理を遅延実行するための関数型インターフェイス<br>
+ * 生成されたJavaコード中で、COBOLフィールドを後から評価したい箇所(コールバック)を表現するために用いる。
+ */
 public interface GetAbstractCobolField {
     /**
-     * TODO: 準備中
+     * 処理を実行し、結果の{@link AbstractCobolField}を返す。
      *
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @return 処理結果のCOBOLフィールド
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     AbstractCobolField run() throws CobolStopRunException;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/GetInt.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/GetInt.java
@@ -20,13 +20,16 @@ package jp.osscons.opensourcecobol.libcobj.common;
 
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * int型の値を返す処理を遅延実行するための関数型インターフェイス<br>
+ * 生成されたJavaコード中で、int型の値を後から評価したい箇所(コールバック)を表現するために用いる。
+ */
 public interface GetInt {
     /**
-     * TODO: 準備中
+     * 処理を実行し、結果のint型の値を返す。
      *
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @return 処理結果のint型の値
+     * @throws CobolStopRunException 処理中にSTOP RUNが実行された場合
      */
     int run() throws CobolStopRunException;
 }


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/787 に関するPR

# 概要

`libcobj/common` パッケージ配下のクラスに対して Javadoc を追加・整備した。
ソースコードの動作に影響する変更は含まれておらず、ドキュメンテーションコメントのみの更新である。

# 変更点

- `libcobj/common` 配下の以下12ファイルについて、クラス・メソッド・フィールドの Javadoc を追加・更新した。
  - `CobolCallParams.java`
  - `CobolCheck.java`
  - `CobolConstant.java`
  - `CobolControl.java`
  - `CobolExternal.java`
  - `CobolInspect.java`
  - `CobolIntrinsic.java`
  - `CobolModule.java`
  - `CobolString.java`
  - `CobolUtil.java`
  - `GetAbstractCobolField.java`
  - `GetInt.java`

# その他

- 本PRはJavadoc（コメント）の追加・修正のみで、実行ロジックの変更は含まれていない。
