### PR TITLE
doc: add Javadoc to INDEXED file related classes

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
@@ -21,20 +21,19 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /**
- * Describes a single key (primary or alternate) of an INDEXED file.
+ * INDEXEDファイルの1つのキー（主キーまたは副キー）を表す。
  *
- * <p>The compiler ({@code cobj}) generates one {@code CobolFileKey} per {@code RECORD KEY} / {@code
- * ALTERNATE RECORD KEY} declared in a {@code SELECT} clause and passes the resulting array to
- * {@link CobolFileFactory#makeCobolFileInstance}. Each entry carries the COBOL field that holds the
- * key value, a duplicates flag, the byte offset of the key within the record, and—when the key is a
- * SPLIT KEY—the list of {@link KeyComponent}s that make it up.
+ * <p>コンパイラ（{@code cobj}）は、{@code SELECT}句で宣言された{@code RECORD KEY} / {@code ALTERNATE RECORD
+ * KEY}ごとに{@code CobolFileKey}を1つ生成し、その配列を{@link
+ * CobolFileFactory#makeCobolFileInstance}に渡す。各要素は、キー値を保持するCOBOLフィールド、重複フラグ、レコード内でのキーのバイトオフセット、そしてキーがSPLIT
+ * KEYの場合はそれを構成する{@link KeyComponent}のリストを保持する。
  *
- * <p>In the SQLite storage used by {@link CobolIndexedFile}, the entry at index {@code 0} is the
- * primary key (stored in {@code table0}) and entries at index {@code i >= 1} are alternate keys
- * (stored in {@code tableI}).
+ * <p>{@link
+ * CobolIndexedFile}が利用するSQLiteストレージでは、インデックス{@code 0}の要素が主キー（{@code table0}に格納）であり、インデックス{@code
+ * i >= 1}の要素が副キー（{@code tableI}に格納）である。
  */
 public class CobolFileKey {
-    /** The maximum number of {@link KeyComponent}s a single SPLIT KEY may consist of. */
+    /** 1つのSPLIT KEYを構成できる{@link KeyComponent}の最大数。 */
     public static final int COB_MAX_KEY_COMPONENTS = 8;
 
     private AbstractCobolField field;
@@ -44,107 +43,105 @@ public class CobolFileKey {
     private KeyComponent[] component = new KeyComponent[COB_MAX_KEY_COMPONENTS];
 
     /**
-     * Returns the COBOL field that holds the value of this key.
+     * このキーの値を保持するCOBOLフィールドを返す。
      *
-     * @return the key field
+     * @return キーフィールド
      */
     public AbstractCobolField getField() {
         return field;
     }
 
     /**
-     * Sets the COBOL field that holds the value of this key.
+     * このキーの値を保持するCOBOLフィールドを設定する。
      *
-     * @param field the key field
+     * @param field キーフィールド
      */
     public void setField(AbstractCobolField field) {
         this.field = field;
     }
 
     /**
-     * Returns the duplicates flag of this key.
+     * このキーの重複フラグを返す。
      *
-     * @return {@code 0} if duplicate values are not allowed (primary key or {@code ALTERNATE RECORD
-     *     KEY} without {@code WITH DUPLICATES}), or a non-zero value if duplicates are allowed
-     *     ({@code ALTERNATE RECORD KEY ... WITH DUPLICATES})
+     * @return 重複値を許可しない場合（主キー、または{@code WITH DUPLICATES}なしの{@code ALTERNATE RECORD
+     *     KEY}）は{@code 0}、重複値を許可する場合（{@code ALTERNATE RECORD KEY ... WITH
+     *     DUPLICATES}）は非ゼロ値
      */
     public int getFlag() {
         return flag;
     }
 
     /**
-     * Sets the duplicates flag of this key.
+     * このキーの重複フラグを設定する。
      *
-     * @param flag {@code 0} to disallow duplicate values, or a non-zero value to allow them
+     * @param flag 重複値を許可しない場合は{@code 0}、許可する場合は非ゼロ値
      */
     public void setFlag(int flag) {
         this.flag = flag;
     }
 
     /**
-     * Returns the byte offset of this key within the record.
+     * レコード内でのこのキーのバイトオフセットを返す。
      *
-     * @return the 0-origin byte offset from the beginning of the record, or {@code -1} when the key
-     *     is a SPLIT KEY (in which case the layout is described by {@link #getComponent()})
+     * @return レコード先頭からの0始まりのバイトオフセット。キーがSPLIT KEYの場合は{@code
+     *     -1}（その場合のレイアウトは{@link #getComponent()}で記述される）
      */
     public int getOffset() {
         return offset;
     }
 
     /**
-     * Sets the byte offset of this key within the record.
+     * レコード内でのこのキーのバイトオフセットを設定する。
      *
-     * @param offset the 0-origin byte offset from the beginning of the record, or {@code -1} for a
-     *     SPLIT KEY
+     * @param offset レコード先頭からの0始まりのバイトオフセット。SPLIT KEYの場合は{@code -1}
      */
     public void setOffset(int offset) {
         this.offset = offset;
     }
 
     /**
-     * Returns the number of {@link KeyComponent}s that make up this key.
+     * このキーを構成する{@link KeyComponent}の数を返す。
      *
-     * @return the number of valid entries in the array returned by {@link #getComponent()}; a SPLIT
-     *     KEY has two or more, an ordinary key has zero
+     * @return {@link
+     *     #getComponent()}が返す配列のうち有効な要素数。SPLIT KEYは2以上、通常のキーは0
      */
     public int getCountComponents() {
         return countComponents;
     }
 
     /**
-     * Sets the number of {@link KeyComponent}s that make up this key.
+     * このキーを構成する{@link KeyComponent}の数を設定する。
      *
-     * @param countComponents the number of valid entries in the component array
+     * @param countComponents 構成要素配列のうち有効な要素数
      */
     public void setCountComponents(int countComponents) {
         this.countComponents = countComponents;
     }
 
     /**
-     * Returns the array of {@link KeyComponent}s describing a SPLIT KEY.
+     * SPLIT KEYを記述する{@link KeyComponent}の配列を返す。
      *
-     * <p>Only the first {@link #getCountComponents()} entries are meaningful.
+     * <p>有効なのは先頭{@link #getCountComponents()}個の要素のみである。
      *
-     * @return the component array (never {@code null}; its capacity is {@link
-     *     #COB_MAX_KEY_COMPONENTS})
+     * @return 構成要素配列（{@code null}にはならない。容量は{@link #COB_MAX_KEY_COMPONENTS}）
      */
     public KeyComponent[] getComponent() {
         return component;
     }
 
     /**
-     * Sets the array of {@link KeyComponent}s describing a SPLIT KEY.
+     * SPLIT KEYを記述する{@link KeyComponent}の配列を設定する。
      *
-     * @param component the component array
+     * @param component 構成要素配列
      */
     public void setComponent(KeyComponent[] component) {
         this.component = component;
     }
 
     /**
-     * Returns the maximum number of components a SPLIT KEY may consist of.
+     * SPLIT KEYを構成できる要素の最大数を返す。
      *
-     * @return the value of {@link #COB_MAX_KEY_COMPONENTS}
+     * @return {@link #COB_MAX_KEY_COMPONENTS}の値
      */
     public static int getCobMaxKeyComponents() {
         return COB_MAX_KEY_COMPONENTS;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
@@ -20,9 +20,21 @@ package jp.osscons.opensourcecobol.libcobj.file;
 
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
-/** TODO: 準備中 */
+/**
+ * Describes a single key (primary or alternate) of an INDEXED file.
+ *
+ * <p>The compiler ({@code cobj}) generates one {@code CobolFileKey} per {@code RECORD KEY} / {@code
+ * ALTERNATE RECORD KEY} declared in a {@code SELECT} clause and passes the resulting array to
+ * {@link CobolFileFactory#makeCobolFileInstance}. Each entry carries the COBOL field that holds the
+ * key value, a duplicates flag, the byte offset of the key within the record, and—when the key is a
+ * SPLIT KEY—the list of {@link KeyComponent}s that make it up.
+ *
+ * <p>In the SQLite storage used by {@link CobolIndexedFile}, the entry at index {@code 0} is the
+ * primary key (stored in {@code table0}) and entries at index {@code i >= 1} are alternate keys
+ * (stored in {@code tableI}).
+ */
 public class CobolFileKey {
-    /** TODO: 準備中 */
+    /** The maximum number of {@link KeyComponent}s a single SPLIT KEY may consist of. */
     public static final int COB_MAX_KEY_COMPONENTS = 8;
 
     private AbstractCobolField field;
@@ -32,99 +44,107 @@ public class CobolFileKey {
     private KeyComponent[] component = new KeyComponent[COB_MAX_KEY_COMPONENTS];
 
     /**
-     * TODO: 準備中
+     * Returns the COBOL field that holds the value of this key.
      *
-     * @return TODO: 準備中
+     * @return the key field
      */
     public AbstractCobolField getField() {
         return field;
     }
 
     /**
-     * TODO: 準備中
+     * Sets the COBOL field that holds the value of this key.
      *
-     * @param field TODO: 準備中
+     * @param field the key field
      */
     public void setField(AbstractCobolField field) {
         this.field = field;
     }
 
     /**
-     * TODO: 準備中
+     * Returns the duplicates flag of this key.
      *
-     * @return TODO: 準備中
+     * @return {@code 0} if duplicate values are not allowed (primary key or {@code ALTERNATE RECORD
+     *     KEY} without {@code WITH DUPLICATES}), or a non-zero value if duplicates are allowed
+     *     ({@code ALTERNATE RECORD KEY ... WITH DUPLICATES})
      */
     public int getFlag() {
         return flag;
     }
 
     /**
-     * TODO: 準備中
+     * Sets the duplicates flag of this key.
      *
-     * @param flag TODO: 準備中
+     * @param flag {@code 0} to disallow duplicate values, or a non-zero value to allow them
      */
     public void setFlag(int flag) {
         this.flag = flag;
     }
 
     /**
-     * TODO: 準備中
+     * Returns the byte offset of this key within the record.
      *
-     * @return TODO: 準備中
+     * @return the 0-origin byte offset from the beginning of the record, or {@code -1} when the key
+     *     is a SPLIT KEY (in which case the layout is described by {@link #getComponent()})
      */
     public int getOffset() {
         return offset;
     }
 
     /**
-     * TODO: 準備中
+     * Sets the byte offset of this key within the record.
      *
-     * @param offset TODO: 準備中
+     * @param offset the 0-origin byte offset from the beginning of the record, or {@code -1} for a
+     *     SPLIT KEY
      */
     public void setOffset(int offset) {
         this.offset = offset;
     }
 
     /**
-     * TODO: 準備中
+     * Returns the number of {@link KeyComponent}s that make up this key.
      *
-     * @return TODO: 準備中
+     * @return the number of valid entries in the array returned by {@link #getComponent()}; a SPLIT
+     *     KEY has two or more, an ordinary key has zero
      */
     public int getCountComponents() {
         return countComponents;
     }
 
     /**
-     * TODO: 準備中
+     * Sets the number of {@link KeyComponent}s that make up this key.
      *
-     * @param countComponents TODO: 準備中
+     * @param countComponents the number of valid entries in the component array
      */
     public void setCountComponents(int countComponents) {
         this.countComponents = countComponents;
     }
 
     /**
-     * TODO: 準備中
+     * Returns the array of {@link KeyComponent}s describing a SPLIT KEY.
      *
-     * @return TODO: 準備中
+     * <p>Only the first {@link #getCountComponents()} entries are meaningful.
+     *
+     * @return the component array (never {@code null}; its capacity is {@link
+     *     #COB_MAX_KEY_COMPONENTS})
      */
     public KeyComponent[] getComponent() {
         return component;
     }
 
     /**
-     * TODO: 準備中
+     * Sets the array of {@link KeyComponent}s describing a SPLIT KEY.
      *
-     * @param component TODO: 準備中
+     * @param component the component array
      */
     public void setComponent(KeyComponent[] component) {
         this.component = component;
     }
 
     /**
-     * TODO: 準備中
+     * Returns the maximum number of components a SPLIT KEY may consist of.
      *
-     * @return TODO: 準備中
+     * @return the value of {@link #COB_MAX_KEY_COMPONENTS}
      */
     public static int getCobMaxKeyComponents() {
         return COB_MAX_KEY_COMPONENTS;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -82,7 +82,7 @@ public class CobolIndexedFile extends CobolFile {
      * FD}宣言の属性に対応する。
      *
      * @param selectName {@code SELECT}句で指定された名前
-     * @param fileStatus COBOLの{@code FILE STATUS}用ストレージ（4バイトのバッファ）
+     * @param fileStatus COBOLの{@code FILE STATUS}用ストレージ（2バイトのバッファ）
      * @param assign 割り当て名（ファイルパス）を保持するフィールド
      * @param record レコード領域を表すフィールド
      * @param recordSize 現在のレコード長を保持するフィールド

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -624,7 +624,7 @@ public class CobolIndexedFile extends CobolFile {
      * @param cond 比較条件（{@link #COB_EQ}、{@link #COB_GT}、{@link #COB_GE}、{@link
      *     #COB_LT}、{@link #COB_LE}, {@link #COB_NE}のいずれか。
      * @param key 検索するキー値を保持するフィールド
-     * @param readOpts 読み込みオプションフラグ（{@code COB_READ_*}）
+     * @param readOpts 現在未使用
      * @param testLock レコードロックをテストするか（現状このメソッドでは未使用）
      * @return condが {@link #COB_NE}の場合 {@code COB_STATUS_23_KEY_NOT_EXISTS}。
      *     そうでない場合、レコードが見つかった場合は{@code COB_STATUS_00_SUCCESS}、一致するものがなかった場合は{@code COB_STATUS_23_KEY_NOT_EXISTS}、カーソル生成に失敗した場合は{@code

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -30,7 +30,23 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import org.sqlite.SQLiteConfig;
 import org.sqlite.SQLiteErrorCode;
 
-/** TODO: 準備中 */
+/**
+ * Concrete {@link CobolFile} implementation for INDEXED files ({@code ORGANIZATION IS INDEXED}).
+ *
+ * <p>Each INDEXED file is backed by a single SQLite database (one file = one database, accessed
+ * through the xerial {@code sqlite-jdbc} driver). The primary key is stored in table {@code table0}
+ * and each alternate key in {@code tableI}; file-wide locks are held in a {@code file_lock} table
+ * and record locks in the {@code locked_by} column of {@code table0}; file metadata (record size
+ * and key layout) is kept in the {@code metadata_*} tables.
+ *
+ * <p>This class overrides the {@code *_} hook methods of {@link CobolFile} (such as {@link
+ * #open_}, {@link #read_}, {@link #write_}, {@link #rewrite_}, {@link #delete_} and {@link
+ * #start_}) and translates each COBOL I/O verb into the corresponding SQL operations. Sequential
+ * navigation ({@code READ NEXT}/{@code READ PREVIOUS}) is emulated with an {@link IndexedCursor}.
+ *
+ * <p>All SQL runs inside an explicit transaction ({@code setAutoCommit(false)},
+ * {@code TRANSACTION_SERIALIZABLE}); each statement commits on success and rolls back on failure.
+ */
 public class CobolIndexedFile extends CobolFile {
     private Optional<IndexedCursor> cursor;
     private boolean updateWhileReading = false;
@@ -40,55 +56,61 @@ public class CobolIndexedFile extends CobolFile {
     private int fetchKeyIndex = -1;
     private byte[] previousLockedRecordKey = null;
 
-    /** TODO: 準備中 */
+    /** Comparison condition for {@code START}/{@code READ}: key is equal ({@code =}). */
     public static final int COB_EQ = 1;
 
-    /** TODO: 準備中 */
+    /** Comparison condition for {@code START}/{@code READ}: key is less than ({@code <}). */
     public static final int COB_LT = 2;
 
-    /** TODO: 準備中 */
+    /** Comparison condition for {@code START}/{@code READ}: key is less than or equal ({@code <=}). */
     public static final int COB_LE = 3;
 
-    /** TODO: 準備中 */
+    /** Comparison condition for {@code START}/{@code READ}: key is greater than ({@code >}). */
     public static final int COB_GT = 4;
 
-    /** TODO: 準備中 */
+    /**
+     * Comparison condition for {@code START}/{@code READ}: key is greater than or equal ({@code
+     * >=}).
+     */
     public static final int COB_GE = 5;
 
-    /** TODO: 準備中 */
+    /** Comparison condition for {@code START}/{@code READ}: key is not equal ({@code <>}). */
     public static final int COB_NE = 6;
 
     private static String storedProcessUuid = null;
     private static String storedProcessId = null;
 
     /**
-     * TODO: 準備中
+     * Constructs an INDEXED file instance. This constructor is normally invoked indirectly from the
+     * generated Java code through {@link CobolFileFactory#makeCobolFileInstance}; its arguments
+     * mirror the attributes of the COBOL {@code SELECT}/{@code FD} declaration.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
+     * @param selectName the name given in the {@code SELECT} clause
+     * @param fileStatus the COBOL {@code FILE STATUS} storage (a 4-byte buffer)
+     * @param assign the field holding the assignment name (file path)
+     * @param record the field that represents the record area
+     * @param recordSize the field that holds the current record length
+     * @param recordMin the minimum record length
+     * @param recordMax the maximum record length
+     * @param nkeys the number of keys (1 primary plus the alternate keys)
+     * @param keys the key descriptors; index {@code 0} is the primary key
+     * @param organization the file organization ({@code COB_ORG_INDEXED} for this class)
+     * @param accessMode the access mode (sequential, dynamic, or random)
+     * @param lockMode the lock mode flags ({@code COB_LOCK_*})
+     * @param openMode the initial open mode
+     * @param flagOptional whether the file is declared {@code OPTIONAL}
+     * @param lastOpenMode the most recent open mode
+     * @param special the special-file flag
+     * @param flagNonexistent whether the file is currently known to be nonexistent
+     * @param flagEndOfFile whether the cursor is positioned at end of file
+     * @param flagBeginOfFile whether the cursor is positioned at beginning of file
+     * @param flagFirstRead whether the next read is the first read
+     * @param flagReadDone whether a read has been performed
+     * @param flagSelectFeatures the OR of select-feature flags ({@code FILE STATUS}, {@code
+     *     LINAGE}, {@code EXTERNAL})
+     * @param flagNeedsNl whether a trailing newline is needed
+     * @param flagNeedsTop whether a top-of-page is needed
+     * @param fileVersion the on-disk format version ({@code COB_FILE_VERSION})
      */
     public CobolIndexedFile(
             String selectName,
@@ -171,20 +193,21 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * Returns the SQLite table name for the key with the given index.
      *
-     * @param index TODO: 準備中
-     * @return TODO: 準備中
+     * @param index the key index ({@code 0} for the primary key, {@code >= 1} for alternate keys)
+     * @return the table name, e.g. {@code "table0"}, {@code "table1"}, ...
      */
     public static String getTableName(int index) {
         return String.format("table%d", index);
     }
 
     /**
-     * TODO: 準備中
+     * Returns the cursor name for the key with the given index.
      *
-     * @param index TODO: 準備中
-     * @return TODO: 準備中
+     * @param index the key index
+     * @return the cursor name, e.g. {@code "cursor0"}, {@code "cursor1"}, ... (currently unused, but
+     *     kept for compatibility)
      */
     public static String getCursorName(int index) {
         return String.format("cursor%d", index);
@@ -195,9 +218,15 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * Controls whether each modifying statement ({@code WRITE}/{@code REWRITE}/{@code DELETE})
+     * commits its transaction immediately.
      *
-     * @param commitOnModification TODO: 準備中
+     * <p>By default this is {@code true}. Bulk loaders such as {@code cobj-idx load} set it to
+     * {@code false} to suppress per-record commits for speed and commit once at the end via {@link
+     * #commitJdbcTransaction()}.
+     *
+     * @param commitOnModification {@code true} to commit after every modification, {@code false} to
+     *     defer committing
      */
     public void setCommitOnModification(boolean commitOnModification) {
         this.commitOnModification = commitOnModification;
@@ -592,13 +621,23 @@ public class CobolIndexedFile extends CobolFile {
 
     // Equivalent to indexed_start_internal in libcob/fileio.c
     /**
-     * TODO: 準備中
+     * Positions the cursor on the first record matching the given key and comparison condition.
      *
-     * @param cond TODO: 準備中
-     * @param key TODO: 準備中
-     * @param readOpts TODO: 準備中
-     * @param testLock TODO: 準備中
-     * @return TODO: 準備中
+     * <p>The key field address is matched against the declared keys to determine which key (and
+     * therefore which SQLite table) to use, a fresh {@link IndexedCursor} is created for that key,
+     * and a single record is fetched. On success the current key/record buffers ({@code p.key} /
+     * {@code p.data}) are updated. This is the shared implementation behind {@link #start_(int,
+     * AbstractCobolField)} and the random {@link #read_(AbstractCobolField, int)}.
+     *
+     * @param cond the comparison condition ({@link #COB_EQ}, {@link #COB_GT}, {@link #COB_GE},
+     *     {@link #COB_LT}, or {@link #COB_LE}; {@link #COB_NE} is not supported and causes the
+     *     cursor to fail)
+     * @param key the field holding the key value to search for
+     * @param readOpts the read option flags ({@code COB_READ_*})
+     * @param testLock whether to test record locks (currently unused by this method)
+     * @return {@code COB_STATUS_00_SUCCESS} if a record was found, {@code
+     *     COB_STATUS_23_KEY_NOT_EXISTS} if none matched, or {@code COB_STATUS_30_PERMANENT_ERROR}
+     *     on a cursor creation failure
      */
     public int indexed_start_internal(
             int cond, AbstractCobolField key, int readOpts, boolean testLock) {
@@ -1362,7 +1401,13 @@ public class CobolIndexedFile extends CobolFile {
         System.err.println("Unlocking INDEXED file is not implemented");
     }
 
-    /** TODO: 準備中 */
+    /**
+     * Commits the current JDBC transaction explicitly.
+     *
+     * <p>Intended for use together with {@link #setCommitOnModification(boolean)}{@code (false)}:
+     * after a batch of modifications has been performed with per-statement committing suppressed,
+     * this method flushes them all in a single commit.
+     */
     public void commitJdbcTransaction() {
         IndexedFile p = this.filei;
         try {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -622,12 +622,12 @@ public class CobolIndexedFile extends CobolFile {
      * AbstractCobolField)}とランダムな{@link #read_(AbstractCobolField, int)}の共通実装である。
      *
      * @param cond 比較条件（{@link #COB_EQ}、{@link #COB_GT}、{@link #COB_GE}、{@link
-     *     #COB_LT}、{@link #COB_LE}のいずれか。{@link #COB_NE}はサポートされておらず、カーソルの生成に失敗する）
+     *     #COB_LT}、{@link #COB_LE}, {@link #COB_NE}のいずれか。
      * @param key 検索するキー値を保持するフィールド
      * @param readOpts 読み込みオプションフラグ（{@code COB_READ_*}）
      * @param testLock レコードロックをテストするか（現状このメソッドでは未使用）
-     * @return レコードが見つかった場合は{@code COB_STATUS_00_SUCCESS}、一致するものがなかった場合は{@code
-     *     COB_STATUS_23_KEY_NOT_EXISTS}、カーソル生成に失敗した場合は{@code
+     * @return condが {@link #COB_NE}の場合 {@code COB_STATUS_23_KEY_NOT_EXISTS}。
+     *     そうでない場合、レコードが見つかった場合は{@code COB_STATUS_00_SUCCESS}、一致するものがなかった場合は{@code COB_STATUS_23_KEY_NOT_EXISTS}、カーソル生成に失敗した場合は{@code
      *     COB_STATUS_30_PERMANENT_ERROR}
      */
     public int indexed_start_internal(

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolIndexedFile.java
@@ -31,21 +31,20 @@ import org.sqlite.SQLiteConfig;
 import org.sqlite.SQLiteErrorCode;
 
 /**
- * Concrete {@link CobolFile} implementation for INDEXED files ({@code ORGANIZATION IS INDEXED}).
+ * INDEXEDファイル（{@code ORGANIZATION IS INDEXED}）向けの{@link CobolFile}の具象実装。
  *
- * <p>Each INDEXED file is backed by a single SQLite database (one file = one database, accessed
- * through the xerial {@code sqlite-jdbc} driver). The primary key is stored in table {@code table0}
- * and each alternate key in {@code tableI}; file-wide locks are held in a {@code file_lock} table
- * and record locks in the {@code locked_by} column of {@code table0}; file metadata (record size
- * and key layout) is kept in the {@code metadata_*} tables.
+ * <p>各INDEXEDファイルは1つのSQLiteデータベースをバックエンドとする（1ファイル＝1データベースであり、xerialの{@code
+ * sqlite-jdbc}ドライバ経由でアクセスする）。主キーは{@code table0}テーブルに、各副キーは{@code
+ * tableI}に格納される。ファイル全体のロックは{@code file_lock}テーブルで、レコードロックは{@code table0}の{@code
+ * locked_by}列で管理する。ファイルのメタデータ（レコードサイズとキーのレイアウト）は{@code metadata_*}テーブルに保持する。
  *
- * <p>This class overrides the {@code *_} hook methods of {@link CobolFile} (such as {@link
- * #open_}, {@link #read_}, {@link #write_}, {@link #rewrite_}, {@link #delete_} and {@link
- * #start_}) and translates each COBOL I/O verb into the corresponding SQL operations. Sequential
- * navigation ({@code READ NEXT}/{@code READ PREVIOUS}) is emulated with an {@link IndexedCursor}.
+ * <p>このクラスは{@link CobolFile}の{@code *_}フックメソッド（{@link #open_}、{@link #read_}、{@link
+ * #write_}、{@link #rewrite_}、{@link #delete_}、{@link
+ * #start_}など）をオーバーライドし、各COBOLのI/O動詞を対応するSQL操作へ変換する。順次ナビゲーション（{@code READ NEXT}／{@code
+ * READ PREVIOUS}）は{@link IndexedCursor}でエミュレートする。
  *
- * <p>All SQL runs inside an explicit transaction ({@code setAutoCommit(false)},
- * {@code TRANSACTION_SERIALIZABLE}); each statement commits on success and rolls back on failure.
+ * <p>すべてのSQLは明示的なトランザクション内で実行され（{@code setAutoCommit(false)}、{@code
+ * TRANSACTION_SERIALIZABLE}）、各文は成功時にコミット、失敗時にロールバックする。
  */
 public class CobolIndexedFile extends CobolFile {
     private Optional<IndexedCursor> cursor;
@@ -56,61 +55,58 @@ public class CobolIndexedFile extends CobolFile {
     private int fetchKeyIndex = -1;
     private byte[] previousLockedRecordKey = null;
 
-    /** Comparison condition for {@code START}/{@code READ}: key is equal ({@code =}). */
+    /** {@code START}/{@code READ}の比較条件：キーが等しい（{@code =}）。 */
     public static final int COB_EQ = 1;
 
-    /** Comparison condition for {@code START}/{@code READ}: key is less than ({@code <}). */
+    /** {@code START}/{@code READ}の比較条件：キーが小さい（{@code <}）。 */
     public static final int COB_LT = 2;
 
-    /** Comparison condition for {@code START}/{@code READ}: key is less than or equal ({@code <=}). */
+    /** {@code START}/{@code READ}の比較条件：キーが小さいか等しい（{@code <=}）。 */
     public static final int COB_LE = 3;
 
-    /** Comparison condition for {@code START}/{@code READ}: key is greater than ({@code >}). */
+    /** {@code START}/{@code READ}の比較条件：キーが大きい（{@code >}）。 */
     public static final int COB_GT = 4;
 
-    /**
-     * Comparison condition for {@code START}/{@code READ}: key is greater than or equal ({@code
-     * >=}).
-     */
+    /** {@code START}/{@code READ}の比較条件：キーが大きいか等しい（{@code >=}）。 */
     public static final int COB_GE = 5;
 
-    /** Comparison condition for {@code START}/{@code READ}: key is not equal ({@code <>}). */
+    /** {@code START}/{@code READ}の比較条件：キーが等しくない（{@code <>}）。 */
     public static final int COB_NE = 6;
 
     private static String storedProcessUuid = null;
     private static String storedProcessId = null;
 
     /**
-     * Constructs an INDEXED file instance. This constructor is normally invoked indirectly from the
-     * generated Java code through {@link CobolFileFactory#makeCobolFileInstance}; its arguments
-     * mirror the attributes of the COBOL {@code SELECT}/{@code FD} declaration.
+     * INDEXEDファイルのインスタンスを構築する。通常このコンストラクタは、生成されたJavaコードから{@link
+     * CobolFileFactory#makeCobolFileInstance}を介して間接的に呼び出される。引数はCOBOLの{@code SELECT}／{@code
+     * FD}宣言の属性に対応する。
      *
-     * @param selectName the name given in the {@code SELECT} clause
-     * @param fileStatus the COBOL {@code FILE STATUS} storage (a 4-byte buffer)
-     * @param assign the field holding the assignment name (file path)
-     * @param record the field that represents the record area
-     * @param recordSize the field that holds the current record length
-     * @param recordMin the minimum record length
-     * @param recordMax the maximum record length
-     * @param nkeys the number of keys (1 primary plus the alternate keys)
-     * @param keys the key descriptors; index {@code 0} is the primary key
-     * @param organization the file organization ({@code COB_ORG_INDEXED} for this class)
-     * @param accessMode the access mode (sequential, dynamic, or random)
-     * @param lockMode the lock mode flags ({@code COB_LOCK_*})
-     * @param openMode the initial open mode
-     * @param flagOptional whether the file is declared {@code OPTIONAL}
-     * @param lastOpenMode the most recent open mode
-     * @param special the special-file flag
-     * @param flagNonexistent whether the file is currently known to be nonexistent
-     * @param flagEndOfFile whether the cursor is positioned at end of file
-     * @param flagBeginOfFile whether the cursor is positioned at beginning of file
-     * @param flagFirstRead whether the next read is the first read
-     * @param flagReadDone whether a read has been performed
-     * @param flagSelectFeatures the OR of select-feature flags ({@code FILE STATUS}, {@code
-     *     LINAGE}, {@code EXTERNAL})
-     * @param flagNeedsNl whether a trailing newline is needed
-     * @param flagNeedsTop whether a top-of-page is needed
-     * @param fileVersion the on-disk format version ({@code COB_FILE_VERSION})
+     * @param selectName {@code SELECT}句で指定された名前
+     * @param fileStatus COBOLの{@code FILE STATUS}用ストレージ（4バイトのバッファ）
+     * @param assign 割り当て名（ファイルパス）を保持するフィールド
+     * @param record レコード領域を表すフィールド
+     * @param recordSize 現在のレコード長を保持するフィールド
+     * @param recordMin 最小レコード長
+     * @param recordMax 最大レコード長
+     * @param nkeys キーの数（主キー1つと副キーの合計）
+     * @param keys キー記述子。インデックス{@code 0}が主キー
+     * @param organization ファイル組織（このクラスでは{@code COB_ORG_INDEXED}）
+     * @param accessMode アクセスモード（順次、動的、またはランダム）
+     * @param lockMode ロックモードフラグ（{@code COB_LOCK_*}）
+     * @param openMode 初期オープンモード
+     * @param flagOptional ファイルが{@code OPTIONAL}と宣言されているか
+     * @param lastOpenMode 直近のオープンモード
+     * @param special 特殊ファイルフラグ
+     * @param flagNonexistent ファイルが現在存在しないと判明しているか
+     * @param flagEndOfFile カーソルがファイル終端に位置しているか
+     * @param flagBeginOfFile カーソルがファイル先頭に位置しているか
+     * @param flagFirstRead 次の読み込みが最初の読み込みか
+     * @param flagReadDone 読み込みが実行済みか
+     * @param flagSelectFeatures select機能フラグのOR（{@code FILE STATUS}、{@code LINAGE}、{@code
+     *     EXTERNAL}）
+     * @param flagNeedsNl 末尾の改行が必要か
+     * @param flagNeedsTop 改ページ（先頭出し）が必要か
+     * @param fileVersion ディスク上のフォーマットバージョン（{@code COB_FILE_VERSION}）
      */
     public CobolIndexedFile(
             String selectName,
@@ -193,21 +189,20 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     /**
-     * Returns the SQLite table name for the key with the given index.
+     * 指定したインデックスのキーに対応するSQLiteテーブル名を返す。
      *
-     * @param index the key index ({@code 0} for the primary key, {@code >= 1} for alternate keys)
-     * @return the table name, e.g. {@code "table0"}, {@code "table1"}, ...
+     * @param index キーのインデックス（主キーは{@code 0}、副キーは{@code 1}以上）
+     * @return テーブル名（例：{@code "table0"}、{@code "table1"}、…）
      */
     public static String getTableName(int index) {
         return String.format("table%d", index);
     }
 
     /**
-     * Returns the cursor name for the key with the given index.
+     * 指定したインデックスのキーに対応するカーソル名を返す。
      *
-     * @param index the key index
-     * @return the cursor name, e.g. {@code "cursor0"}, {@code "cursor1"}, ... (currently unused, but
-     *     kept for compatibility)
+     * @param index キーのインデックス
+     * @return カーソル名（例：{@code "cursor0"}、{@code "cursor1"}、…。現在は未使用だが互換性のため残されている）
      */
     public static String getCursorName(int index) {
         return String.format("cursor%d", index);
@@ -218,15 +213,13 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     /**
-     * Controls whether each modifying statement ({@code WRITE}/{@code REWRITE}/{@code DELETE})
-     * commits its transaction immediately.
+     * 各更新文（{@code WRITE}／{@code REWRITE}／{@code DELETE}）がトランザクションを即座にコミットするかどうかを制御する。
      *
-     * <p>By default this is {@code true}. Bulk loaders such as {@code cobj-idx load} set it to
-     * {@code false} to suppress per-record commits for speed and commit once at the end via {@link
-     * #commitJdbcTransaction()}.
+     * <p>デフォルトは{@code true}。{@code cobj-idx
+     * load}のような一括ローダは、速度のためにレコードごとのコミットを抑制するため{@code false}に設定し、最後に{@link
+     * #commitJdbcTransaction()}で一度だけコミットする。
      *
-     * @param commitOnModification {@code true} to commit after every modification, {@code false} to
-     *     defer committing
+     * @param commitOnModification 更新のたびにコミットする場合は{@code true}、コミットを遅延させる場合は{@code false}
      */
     public void setCommitOnModification(boolean commitOnModification) {
         this.commitOnModification = commitOnModification;
@@ -621,23 +614,21 @@ public class CobolIndexedFile extends CobolFile {
 
     // Equivalent to indexed_start_internal in libcob/fileio.c
     /**
-     * Positions the cursor on the first record matching the given key and comparison condition.
+     * 指定したキーと比較条件に一致する最初のレコードにカーソルを位置づける。
      *
-     * <p>The key field address is matched against the declared keys to determine which key (and
-     * therefore which SQLite table) to use, a fresh {@link IndexedCursor} is created for that key,
-     * and a single record is fetched. On success the current key/record buffers ({@code p.key} /
-     * {@code p.data}) are updated. This is the shared implementation behind {@link #start_(int,
-     * AbstractCobolField)} and the random {@link #read_(AbstractCobolField, int)}.
+     * <p>キーフィールドのアドレスを宣言済みのキーと照合してどのキー（したがってどのSQLiteテーブル）を使うかを判定し、そのキー向けに新しい{@link
+     * IndexedCursor}を生成して、1件のレコードをフェッチする。成功時には現在のキー／レコードバッファ（{@code p.key}／{@code
+     * p.data}）が更新される。これは{@link #start_(int,
+     * AbstractCobolField)}とランダムな{@link #read_(AbstractCobolField, int)}の共通実装である。
      *
-     * @param cond the comparison condition ({@link #COB_EQ}, {@link #COB_GT}, {@link #COB_GE},
-     *     {@link #COB_LT}, or {@link #COB_LE}; {@link #COB_NE} is not supported and causes the
-     *     cursor to fail)
-     * @param key the field holding the key value to search for
-     * @param readOpts the read option flags ({@code COB_READ_*})
-     * @param testLock whether to test record locks (currently unused by this method)
-     * @return {@code COB_STATUS_00_SUCCESS} if a record was found, {@code
-     *     COB_STATUS_23_KEY_NOT_EXISTS} if none matched, or {@code COB_STATUS_30_PERMANENT_ERROR}
-     *     on a cursor creation failure
+     * @param cond 比較条件（{@link #COB_EQ}、{@link #COB_GT}、{@link #COB_GE}、{@link
+     *     #COB_LT}、{@link #COB_LE}のいずれか。{@link #COB_NE}はサポートされておらず、カーソルの生成に失敗する）
+     * @param key 検索するキー値を保持するフィールド
+     * @param readOpts 読み込みオプションフラグ（{@code COB_READ_*}）
+     * @param testLock レコードロックをテストするか（現状このメソッドでは未使用）
+     * @return レコードが見つかった場合は{@code COB_STATUS_00_SUCCESS}、一致するものがなかった場合は{@code
+     *     COB_STATUS_23_KEY_NOT_EXISTS}、カーソル生成に失敗した場合は{@code
+     *     COB_STATUS_30_PERMANENT_ERROR}
      */
     public int indexed_start_internal(
             int cond, AbstractCobolField key, int readOpts, boolean testLock) {
@@ -1402,11 +1393,10 @@ public class CobolIndexedFile extends CobolFile {
     }
 
     /**
-     * Commits the current JDBC transaction explicitly.
+     * 現在のJDBCトランザクションを明示的にコミットする。
      *
-     * <p>Intended for use together with {@link #setCommitOnModification(boolean)}{@code (false)}:
-     * after a batch of modifications has been performed with per-statement committing suppressed,
-     * this method flushes them all in a single commit.
+     * <p>{@link #setCommitOnModification(boolean)}{@code
+     * (false)}と組み合わせて使うことを想定している。文ごとのコミットを抑制した状態で一連の更新を行った後、このメソッドがそれらをまとめて1回のコミットでフラッシュする。
      */
     public void commitJdbcTransaction() {
         IndexedFile p = this.filei;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -8,21 +8,28 @@ import java.util.Optional;
 
 /** Represents a result of fetching a data from SQLite tables. */
 class FetchResult {
-    /** TODO: 準備中 */
+    /** The key value of the fetched row (the {@code key} column). */
     byte[] key;
 
-    /** TODO: 準備中 */
+    /**
+     * The {@code value} column of the fetched row.
+     *
+     * <p>Its meaning depends on the query that produced this result: for the primary table, and for
+     * the JOIN-based queries used while stepping through an alternate-key table, it holds the record
+     * body (from {@code table0.value}); for the direct (non-JOIN) sub-table queries it holds the
+     * primary-key reference.
+     */
     byte[] value;
 
-    /** TODO: 準備中 */
+    /** The duplicate number of the fetched row for a duplicates-enabled key; {@code 0} otherwise. */
     int dupNo;
 
     /**
-     * TODO: 準備中
+     * Constructs a fetch result for a duplicates-enabled key.
      *
-     * @param key TODO: 準備中
-     * @param value TODO: 準備中
-     * @param dupNo TODO: 準備中
+     * @param key the key value of the fetched row
+     * @param value the value of the fetched row
+     * @param dupNo the duplicate number of the fetched row
      */
     FetchResult(byte[] key, byte[] value, int dupNo) {
         this.key = key;
@@ -31,10 +38,10 @@ class FetchResult {
     }
 
     /**
-     * TODO: 準備中
+     * Constructs a fetch result with a duplicate number of {@code 0}.
      *
-     * @param key TODO: 準備中
-     * @param value TODO: 準備中
+     * @param key the key value of the fetched row
+     * @param value the value of the fetched row
      */
     FetchResult(byte[] key, byte[] value) {
         this.key = key;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedCursor.java
@@ -8,28 +8,26 @@ import java.util.Optional;
 
 /** Represents a result of fetching a data from SQLite tables. */
 class FetchResult {
-    /** The key value of the fetched row (the {@code key} column). */
+    /** 取得した行のキー値（{@code key}列）。 */
     byte[] key;
 
     /**
-     * The {@code value} column of the fetched row.
+     * 取得した行の{@code value}列。
      *
-     * <p>Its meaning depends on the query that produced this result: for the primary table, and for
-     * the JOIN-based queries used while stepping through an alternate-key table, it holds the record
-     * body (from {@code table0.value}); for the direct (non-JOIN) sub-table queries it holds the
-     * primary-key reference.
+     * <p>この値の意味は、結果を生成したクエリによって異なる。主テーブルに対するクエリ、および副キーテーブルを走査する際に使用されるJOINベースのクエリでは、レコード本体（{@code
+     * table0.value}由来）を保持する。副テーブルに対する直接（JOINなし）のクエリでは、主キーへの参照を保持する。
      */
     byte[] value;
 
-    /** The duplicate number of the fetched row for a duplicates-enabled key; {@code 0} otherwise. */
+    /** 重複を許可するキーにおける取得行の重複番号。それ以外の場合は{@code 0}。 */
     int dupNo;
 
     /**
-     * Constructs a fetch result for a duplicates-enabled key.
+     * 重複を許可するキー向けのフェッチ結果を構築する。
      *
-     * @param key the key value of the fetched row
-     * @param value the value of the fetched row
-     * @param dupNo the duplicate number of the fetched row
+     * @param key 取得した行のキー値
+     * @param value 取得した行の値
+     * @param dupNo 取得した行の重複番号
      */
     FetchResult(byte[] key, byte[] value, int dupNo) {
         this.key = key;
@@ -38,10 +36,10 @@ class FetchResult {
     }
 
     /**
-     * Constructs a fetch result with a duplicate number of {@code 0}.
+     * 重複番号を{@code 0}としてフェッチ結果を構築する。
      *
-     * @param key the key value of the fetched row
-     * @param value the value of the fetched row
+     * @param key 取得した行のキー値
+     * @param value 取得した行の値
      */
     FetchResult(byte[] key, byte[] value) {
         this.key = key;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
@@ -22,63 +22,55 @@ import java.sql.Connection;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
 /**
- * Holds the runtime state of one opened INDEXED file.
+ * オープン中の1つのINDEXEDファイルの実行時状態を保持する。
  *
- * <p>An instance is created by {@link CobolIndexedFile#open_(String, int, int)} and kept in {@code
- * CobolFile.filei} for the lifetime of the open. It bundles the JDBC connection to the backing
- * SQLite database together with the current key/record buffers and other bookkeeping used while
- * executing COBOL I/O statements. This is a package-private plain data holder; the actual logic
- * lives in {@link CobolIndexedFile}.
+ * <p>インスタンスは{@link CobolIndexedFile#open_(String, int, int)}で生成され、オープンの間{@code
+ * CobolFile.filei}に保持される。バックエンドのSQLiteデータベースへのJDBC接続に加え、現在のキー／レコードバッファや、COBOLのI/O文を実行する際に使用するその他の管理情報をまとめて保持する。これはパッケージプライベートな単純なデータ保持クラスであり、実際のロジックは{@link
+ * CobolIndexedFile}に存在する。
  */
 class IndexedFile {
-    /** Index into the key array identifying the key most recently used (e.g. by {@code START}). */
+    /** 直近に使用されたキー（例：{@code START}で使用）を示すキー配列へのインデックス。 */
     int key_index;
 
-    /** The primary key value written by the previous {@code WRITE}, used for sequential ordering. */
+    /** 直前の{@code WRITE}で書き込まれた主キー値。順次書き込み時の順序チェックに使用する。 */
     CobolDataStorage last_key;
 
-    /** A scratch buffer large enough to hold the largest key, sized at open time. */
+    /** 最大のキーを格納できる大きさのスクラッチバッファ。オープン時にサイズが決定される。 */
     CobolDataStorage temp_key;
 
-    /** The JDBC connection to the SQLite database that backs this file. */
+    /** このファイルのバックエンドであるSQLiteデータベースへのJDBC接続。 */
     Connection connection;
 
-    /** The current key value (raw bytes) being read or written. */
+    /** 読み書き中の現在のキー値（生のバイト列）。 */
     byte[] key;
 
-    /** The current record value (raw bytes) being read or written. */
+    /** 読み書き中の現在のレコード値（生のバイト列）。 */
     byte[] data;
 
-    /** Reserved for per-key read bookkeeping; not actively used by the current implementation. */
+    /** キーごとの読み込み管理用に予約されているが、現在の実装では実際には使用されていない。 */
     byte[][] last_readkey;
 
-    /**
-     * Reserved per-key duplicate-number ({@code dupNo}) state; allocated at open time but not
-     * actively read by the current implementation.
-     */
+    /** キーごとの重複番号（{@code dupNo}）状態として予約されているが、オープン時に確保されるのみで現在の実装では読み取られない。 */
     int[] last_dupno;
 
-    /**
-     * Reserved per-key state for REWRITE; allocated at open time but not actively used by the
-     * current implementation, which instead threads duplicate numbers through a local array.
-     */
+    /** REWRITE用のキーごとの状態として予約されているが、オープン時に確保されるのみで、現在の実装では代わりにローカル配列で重複番号を受け渡しており、実際には使用されていない。 */
     int[] rewrite_sec_key;
 
-    /** The resolved path of the SQLite database file. */
+    /** 解決済みのSQLiteデータベースファイルのパス。 */
     String filename;
 
-    /** Reserved for record-lock bookkeeping. */
+    /** レコードロックの管理用に予約されている。 */
     Object record_lock;
 
-    /** {@code true} while a write cursor is open during a WRITE/REWRITE/DELETE operation. */
+    /** WRITE/REWRITE/DELETE操作中に書き込みカーソルがオープンしている間は{@code true}。 */
     boolean write_cursor_open;
 
-    /** Reserved lock identifier. */
+    /** 予約済みのロック識別子。 */
     int lock_id;
 
-    /** {@code true} while this process currently holds a record lock. */
+    /** このプロセスが現在レコードロックを保持している間は{@code true}。 */
     boolean record_locked;
 
-    /** The length, in characters, of {@link #filename}. */
+    /** {@link #filename}の文字数。 */
     int filenamelen;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
@@ -68,7 +68,7 @@ class IndexedFile {
     /** 予約済みのロック識別子。 */
     int lock_id;
 
-    /** このプロセスが現在レコードロックを保持している間は{@code true}。 */
+    /** 現在未使用。予約済み。 */
     boolean record_locked;
 
     /** {@link #filename}の文字数。 */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/IndexedFile.java
@@ -21,50 +21,64 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import java.sql.Connection;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
-/** TODO: 準備中 */
+/**
+ * Holds the runtime state of one opened INDEXED file.
+ *
+ * <p>An instance is created by {@link CobolIndexedFile#open_(String, int, int)} and kept in {@code
+ * CobolFile.filei} for the lifetime of the open. It bundles the JDBC connection to the backing
+ * SQLite database together with the current key/record buffers and other bookkeeping used while
+ * executing COBOL I/O statements. This is a package-private plain data holder; the actual logic
+ * lives in {@link CobolIndexedFile}.
+ */
 class IndexedFile {
-    /** TODO: 準備中 */
+    /** Index into the key array identifying the key most recently used (e.g. by {@code START}). */
     int key_index;
 
-    /** TODO: 準備中 */
+    /** The primary key value written by the previous {@code WRITE}, used for sequential ordering. */
     CobolDataStorage last_key;
 
-    /** TODO: 準備中 */
+    /** A scratch buffer large enough to hold the largest key, sized at open time. */
     CobolDataStorage temp_key;
 
-    /** TODO: 準備中 */
+    /** The JDBC connection to the SQLite database that backs this file. */
     Connection connection;
 
-    /** TODO: 準備中 */
+    /** The current key value (raw bytes) being read or written. */
     byte[] key;
 
-    /** TODO: 準備中 */
+    /** The current record value (raw bytes) being read or written. */
     byte[] data;
 
-    /** TODO: 準備中 */
+    /** Reserved for per-key read bookkeeping; not actively used by the current implementation. */
     byte[][] last_readkey;
 
-    /** TODO: 準備中 */
+    /**
+     * Reserved per-key duplicate-number ({@code dupNo}) state; allocated at open time but not
+     * actively read by the current implementation.
+     */
     int[] last_dupno;
 
-    /** TODO: 準備中 */
+    /**
+     * Reserved per-key state for REWRITE; allocated at open time but not actively used by the
+     * current implementation, which instead threads duplicate numbers through a local array.
+     */
     int[] rewrite_sec_key;
 
-    /** TODO: 準備中 */
+    /** The resolved path of the SQLite database file. */
     String filename;
 
-    /** TODO: 準備中 */
+    /** Reserved for record-lock bookkeeping. */
     Object record_lock;
 
-    /** TODO: 準備中 */
+    /** {@code true} while a write cursor is open during a WRITE/REWRITE/DELETE operation. */
     boolean write_cursor_open;
 
-    /** TODO: 準備中 */
+    /** Reserved lock identifier. */
     int lock_id;
 
-    /** TODO: 準備中 */
+    /** {@code true} while this process currently holds a record lock. */
     boolean record_locked;
 
-    /** TODO: 準備中 */
+    /** The length, in characters, of {@link #filename}. */
     int filenamelen;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
@@ -21,18 +21,17 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /**
- * Represents a single component of a SPLIT KEY of an INDEXED file.
+ * INDEXEDファイルのSPLIT KEYを構成する1つの要素を表す。
  *
- * <p>COBOL allows a record key to be composed of several non-contiguous fields (a SPLIT KEY, e.g.
- * {@code RECORD KEY IS K = F1 F2 ...}). Each constituent field is described by one {@code
- * KeyComponent}. The compiler ({@code cobj}) emits, for every key that has more than one component,
- * an array of {@code KeyComponent} and stores it into the owning {@link CobolFileKey} via {@link
- * CobolFileKey#setComponent(KeyComponent[])}.
+ * <p>COBOLでは、レコードキーを連続しない複数のフィールドから構成できる（SPLIT KEY。例：{@code RECORD KEY IS K = F1 F2
+ * ...}）。その構成フィールド1つ1つが{@code KeyComponent}で表現される。コンパイラ（{@code
+ * cobj}）は、2つ以上の要素を持つキーごとに{@code KeyComponent}の配列を生成し、{@link
+ * CobolFileKey#setComponent(KeyComponent[])}を通じて所有者である{@link CobolFileKey}に格納する。
  */
 public class KeyComponent {
-    /** The COBOL field that makes up this component of the key. */
+    /** このキー要素を構成するCOBOLフィールド。 */
     public AbstractCobolField field;
 
-    /** The 0-origin byte offset of this component from the beginning of the record. */
+    /** レコード先頭からのこの要素の0始まりのバイトオフセット。 */
     public int rb;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
@@ -20,11 +20,19 @@ package jp.osscons.opensourcecobol.libcobj.file;
 
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
-/** TODO: 準備中 */
+/**
+ * Represents a single component of a SPLIT KEY of an INDEXED file.
+ *
+ * <p>COBOL allows a record key to be composed of several non-contiguous fields (a SPLIT KEY, e.g.
+ * {@code RECORD KEY IS K = F1 F2 ...}). Each constituent field is described by one {@code
+ * KeyComponent}. The compiler ({@code cobj}) emits, for every key that has more than one component,
+ * an array of {@code KeyComponent} and stores it into the owning {@link CobolFileKey} via {@link
+ * CobolFileKey#setComponent(KeyComponent[])}.
+ */
 public class KeyComponent {
-    /** TODO: 準備中 */
+    /** The COBOL field that makes up this component of the key. */
     public AbstractCobolField field;
 
-    /** TODO: 準備中 */
+    /** The 0-origin byte offset of this component from the beginning of the record. */
     public int rb;
 }


### PR DESCRIPTION
## 概要

INDEXEDファイル関連のJavaクラスに、これまでプレースホルダ（`TODO: 準備中`）のままだったJavadocコメントを記述しました。

## 対象クラス

- `CobolIndexedFile` — INDEXEDファイルの具象実装（SQLiteをストレージとして利用）
- `CobolFileKey` — 1つのキー（主キー／副キー）を表すクラス
- `KeyComponent` — SPLIT KEYの構成要素を表すクラス
- `IndexedFile` — オープン中の1ファイルの実行時状態を保持するクラス
- `IndexedCursor` 内の `FetchResult` — フェッチ結果を表すクラス

## 補足

- コメントを付与する対象は、publicなクラス・メソッド・変数を中心としています。
- Javadocはすべて日本語で記述しています。
- ロジックの変更は一切なく、ドキュメントのみの変更です。

---

## Summary

This PR fills in the Javadoc comments for the INDEXED-file related Java classes, which were previously left as `TODO: 準備中` placeholders.

## Target classes

- `CobolIndexedFile` — concrete implementation of INDEXED files (backed by SQLite)
- `CobolFileKey` — represents a single key (primary / alternate)
- `KeyComponent` — represents a component of a SPLIT KEY
- `IndexedFile` — holds the runtime state of one opened file
- `FetchResult` in `IndexedCursor` — represents a fetch result

## Notes

- The comments mainly cover public classes, methods, and fields.
- All Javadoc is written in Japanese.
- This is a documentation-only change with no logic changes.