### PR TITLE
Update Javadoc for libcobj/file

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -207,7 +207,7 @@ public class CobolFile {
     /** 省略可能ファイルが存在せずに正常終了したことを表すCOBOLのファイル状態コード(5). */
     protected static final int COB_STATUS_05_SUCCESS_OPTIONAL = 5;
 
-    /** ユニットに関係しない操作が正常終了したことを表すCOBOLのファイル状態コード(7). */
+    /** リール/ユニットでないファイルに対するREEL/UNIT付き操作が正常終了したことを表すCOBOLのファイル状態コード(7). */
     protected static final int COB_STATUS_07_SUCCESS_NO_UNIT = 7;
 
     /** ファイル終了(end of file)を表すCOBOLのファイル状態コード(10). */
@@ -336,7 +336,7 @@ public class CobolFile {
     /** ファイル状態(FILE STATUS)領域のサイズ(バイト数). */
     protected static final int FNSTATUSSIZE = 3;
 
-    /** 直近に入出力エラーが発生したファイルを保持する静的フィールド. */
+    /** 直近に入出力操作(saveStatusの呼び出し)を行ったファイルを保持する静的フィールド. */
     public static CobolFile errorFile;
 
     /** 各種処理で用いる小さめのバッファのサイズ. */
@@ -1507,7 +1507,7 @@ public class CobolFile {
     /**
      * レコードを順次読み込む(READ文の実装)のオーバーロード. キー引数を整数で受け取り, 内部的には順次読み込みを行う.
      *
-     * @param key 読み込みに用いるキー番号
+     * @param key 読み込みに用いるキー番号(この多重定義では使用されない)
      * @param fnstatus FILE STATUS句で指定されたデータ項目
      * @param readOpts READ文のオプション(COB_READ_*)
      */
@@ -1808,7 +1808,7 @@ public class CobolFile {
         saveStatus(COB_STATUS_00_SUCCESS, fnstatus);
     }
 
-    /** ファイルのロックを解除する下位処理. 開いている場合はバッファをフラッシュしてロックを解放する. */
+    /** ファイルのロックを解除する下位処理. 開いている場合は書き込みバッファをフラッシュする. */
     public void unlock_() {
         if (this.open_mode != COB_OPEN_CLOSED && this.open_mode != COB_OPEN_LOCKED) {
             this.file.flush();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFile.java
@@ -42,252 +42,252 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** INDEXED, RELATIVE, SEQUENTIAL, LINE SEQUENTIAL等のCOBOLの ファイルを実装するための基底クラス */
 public class CobolFile {
-    /** TODO: 準備中 */
+    /** 順編成(SEQUENTIAL)のファイル編成を表す定数. */
     protected static final int COB_ORG_SEQUENTIAL = 0;
 
-    /** TODO: 準備中 */
+    /** 行順編成(LINE SEQUENTIAL)のファイル編成を表す定数. */
     protected static final int COB_ORG_LINE_SEQUENTIAL = 1;
 
-    /** TODO: 準備中 */
+    /** 相対編成(RELATIVE)のファイル編成を表す定数. */
     protected static final int COB_ORG_RELATIVE = 2;
 
-    /** TODO: 準備中 */
+    /** 索引編成(INDEXED)のファイル編成を表す定数. */
     protected static final int COB_ORG_INDEXED = 3;
 
-    /** TODO: 準備中 */
+    /** 整列(SORT)用のファイル編成を表す定数. */
     protected static final int COB_ORG_SORT = 4;
 
-    /** TODO: 準備中 */
+    /** ファイル編成を表す定数の個数(上限値). */
     protected static final int COB_ORG_MAX = 5;
 
-    /** TODO: 準備中 */
+    /** 順アクセス(SEQUENTIAL)のアクセス方式を表す定数. */
     protected static final int COB_ACCESS_SEQUENTIAL = 1;
 
-    /** TODO: 準備中 */
+    /** 動的アクセス(DYNAMIC)のアクセス方式を表す定数. */
     protected static final int COB_ACCESS_DYNAMIC = 2;
 
-    /** TODO: 準備中 */
+    /** 乱アクセス(RANDOM)のアクセス方式を表す定数. */
     protected static final int COB_ACCESS_RANDOM = 3;
 
-    /** TODO: 準備中 */
+    /** OPEN操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_OPEN = 0;
 
-    /** TODO: 準備中 */
+    /** READ操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_READ = 1;
 
-    /** TODO: 準備中 */
+    /** WRITE操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_WRITE = 2;
 
-    /** TODO: 準備中 */
+    /** CLOSE操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_CLOSE = 3;
 
-    /** TODO: 準備中 */
+    /** DELETE操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_DELETE = 4;
 
-    /** TODO: 準備中 */
+    /** REWRITE操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_REWRITE = 5;
 
-    /** TODO: 準備中 */
+    /** START操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_START = 6;
 
-    /** TODO: 準備中 */
+    /** COMMIT操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_COMMIT = 7;
 
-    /** TODO: 準備中 */
+    /** ROLLBACK操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_ROLLBACK = 8;
 
-    /** TODO: 準備中 */
+    /** UNLOCK操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_UNLOCK = 9;
 
-    /** TODO: 準備中 */
+    /** ファイル削除(DELETE FILE)操作を表すI/O操作種別の定数. */
     protected static final int COB_IO_DELETE_FILE = 10;
 
-    /** TODO: 準備中 */
+    /** ファイルが閉じている状態を表すオープンモード. */
     public static final int COB_OPEN_CLOSED = 0;
 
-    /** TODO: 準備中 */
+    /** INPUTモードで開いている状態を表すオープンモード. */
     public static final int COB_OPEN_INPUT = 1;
 
-    /** TODO: 準備中 */
+    /** OUTPUTモードで開いている状態を表すオープンモード. */
     public static final int COB_OPEN_OUTPUT = 2;
 
-    /** TODO: 準備中 */
+    /** I-Oモードで開いている状態を表すオープンモード. */
     public static final int COB_OPEN_I_O = 3;
 
-    /** TODO: 準備中 */
+    /** EXTENDモードで開いている状態を表すオープンモード. */
     public static final int COB_OPEN_EXTEND = 4;
 
-    /** TODO: 準備中 */
+    /** ロックされて閉じている状態を表すオープンモード. */
     public static final int COB_OPEN_LOCKED = 5;
 
-    /** TODO: 準備中 */
+    /** 通常のCLOSE(オプション指定なし)を表すCLOSE文のオプション定数. */
     public static final int COB_CLOSE_NORMAL = 0;
 
-    /** TODO: 準備中 */
+    /** CLOSE後にファイルをロックする(WITH LOCK)ことを表すCLOSE文のオプション定数. */
     public static final int COB_CLOSE_LOCK = 1;
 
-    /** TODO: 準備中 */
+    /** 巻き戻しを行わない(NO REWIND)ことを表すCLOSE文のオプション定数. */
     public static final int COB_CLOSE_NO_REWIND = 2;
 
-    /** TODO: 準備中 */
+    /** ユニット単位のCLOSE(REEL/UNIT)を表すCLOSE文のオプション定数. */
     public static final int COB_CLOSE_UNIT = 3;
 
-    /** TODO: 準備中 */
+    /** ユニットの取り外しを伴うCLOSE(REEL/UNIT FOR REMOVAL)を表すCLOSE文のオプション定数. */
     public static final int COB_CLOSE_UNIT_REMOVAL = 4;
 
-    /** TODO: 準備中 */
+    /** WRITE文のオプションから行数などの値部分を取り出すためのビットマスク. */
     public static final int COB_WRITE_MASK = 0x0000ffff;
 
-    /** TODO: 準備中 */
+    /** 指定行数だけ改行する(ADVANCING LINES)ことを表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_LINES = 0x00010000;
 
-    /** TODO: 準備中 */
+    /** 改ページする(ADVANCING PAGE)ことを表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_PAGE = 0x00020000;
 
-    /** TODO: 準備中 */
+    /** チャネル指定の書き込み(ADVANCING CHANNEL)を表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_CHANNEL = 0x00040000;
 
-    /** TODO: 準備中 */
+    /** 書き込みの後に改行する(AFTER ADVANCING)ことを表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_AFTER = 0x00100000;
 
-    /** TODO: 準備中 */
+    /** 書き込みの前に改行する(BEFORE ADVANCING)ことを表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_BEFORE = 0x00200000;
 
-    /** TODO: 準備中 */
+    /** ページ末尾(END-OF-PAGE)条件の検出を表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_EOP = 0x00400000;
 
-    /** TODO: 準備中 */
+    /** 書き込み時にレコードをロックすることを表すWRITE文のビットフラグ. */
     public static final int COB_WRITE_LOCK = 0x00800000;
 
-    /** TODO: 準備中 */
+    /** 次のレコードを読む(READ NEXT)ことを表すREAD文のビットフラグ. */
     public static final int COB_READ_NEXT = 0x01;
 
-    /** TODO: 準備中 */
+    /** 前のレコードを読む(READ PREVIOUS)ことを表すREAD文のビットフラグ. */
     public static final int COB_READ_PREVIOUS = 0x2;
 
-    /** TODO: 準備中 */
+    /** 先頭のレコードを読む(READ FIRST)ことを表すREAD文のビットフラグ. */
     public static final int COB_READ_FIRST = 0x04;
 
-    /** TODO: 準備中 */
+    /** 末尾のレコードを読む(READ LAST)ことを表すREAD文のビットフラグ. */
     public static final int COB_READ_LAST = 0x08;
 
-    /** TODO: 準備中 */
+    /** 読み込んだレコードをロックすることを表すREAD文のビットフラグ. */
     public static final int COB_READ_LOCK = 0x10;
 
-    /** TODO: 準備中 */
+    /** 読み込んだレコードをロックしないことを表すREAD文のビットフラグ. */
     public static final int COB_READ_NO_LOCK = 0x20;
 
-    /** TODO: 準備中 */
+    /** 既存のロックを保持することを表すREAD文のビットフラグ. */
     public static final int COB_READ_KEPT_LOCK = 0x40;
 
-    /** TODO: 準備中 */
+    /** ロックが取得できるまで待機することを表すREAD文のビットフラグ. */
     public static final int COB_READ_WAIT_LOCK = 0x80;
 
-    /** TODO: 準備中 */
+    /** 他プロセスのロックを無視して読むことを表すREAD文のビットフラグ. */
     public static final int COB_READ_IGNORE_LOCK = 0x100;
 
-    /** TODO: 準備中 */
+    /** ユーザ定義のファイルハンドラを指定する環境変数の名前. */
     protected static final String TIS_DEFINE_USERFH = "OC_USERFH";
 
-    /** TODO: 準備中 */
+    /** I-Oモードで開く際に存在しないファイルを作成するかを指定する環境変数の名前. */
     protected static final String COB_IO_CREATES = "OC_IO_CREATES";
 
-    /** TODO: 準備中 */
+    /** EXTENDモードで開く際に存在しないファイルを作成するかを指定する環境変数の名前. */
     protected static final String COB_EXTEND_CREATES = "OC_EXTEND_CREATES";
 
-    /** TODO: 準備中 */
+    /** 正常終了を表すCOBOLのファイル状態コード(0). */
     protected static final int COB_STATUS_00_SUCCESS = 0;
 
-    /** TODO: 準備中 */
+    /** 重複キーを許して正常終了したことを表すCOBOLのファイル状態コード(2). */
     protected static final int COB_STATUS_02_SUCCESS_DUPLICATE = 2;
 
-    /** TODO: 準備中 */
+    /** レコード長が一致しないが正常終了したことを表すCOBOLのファイル状態コード(4). */
     protected static final int COB_STATUS_04_SUCCESS_INCOMPLETE = 4;
 
-    /** TODO: 準備中 */
+    /** 省略可能ファイルが存在せずに正常終了したことを表すCOBOLのファイル状態コード(5). */
     protected static final int COB_STATUS_05_SUCCESS_OPTIONAL = 5;
 
-    /** TODO: 準備中 */
+    /** ユニットに関係しない操作が正常終了したことを表すCOBOLのファイル状態コード(7). */
     protected static final int COB_STATUS_07_SUCCESS_NO_UNIT = 7;
 
-    /** TODO: 準備中 */
+    /** ファイル終了(end of file)を表すCOBOLのファイル状態コード(10). */
     protected static final int COB_STATUS_10_END_OF_FILE = 10;
 
-    /** TODO: 準備中 */
+    /** 相対キーがキー項目の範囲を超えていることを表すCOBOLのファイル状態コード(14). */
     protected static final int COB_STATUS_14_OUT_OF_KEY_RANGE = 14;
 
-    /** TODO: 準備中 */
+    /** キーの順序が不正(昇順でない)であることを表すCOBOLのファイル状態コード(21). */
     protected static final int COB_STATUS_21_KEY_INVALID = 21;
 
-    /** TODO: 準備中 */
+    /** 既に同じキーのレコードが存在することを表すCOBOLのファイル状態コード(22). */
     protected static final int COB_STATUS_22_KEY_EXISTS = 22;
 
-    /** TODO: 準備中 */
+    /** 該当するキーのレコードが存在しないことを表すCOBOLのファイル状態コード(23). */
     protected static final int COB_STATUS_23_KEY_NOT_EXISTS = 23;
 
-    /** TODO: 準備中 */
+    /** 回復不能な入出力エラー(永続的エラー)を表すCOBOLのファイル状態コード(30). */
     protected static final int COB_STATUS_30_PERMANENT_ERROR = 30;
 
-    /** TODO: 準備中 */
+    /** ファイル名が矛盾していることを表すCOBOLのファイル状態コード(31). */
     protected static final int COB_STATUS_31_INCONSISTENT_FILENAME = 31;
 
-    /** TODO: 準備中 */
+    /** ファイル領域の境界を超えたことを表すCOBOLのファイル状態コード(34). */
     protected static final int COB_STATUS_34_BOUNDARY_VIOLATION = 34;
 
-    /** TODO: 準備中 */
+    /** ファイルが存在しないことを表すCOBOLのファイル状態コード(35). */
     protected static final int COB_STATUS_35_NOT_EXISTS = 35;
 
-    /** TODO: 準備中 */
+    /** ファイルへのアクセス権がないことを表すCOBOLのファイル状態コード(37). */
     protected static final int COB_STATUS_37_PERMISSION_DENIED = 37;
 
-    /** TODO: 準備中 */
+    /** ロック付きでCLOSEされたファイルを開こうとしたことを表すCOBOLのファイル状態コード(38). */
     protected static final int COB_STATUS_38_CLOSED_WITH_LOCK = 38;
 
-    /** TODO: 準備中 */
+    /** ファイル属性が矛盾していることを表すCOBOLのファイル状態コード(39). */
     protected static final int COB_STATUS_39_CONFLICT_ATTRIBUTE = 39;
 
-    /** TODO: 準備中 */
+    /** 既に開いているファイルを開こうとしたことを表すCOBOLのファイル状態コード(41). */
     protected static final int COB_STATUS_41_ALREADY_OPEN = 41;
 
-    /** TODO: 準備中 */
+    /** 開いていないファイルを操作しようとしたことを表すCOBOLのファイル状態コード(42). */
     protected static final int COB_STATUS_42_NOT_OPEN = 42;
 
-    /** TODO: 準備中 */
+    /** 直前にREADが実行されていないことを表すCOBOLのファイル状態コード(43). */
     protected static final int COB_STATUS_43_READ_NOT_DONE = 43;
 
-    /** TODO: 準備中 */
+    /** レコード長が許容範囲を超えていることを表すCOBOLのファイル状態コード(44). */
     protected static final int COB_STATUS_44_RECORD_OVERFLOW = 44;
 
-    /** TODO: 準備中 */
+    /** READに失敗したことを表すCOBOLのファイル状態コード(46). */
     protected static final int COB_STATUS_46_READ_ERROR = 46;
 
-    /** TODO: 準備中 */
+    /** READ/STARTが許可されていないことを表すCOBOLのファイル状態コード(47). */
     protected static final int COB_STATUS_47_INPUT_DENIED = 47;
 
-    /** TODO: 準備中 */
+    /** WRITEが許可されていないことを表すCOBOLのファイル状態コード(48). */
     protected static final int COB_STATUS_48_OUTPUT_DENIED = 48;
 
-    /** TODO: 準備中 */
+    /** DELETE/REWRITEが許可されていないことを表すCOBOLのファイル状態コード(49). */
     protected static final int COB_STATUS_49_I_O_DENIED = 49;
 
-    /** TODO: 準備中 */
+    /** レコードが他のプロセスによってロックされていることを表すCOBOLのファイル状態コード(51). */
     protected static final int COB_STATUS_51_RECORD_LOCKED = 51;
 
-    /** TODO: 準備中 */
+    /** ページ末尾(end of page)条件が発生したことを表すCOBOLのファイル状態コード(52). */
     protected static final int COB_STATUS_52_EOP = 52;
 
-    /** TODO: 準備中 */
+    /** LINAGEの指定値が不正であることを表すCOBOLのファイル状態コード(57). */
     protected static final int COB_STATUS_57_I_O_LINAGE = 57;
 
-    /** TODO: 準備中 */
+    /** ファイル共有の競合が発生したことを表すCOBOLのファイル状態コード(61). */
     protected static final int COB_STATUS_61_FILE_SHARING = 61;
 
-    /** TODO: 準備中 */
+    /** 実行時ライブラリがこの操作に対応していないことを表すCOBOLのファイル状態コード(91). */
     protected static final int COB_STATUS_91_NOT_AVAILABLE = 91;
 
     /**
-     * File status 92: Version incompatibility.
-     * Indicates that the file operation failed due to a version mismatch between the file and the program.
+     * ファイルとプログラムの間でバージョンが一致しないためにファイル操作が失敗したことを表す.
+     * COBOLのファイル状態コード(92).
      */
     protected static final int COB_STATUS_92_VERSION_INCOMPATIBLE = 92;
 
@@ -295,104 +295,104 @@ public class CobolFile {
     // The following constants must not be equal
     // to any of the above constants `COB_STATUS_*`
 
-    /** TODO: 準備中 */
+    /** ファイルが存在しないことを表すエラー種別(POSIXのENOENT相当). */
     protected static final int ENOENT = 1002;
 
-    /** TODO: 準備中 */
+    /** 不正なファイルディスクリプタを表すエラー種別(POSIXのEBADF相当). */
     protected static final int EBADF = 1009;
 
-    /** TODO: 準備中 */
+    /** アクセス権がないことを表すエラー種別(POSIXのEACCES相当). */
     protected static final int EACCESS = 1013;
 
-    /** TODO: 準備中 */
+    /** 対象がディレクトリであることを表すエラー種別(POSIXのEISDIR相当). */
     protected static final int EISDIR = 1021;
 
-    /** TODO: 準備中 */
+    /** 読み取り専用ファイルシステムであることを表すエラー種別(POSIXのEROFS相当). */
     protected static final int EROFS = 1030;
 
-    /** TODO: 準備中 */
+    /** 資源が一時的に利用できないことを表すエラー種別(POSIXのEAGAIN相当). */
     protected static final int EAGAIN = 1011;
 
     // ==============================================
 
-    /** TODO: 準備中 */
+    /** LINAGEの指定値が不正であることを表す内部コード. */
     protected static final int COB_LINAGE_INVALID = 16384;
 
-    /** TODO: 準備中 */
+    /** 機能が構成されていないことを表す内部コード. */
     protected static final int COB_NOT_CONFIGURED = 32768;
 
-    /** TODO: 準備中 */
+    /** SELECT句でFILE STATUSが指定されていることを表すビットフラグ. */
     public static final int COB_SELECT_FILE_STATUS = 0x01;
 
-    /** TODO: 準備中 */
+    /** SELECT句でEXTERNALが指定されていることを表すビットフラグ. */
     public static final int COB_SELECT_EXTERNAL = 0x02;
 
-    /** TODO: 準備中 */
+    /** SELECT句でLINAGEが指定されていることを表すビットフラグ. */
     public static final int COB_SELECT_LINAGE = 0x04;
 
-    /** TODO: 準備中 */
+    /** SELECT句で分割キー(SPLIT KEY)が指定されていることを表すビットフラグ. */
     public static final int COB_SELECT_SPLITKEY = 0x08;
 
-    /** TODO: 準備中 */
+    /** ファイル状態(FILE STATUS)領域のサイズ(バイト数). */
     protected static final int FNSTATUSSIZE = 3;
 
-    /** TODO: 準備中 */
+    /** 直近に入出力エラーが発生したファイルを保持する静的フィールド. */
     public static CobolFile errorFile;
 
-    /** TODO: 準備中 */
+    /** 各種処理で用いる小さめのバッファのサイズ. */
     protected static int COB_SMALL_BUFF = 1024;
 
-    /** TODO: 準備中 */
+    /** 小さめのバッファに格納できる最大長(COB_SMALL_BUFF - 1). */
     protected static int COB_SMALL_MAX = COB_SMALL_BUFF - 1;
 
-    /** TODO: 準備中 */
+    /** 排他ロック(EXCLUSIVE)を表すロック方式のビット. */
     protected static final int COB_LOCK_EXCLUSIVE = 1;
 
-    /** TODO: 準備中 */
+    /** 手動ロック(MANUAL)を表すロック方式のビット. */
     protected static final int COB_LOCK_MANUAL = 2;
 
-    /** TODO: 準備中 */
+    /** 自動ロック(AUTOMATIC)を表すロック方式のビット. */
     protected static final int COB_LOCK_AUTOMATIC = 4;
 
-    /** TODO: 準備中 */
+    /** 複数ロック(MULTIPLE)を表すロック方式のビット. */
     protected static final int COB_LOCK_MULTIPLE = 8;
 
-    /** TODO: 準備中 */
+    /** ロック方式のビットを取り出すためのビットマスク. */
     protected static final int COB_LOCK_MASK = 0x7;
 
-    /** TODO: 準備中 */
+    /** ファイルを探索する既定のディレクトリパス(環境変数COB_FILE_PATHの値). */
     protected static String cob_file_path = null;
 
-    /** TODO: 準備中 */
+    /** 行順編成でNULL文字を扱うかどうかの設定(環境変数COB_LS_NULLSの値). */
     protected static String cob_ls_nulls = null;
 
-    /** TODO: 準備中 */
+    /** 行順編成で固定長として扱うかどうかの設定(環境変数COB_LS_FIXEDの値). */
     protected static String cob_ls_fixed = null;
 
-    /** TODO: 準備中 */
+    /** ファイル名マッピング時に環境変数名を組み立てるための作業用バッファ. */
     protected static byte[] file_open_env = new byte[1024];
 
-    /** TODO: 準備中 */
+    /** 実際に開くファイルの名前を保持する作業用フィールド. */
     protected static String file_open_name;
 
-    /** TODO: 準備中 */
+    /** ファイル名マッピング時に生成したファイル名を保持する作業用バッファ. */
     protected static byte[] file_open_buff = new byte[1024];
 
-    /** TODO: 準備中 */
+    /** ファイル名を環境変数として解決する際に試みる接頭辞の一覧. */
     protected static final String[] prefix = {"DD_", "dd_", ""};
 
-    /** TODO: 準備中 */
+    /** prefixの要素数. */
     protected static final int NUM_PREFIX = prefix.length;
 
-    /** TODO: 準備中 */
+    /** ページ末尾(end of page)条件が発生したかどうかを表すフラグ. */
     protected static int eop_status = 0;
 
-    /** TODO: 準備中 */
+    /** 書き込み後に同期(sync)を行うかどうかの設定(環境変数COB_SYNCの値に対応). */
     protected static int cob_do_sync = 0;
 
     private static List<CobolFile> file_cache = new ArrayList<CobolFile>();
 
-    /** TODO: 準備中 */
+    /** ファイル状態コードの十の位に対応するCOBOL例外IDの対応表. */
     protected static int[] status_exception = {
         0,
         CobolExceptionId.COB_EC_I_O_AT_END,
@@ -406,157 +406,157 @@ public class CobolFile {
         CobolExceptionId.COB_EC_I_O_IMP
     };
 
-    /** TODO: 準備中 */
+    /** SELECT句で指定されたファイルの名前. */
     public String select_name;
 
-    /** TODO: 準備中 */
+    /** 直近の入出力操作の結果を表す2バイトのファイル状態(FILE STATUS)領域. */
     public byte[] file_status;
 
-    /** TODO: 準備中 */
+    /** ASSIGN句で指定されたファイル名を表すデータ項目. */
     protected AbstractCobolField assign;
 
-    /** TODO: 準備中 */
+    /** レコード領域を表すデータ項目. */
     public AbstractCobolField record;
 
-    /** TODO: 準備中 */
+    /** 可変長レコードの実際の長さを保持するデータ項目. */
     protected AbstractCobolField record_size;
 
-    /** TODO: 準備中 */
+    /** 索引編成ファイルのキー情報の配列. */
     protected CobolFileKey[] keys;
 
-    /** TODO: 準備中 */
+    /** ファイルの低水準な読み書きを担うFileIOインスタンス. */
     public FileIO file;
 
-    /** TODO: 準備中 */
+    /** SORT/MERGE実行時の状態を保持するCobolSortインスタンス. */
     protected CobolSort filex;
 
-    /** TODO: 準備中 */
+    /** 索引編成ファイルの内部状態を保持するIndexedFileインスタンス. */
     protected IndexedFile filei;
 
-    /** TODO: 準備中 */
+    /** LINAGE句に関する情報を保持するLinageインスタンス. */
     protected Linage linorkeyptr;
 
-    /** TODO: 準備中 */
+    /** SORT/MERGEで用いる照合順序(COLLATING SEQUENCE)を表すデータ領域. */
     protected CobolDataStorage sort_collating;
 
-    /** TODO: 準備中 */
+    /** 外部ファイルハンドラ(EXTFH)用のポインタ. */
     protected Object extfh_ptr;
 
-    /** TODO: 準備中 */
+    /** レコードの最小長. */
     protected int record_min;
 
-    /** TODO: 準備中 */
+    /** レコードの最大長. */
     public int record_max;
 
-    /** TODO: 準備中 */
+    /** 索引編成ファイルのキーの個数. */
     protected int nkeys;
 
-    /** TODO: 準備中 */
+    /** ファイル編成(COB_ORG_*). */
     protected char organization;
 
-    /** TODO: 準備中 */
+    /** アクセス方式(COB_ACCESS_*). */
     protected char access_mode;
 
-    /** TODO: 準備中 */
+    /** ロック方式(COB_LOCK_*). */
     protected char lock_mode;
 
-    /** TODO: 準備中 */
+    /** 現在のオープンモード(COB_OPEN_*). */
     protected char open_mode;
 
-    /** TODO: 準備中 */
+    /** ファイルが省略可能(OPTIONAL)かどうかを表すフラグ. */
     protected boolean flag_optional;
 
-    /** TODO: 準備中 */
+    /** 直近にOPENした際のオープンモード. */
     public char last_open_mode;
 
-    /** TODO: 準備中 */
+    /** 標準入力/標準出力などの特殊ファイルの種別. */
     protected char special;
 
-    /** TODO: 準備中 */
+    /** ファイルが存在しない状態で開かれたかどうかを表すフラグ. */
     protected boolean flag_nonexistent;
 
-    /** TODO: 準備中 */
+    /** ファイル終了に達したかどうかを表すフラグ. */
     protected boolean flag_end_of_file;
 
-    /** TODO: 準備中 */
+    /** ファイル先頭に達したかどうかを表すフラグ. */
     protected boolean flag_begin_of_file;
 
-    /** TODO: 準備中 */
+    /** 最初のREADかどうかを表すフラグ. */
     protected char flag_first_read;
 
-    /** TODO: 準備中 */
+    /** 直前にREADが実行されたかどうかを表すフラグ. */
     protected boolean flag_read_done;
 
-    /** TODO: 準備中 */
+    /** SELECT句で指定された機能(COB_SELECT_*)を表すビットフラグ. */
     public char flag_select_features;
 
-    /** TODO: 準備中 */
+    /** 次の書き込み前に改行の出力が必要かどうかを表すフラグ. */
     protected boolean flag_needs_nl;
 
-    /** TODO: 準備中 */
+    /** 次の書き込み前にページ先頭の処理が必要かどうかを表すフラグ. */
     protected boolean flag_needs_top;
 
-    /** TODO: 準備中 */
+    /** ファイルのバージョン. */
     protected char file_version;
 
-    /** TODO: 準備中 */
+    /** 実行時に用いる作業用バッファ. */
     protected static String runtime_buffer;
 
-    /** TODO: 準備中 */
+    /** 作業用のファイル名を保持する静的フィールド. */
     protected static String name;
 
-    /** TODO: 準備中 */
+    /** 作業用のファイル状態を保持する静的フィールド. */
     protected static byte[] status;
 
     /**
-     * TODO: 準備中
+     * LINAGE句に関する情報を保持するLinageインスタンスを取得する.
      *
-     * @return TODO: 準備中
+     * @return linorkeyptrに保持されたLinageインスタンス
      */
     public Linage getLinorkeyptr() {
         return this.linorkeyptr;
     }
 
     /**
-     * TODO: 準備中
+     * LINAGE句に関する情報を保持するLinageインスタンスを設定する.
      *
-     * @param ptr TODO: 準備中
+     * @param ptr 設定するLinageインスタンス
      */
     public void setLinorkeyptr(Linage ptr) {
         this.linorkeyptr = ptr;
     }
 
-    /** TODO: 準備中 */
+    /** 引数を取らないコンストラクタ. */
     public CobolFile() {}
 
     /**
-     * TODO: 準備中
+     * 各フィールドの値を指定してCobolFileを生成するコンストラクタ.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
+     * @param selectName SELECT句で指定されたファイルの名前
+     * @param fileStatus ファイル状態(FILE STATUS)を格納する2バイトの領域
+     * @param assign ASSIGN句で指定されたファイル名を表すデータ項目
+     * @param record レコード領域を表すデータ項目
+     * @param recordSize 可変長レコードの実際の長さを保持するデータ項目
+     * @param recordMin レコードの最小長
+     * @param recordMax レコードの最大長
+     * @param nkeys 索引編成ファイルのキーの個数
+     * @param keys 索引編成ファイルのキー情報の配列
+     * @param organization ファイル編成(COB_ORG_*)
+     * @param accessMode アクセス方式(COB_ACCESS_*)
+     * @param lockMode ロック方式(COB_LOCK_*)
+     * @param openMode オープンモード(COB_OPEN_*)
+     * @param flagOptional ファイルが省略可能(OPTIONAL)かどうかを表すフラグ
+     * @param lastOpenMode 直近にOPENした際のオープンモード
+     * @param special 標準入力/標準出力などの特殊ファイルの種別
+     * @param flagNonexistent ファイルが存在しない状態で開かれたかどうかを表すフラグ
+     * @param flagEndOfFile ファイル終了に達したかどうかを表すフラグ
+     * @param flagBeginOfFile ファイル先頭に達したかどうかを表すフラグ
+     * @param flagFirstRead 最初のREADかどうかを表すフラグ
+     * @param flagReadDone 直前にREADが実行されたかどうかを表すフラグ
+     * @param flagSelectFeatures SELECT句で指定された機能(COB_SELECT_*)を表すビットフラグ
+     * @param flagNeedsNl 次の書き込み前に改行の出力が必要かどうかを表すフラグ
+     * @param flagNeedsTop 次の書き込み前にページ先頭の処理が必要かどうかを表すフラグ
+     * @param fileVersion ファイルのバージョン
      */
     public CobolFile(
             String selectName,
@@ -614,10 +614,11 @@ public class CobolFile {
 
     // libcob/fileio.cのsave_statusの実装 RETURN_STATUSマクロは実装できないため,本メソッドの呼び出し後の次の文はreturn;を書くこと.
     /**
-     * TODO: 準備中
+     * 入出力操作の結果をファイル状態(FILE STATUS)領域に保存し, 0以外の場合は対応するCOBOL例外を設定する.
+     * libcob/fileio.cのsave_statusの実装.
      *
-     * @param status TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param status 保存するファイル状態コード
+     * @param fnstatus FILE STATUS句で指定されたデータ項目(nullの場合は設定しない)
      */
     protected void saveStatus(int status, AbstractCobolField fnstatus) {
         CobolFile.errorFile = this;
@@ -645,17 +646,18 @@ public class CobolFile {
 
     // libcob/fileio.のcob_invoke_funの実装
     /**
-     * TODO: 準備中
+     * ユーザ定義のファイルハンドラを呼び出す. 現在は常に0を返す(未実装).
+     * libcob/fileio.cのcob_invoke_funの実装.
      *
-     * @param operate TODO: 準備中
-     * @param f TODO: 準備中
-     * @param key TODO: 準備中
-     * @param rec TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param startCond TODO: 準備中
-     * @param readOpts TODO: 準備中
-     * @return TODO: 準備中
+     * @param operate I/O操作の種別(COB_IO_*)
+     * @param f 操作対象のファイル
+     * @param key 操作に用いるキー項目
+     * @param rec 書き込むレコードのデータ領域
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @param openMode オープンモードを表す文字列
+     * @param startCond START文の比較条件を表す文字列
+     * @param readOpts READ文のオプションを表す文字列
+     * @return ハンドラの戻り値(0はハンドラで処理しなかったことを表す)
      */
     public static int invokeFun(
             int operate,
@@ -671,9 +673,10 @@ public class CobolFile {
 
     // libcob/cob_cache_fileのj実装
     /**
-     * TODO: 準備中
+     * 指定されたファイルをファイルキャッシュに登録する(既に登録されている場合は何もしない).
+     * libcob/fileio.cのcob_cache_fileの実装.
      *
-     * @param f TODO: 準備中
+     * @param f キャッシュに登録するファイル
      */
     protected static void cacheFile(CobolFile f) {
         if (file_cache.contains(f)) {
@@ -684,9 +687,10 @@ public class CobolFile {
 
     // libcob/fileio.cのcob_file_linage_checkの実装 TODO 実装
     /**
-     * TODO: 準備中
+     * LINAGE句の各値(1ページの行数, フッタ, 上下の余白)を検査し, 妥当なら各フィールドに設定する.
+     * libcob/fileio.cのcob_file_linage_checkの実装.
      *
-     * @return TODO: 準備中
+     * @return LINAGEの指定値が不正な場合はtrue, 正常な場合はfalse
      */
     protected boolean file_linage_check() {
         Linage lingptr = getLinorkeyptr();
@@ -730,11 +734,12 @@ public class CobolFile {
 
     // libcob/fileio.cのcob_linage_write_optの実装 TODO 実装
     /**
-     * TODO: 準備中
+     * LINAGE句を持つファイルに対して, WRITE文のオプションに応じた改ページ・改行処理を行う.
+     * libcob/fileio.cのcob_linage_write_optの実装.
      *
-     * @param opt TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param opt WRITE文のオプション(COB_WRITE_*)
+     * @return ファイル状態コード
+     * @throws CobolStopRunException 実行時エラーが発生した場合
      */
     protected int linage_write_opt(int opt) throws CobolStopRunException {
         int i, n;
@@ -798,12 +803,12 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * JIS文字を16進表記でエンコードしたファイル名を元の文字列に復元する.
      *
-     * @param name TODO: 準備中
-     * @param jbuf TODO: 準備中
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param name 変換対象のファイル名のバイト配列
+     * @param jbuf 変換結果の格納先バッファ(nullの場合は新たに確保する)
+     * @param n jbufのサイズ
+     * @return 変換後のバイト配列
      */
     protected byte[] cb_get_jisword_buff(byte[] name, byte[] jbuf, int n) {
         int cs = 0;
@@ -908,9 +913,9 @@ public class CobolFile {
     }
 
     /**
-     * This method is mainly for unlocking the indexed files.
+     * 主に索引編成ファイルのロックを解除するための後処理を行う.
      *
-     * @return true if post-processing is successful, false otherwise.
+     * @return 後処理に成功した場合はtrue, そうでない場合はfalse
      */
     protected boolean postProcess() {
         return true;
@@ -926,11 +931,11 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * ファイルを開く(OPEN文の実装). ファイル名の解決やファイルの存在確認を行い, 結果をファイル状態に保存する.
      *
-     * @param mode TODO: 準備中
-     * @param sharing TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param mode オープンモード(COB_OPEN_*)
+     * @param sharing 共有指定
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void open(int mode, int sharing, AbstractCobolField fnstatus) {
         String openMode = openModeToString(mode);
@@ -1147,24 +1152,24 @@ public class CobolFile {
     // protected long end;
 
     /**
-     * TODO: 準備中
+     * ファイルを開く処理の拡張版(現在は未実装).
      *
-     * @param mode TODO: 準備中
-     * @param sharing TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param mode オープンモード(COB_OPEN_*)
+     * @param sharing 共有指定
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void openEx(int mode, int sharing, AbstractCobolField fnstatus) {
         // this.open_("", mode, sharing);
     }
 
     /**
-     * TODO: 準備中
+     * 指定したモードでファイルを実際に開き, 必要に応じてロックの取得と書き込みバッファの準備を行う.
      *
-     * @param filename TODO: 準備中
-     * @param mode TODO: 準備中
-     * @param sharing TODO: 準備中
-     * @return TODO: 準備中
-     * @throws IOException TODO: 準備中
+     * @param filename 開くファイルの名前
+     * @param mode オープンモード(COB_OPEN_*)
+     * @param sharing 共有指定
+     * @return 成功時は0, 失敗時はエラーを表すコード(ENOENT等またはファイル状態コード)
+     * @throws IOException 入出力エラーが発生した場合
      */
     public int open_(String filename, int mode, int sharing) throws IOException {
         FileChannel fp = null;
@@ -1251,10 +1256,10 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * ファイルを閉じる(CLOSE文の実装). オプションに応じてロックや巻き戻しの扱いを決め, 結果をファイル状態に保存する.
      *
-     * @param opt TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param opt CLOSE文のオプション(COB_CLOSE_*)
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void close(int opt, AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -1299,10 +1304,10 @@ public class CobolFile {
     // }
 
     /**
-     * TODO: 準備中
+     * ファイルを実際に閉じる下位処理. 行順編成では必要に応じて末尾に改行を出力し, ロックを解除する.
      *
-     * @param opt TODO: 準備中
-     * @return TODO: 準備中
+     * @param opt CLOSE文のオプション(COB_CLOSE_*)
+     * @return ファイル状態コード
      */
     public int close_(int opt) {
         switch (opt) {
@@ -1332,11 +1337,11 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * 索引編成/相対編成ファイルで, 指定した比較条件とキーに合致する位置にレコードを位置付ける(START文の実装).
      *
-     * @param cond TODO: 準備中
-     * @param key TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param cond 位置付けの比較条件
+     * @param key 位置付けに用いるキー項目
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void start(int cond, AbstractCobolField key, AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -1372,22 +1377,22 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * START処理の拡張版. 位置付けの下位処理を直接呼び出す.
      *
-     * @param cond TODO: 準備中
-     * @param key TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param cond 位置付けの比較条件
+     * @param key 位置付けに用いるキー項目
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void startEx(int cond, AbstractCobolField key, AbstractCobolField fnstatus) {
         this.start_(cond, key);
     }
 
     /**
-     * TODO: 準備中
+     * 位置付けを行う下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @param cond TODO: 準備中
-     * @param key TODO: 準備中
-     * @return TODO: 準備中
+     * @param cond 位置付けの比較条件
+     * @param key 位置付けに用いるキー項目
+     * @return ファイル状態コード
      */
     public int start_(int cond, AbstractCobolField key) {
         System.out.println("super.start");
@@ -1395,11 +1400,11 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * レコードを読み込む(READ文の実装). キーが指定された場合はキー読み込み, nullの場合は順次読み込みを行い, 結果をファイル状態に保存する.
      *
-     * @param key TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @param readOpts TODO: 準備中
+     * @param key 読み込みに用いるキー項目(順次読み込みの場合はnull)
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @param readOpts READ文のオプション(COB_READ_*)
      */
     public void read(AbstractCobolField key, AbstractCobolField fnstatus, int readOpts) {
         byte[] sbuff = new byte[3];
@@ -1500,33 +1505,33 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * レコードを順次読み込む(READ文の実装)のオーバーロード. キー引数を整数で受け取り, 内部的には順次読み込みを行う.
      *
-     * @param key TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @param readOpts TODO: 準備中
+     * @param key 読み込みに用いるキー番号
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @param readOpts READ文のオプション(COB_READ_*)
      */
     public void read(int key, AbstractCobolField fnstatus, int readOpts) {
         this.read(null, fnstatus, readOpts);
     }
 
     /**
-     * TODO: 準備中
+     * READ処理の拡張版. キー読み込みの下位処理を直接呼び出す.
      *
-     * @param key TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @param readOpts TODO: 準備中
+     * @param key 読み込みに用いるキー項目
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @param readOpts READ文のオプション(COB_READ_*)
      */
     public void readEx(AbstractCobolField key, AbstractCobolField fnstatus, int readOpts) {
         this.read_(key, readOpts);
     }
 
     /**
-     * TODO: 準備中
+     * キーを指定してレコードを読み込む下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @param key TODO: 準備中
-     * @param readOpts TODO: 準備中
-     * @return TODO: 準備中
+     * @param key 読み込みに用いるキー項目
+     * @param readOpts READ文のオプション(COB_READ_*)
+     * @return ファイル状態コード
      */
     public int read_(AbstractCobolField key, int readOpts) {
         System.out.println("super.read");
@@ -1534,10 +1539,10 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * 次(またはオプションに応じて前)のレコードを順次読み込む下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @param readOpts TODO: 準備中
-     * @return TODO: 準備中
+     * @param readOpts READ文のオプション(COB_READ_*)
+     * @return ファイル状態コード
      */
     public int readNext(int readOpts) {
         System.out.println("super.readNext");
@@ -1545,12 +1550,12 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * レコードを書き込む(WRITE文の実装). レコード長を検査し, 状況に応じてREWRITEに委譲した上で結果をファイル状態に保存する.
      *
-     * @param rec TODO: 準備中
-     * @param opt TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param rec 書き込むレコード
+     * @param opt WRITE文のオプション(COB_WRITE_*)
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @throws CobolStopRunException 実行時エラーが発生した場合
      */
     public void write(AbstractCobolField rec, int opt, AbstractCobolField fnstatus)
             throws CobolStopRunException {
@@ -1618,12 +1623,12 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * WRITE処理の拡張版. 書き込みの下位処理を直接呼び出す.
      *
-     * @param rec TODO: 準備中
-     * @param opt TODO: 準備中
-     * @param fnstatus TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param rec 書き込むレコード
+     * @param opt WRITE文のオプション(COB_WRITE_*)
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
+     * @throws CobolStopRunException 実行時エラーが発生した場合
      */
     public void writeEx(AbstractCobolField rec, int opt, AbstractCobolField fnstatus)
             throws CobolStopRunException {
@@ -1631,11 +1636,11 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * レコードを実際に書き込む下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @param opt TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param opt WRITE文のオプション(COB_WRITE_*)
+     * @return ファイル状態コード
+     * @throws CobolStopRunException 実行時エラーが発生した場合
      */
     public int write_(int opt) throws CobolStopRunException {
         System.out.println("super.write");
@@ -1644,11 +1649,12 @@ public class CobolFile {
 
     // libcob/fileio.cのcob_file_write_optの実装
     /**
-     * TODO: 準備中
+     * WRITE文のオプションに応じた改行・改ページ処理を行う. LINAGE句がある場合はその専用処理へ委譲する.
+     * libcob/fileio.cのcob_file_write_optの実装.
      *
-     * @param opt TODO: 準備中
-     * @return TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param opt WRITE文のオプション(COB_WRITE_*)
+     * @return ファイル状態コード
+     * @throws CobolStopRunException 実行時エラーが発生した場合
      */
     protected int file_write_opt(int opt) throws CobolStopRunException {
         if ((this.flag_select_features & COB_SELECT_LINAGE) != 0) {
@@ -1665,11 +1671,11 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * 直前に読み込んだレコードを書き換える(REWRITE文の実装). オープンモードやレコード長を検査し, 結果をファイル状態に保存する.
      *
-     * @param rec TODO: 準備中
-     * @param opt TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param rec 書き換えるレコード
+     * @param opt REWRITE文のオプション
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void rewrite(AbstractCobolField rec, int opt, AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -1714,21 +1720,21 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * REWRITE処理の拡張版. 書き換えの下位処理を直接呼び出す.
      *
-     * @param rec TODO: 準備中
-     * @param opt TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param rec 書き換えるレコード
+     * @param opt REWRITE文のオプション
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void rewriteEx(AbstractCobolField rec, int opt, AbstractCobolField fnstatus) {
         this.rewrite_(opt);
     }
 
     /**
-     * TODO: 準備中
+     * レコードを実際に書き換える下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @param opt TODO: 準備中
-     * @return TODO: 準備中
+     * @param opt REWRITE文のオプション
+     * @return ファイル状態コード
      */
     public int rewrite_(int opt) {
         System.out.println("super.rewrite");
@@ -1736,9 +1742,9 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * 現在のレコードを削除する(DELETE文の実装). オープンモード等を検査し, 結果をファイル状態に保存する.
      *
-     * @param fnstatus TODO: 準備中
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void delete(AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -1770,18 +1776,18 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * DELETE処理の拡張版. 削除の下位処理を直接呼び出す.
      *
-     * @param fnstatus TODO: 準備中
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void deleteEx(AbstractCobolField fnstatus) {
         this.delete_();
     }
 
     /**
-     * TODO: 準備中
+     * レコードを実際に削除する下位処理. ファイル編成ごとにサブクラスで実装される.
      *
-     * @return TODO: 準備中
+     * @return ファイル状態コード
      */
     public int delete_() {
         System.out.println("super.delete");
@@ -1789,9 +1795,9 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * ファイルのロックを解除する(UNLOCK文の実装). 結果をファイル状態に保存する.
      *
-     * @param fnstatus TODO: 準備中
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void unlock(AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -1802,14 +1808,14 @@ public class CobolFile {
         saveStatus(COB_STATUS_00_SUCCESS, fnstatus);
     }
 
-    /** TODO: 準備中 */
+    /** ファイルのロックを解除する下位処理. 開いている場合はバッファをフラッシュしてロックを解放する. */
     public void unlock_() {
         if (this.open_mode != COB_OPEN_CLOSED && this.open_mode != COB_OPEN_LOCKED) {
             this.file.flush();
         }
     }
 
-    /** TODO: 準備中 */
+    /** COMMITを実行し, キャッシュされているすべてのファイルのロックを解除する. */
     public static void commit() {
         if (invokeFun(COB_IO_COMMIT, null, null, null, null, null, null, null) != 0) {
             return;
@@ -1819,7 +1825,7 @@ public class CobolFile {
         }
     }
 
-    /** TODO: 準備中 */
+    /** ROLLBACKを実行し, キャッシュされているすべてのファイルのロックを解除する. */
     public static void rollback() {
         if (invokeFun(COB_IO_ROLLBACK, null, null, null, null, null, null, null) != 0) {
             return;
@@ -1830,7 +1836,7 @@ public class CobolFile {
     }
 
     /// libcob/fileio.cのcob_exit_fileioの実装 TODO 一部だけ実装したため残りを実装する
-    /** TODO: 準備中 */
+    /** ファイル入出力処理の終了時に, 閉じられていないファイルについて暗黙的なCLOSEの警告を出力する. libcob/fileio.cのcob_exit_fileioの実装. */
     public static void exitFileIO() {
         for (CobolFile f : file_cache) {
             if (f.open_mode != COB_OPEN_CLOSED && f.open_mode != COB_OPEN_LOCKED) {
@@ -1845,10 +1851,10 @@ public class CobolFile {
 
     // libcob/fileio.cのcob_syncの実装
     /**
-     * TODO: 準備中
+     * ファイルの内容をディスクに同期(フラッシュ)する. libcob/fileio.cのcob_syncの実装.
      *
-     * @param f TODO: 準備中
-     * @param mode TODO: 準備中
+     * @param f 同期対象のファイル
+     * @param mode 同期の方式(2の場合はより強い同期を行う)
      */
     protected void cob_sync(CobolFile f, int mode) {
         // TODO
@@ -1864,7 +1870,7 @@ public class CobolFile {
     }
 
     // libcob/fileio.cのcob_init_fileioの実装
-    /** TODO: 準備中 */
+    /** ファイル入出力処理を初期化し, COB_SYNCやCOB_FILE_PATH等の関連する環境変数を読み込む. libcob/fileio.cのcob_init_fileioの実装. */
     public static void cob_init_fileio() {
         String s = CobolUtil.getEnv("COB_SYNC");
         if (s != null) {
@@ -1891,7 +1897,7 @@ public class CobolFile {
         file_open_buff = new byte[COB_SMALL_BUFF];
     }
 
-    /** TODO: 準備中 */
+    /** 直近に発生した入出力エラーのファイル状態に応じたエラーメッセージを出力する, 既定のエラーハンドラ. */
     public static void defaultErrorHandle() {
         byte[] fileStatus = CobolFile.errorFile.file_status;
         int status = (fileStatus[0] - '0') * 10 + (fileStatus[1] - '0');
@@ -1970,9 +1976,9 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * ファイルそのものを削除する(DELETE FILEの実装). ファイル名を解決した上でファイルを削除し, 結果をファイル状態に保存する.
      *
-     * @param fnstatus TODO: 準備中
+     * @param fnstatus FILE STATUS句で指定されたデータ項目
      */
     public void cob_delete_file(AbstractCobolField fnstatus) {
         String openMode = openModeToString(this.last_open_mode);
@@ -2125,9 +2131,9 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * SELECT句で指定されたファイルの名前を取得する.
      *
-     * @return TODO: 準備中
+     * @return ファイルの名前
      */
     public String getSelectName() {
         // CobolFile cobolFile = new CobolFile();
@@ -2135,9 +2141,9 @@ public class CobolFile {
     }
 
     /**
-     * TODO: 準備中
+     * ファイル状態(FILE STATUS)領域を取得する.
      *
-     * @return TODO: 準備中
+     * @return 2バイトのファイル状態領域
      */
     public byte[] getFileStatus() {
         // CobolFile cobolFile = new CobolFile();
@@ -2147,10 +2153,10 @@ public class CobolFile {
     private static Map<String, byte[]> externalFileStatusTable = new HashMap<String, byte[]>();
 
     /**
-     * TODO: 準備中
+     * 外部(EXTERNAL)ファイルのファイル状態領域を取得する. 未登録の場合は新たに確保して登録する.
      *
-     * @param key TODO: 準備中
-     * @return TODO: 準備中
+     * @param key 外部ファイルを識別するキー
+     * @return 2バイトのファイル状態領域
      */
     public static byte[] getExternalFileStatus(String key) {
         byte[] bytes = externalFileStatusTable.get(key);
@@ -2166,21 +2172,21 @@ public class CobolFile {
     private static Map<String, CobolFile> externalFileTable = new HashMap<String, CobolFile>();
 
     /**
-     * TODO: 準備中
+     * 指定したキーに対応する外部(EXTERNAL)ファイルを取得する.
      *
-     * @param key TODO: 準備中
-     * @return TODO: 準備中
+     * @param key 外部ファイルを識別するキー
+     * @return 対応するCobolFile(存在しない場合はnull)
      */
     public static CobolFile getExternalFile(String key) {
         return externalFileTable.get(key);
     }
 
     /**
-     * TODO: 準備中
+     * 指定したキーで外部(EXTERNAL)ファイルを登録する.
      *
-     * @param key TODO: 準備中
-     * @param value TODO: 準備中
-     * @return TODO: 準備中
+     * @param key 外部ファイルを識別するキー
+     * @param value 登録するCobolFile
+     * @return 以前に同じキーで登録されていたCobolFile(なければnull)
      */
     public static CobolFile putExternalFile(String key, CobolFile value) {
         return externalFileTable.put(key, value);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
@@ -23,6 +23,9 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 /** ファイル編成に応じた適切なCobolFileのサブクラスを生成するファクトリクラス. */
 public class CobolFileFactory {
 
+    /** ユーティリティクラスのインスタンス化を防ぐための private コンストラクタ。 */
+    private CobolFileFactory() {}
+
     /**
      * ファイル編成(organization)に応じて適切なCobolFileのサブクラスを生成する.
      * 順編成ならCobolSequentialFile,行順編成ならCobolLineSequentialFile,相対編成なら

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
@@ -20,38 +20,41 @@ package jp.osscons.opensourcecobol.libcobj.file;
 
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
-/** TODO: 準備中 */
+/** ファイル編成に応じた適切なCobolFileのサブクラスを生成するファクトリクラス. */
 public class CobolFileFactory {
 
     /**
-     * TODO: 準備中
+     * ファイル編成(organization)に応じて適切なCobolFileのサブクラスを生成する.
+     * 順編成ならCobolSequentialFile,行順編成ならCobolLineSequentialFile,相対編成なら
+     * CobolRelativeFile,索引編成ならCobolIndexedFileを生成し,いずれにも該当しない場合は
+     * 基底クラスCobolFileを生成する.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
-     * @return TODO: 準備中
+     * @param selectName SELECT句で指定されたファイル名
+     * @param fileStatus FILE STATUSのファイル状態コードを格納するバイト配列
+     * @param assign ASSIGN先(割り当てるファイル名)を表すCOBOLデータ項目
+     * @param record レコード領域を表すCOBOLデータ項目
+     * @param recordSize 現在のレコード長を表すCOBOLデータ項目
+     * @param recordMin レコードの最小長
+     * @param recordMax レコードの最大長
+     * @param nkeys 索引編成ファイルのキーの個数
+     * @param keys 索引編成ファイルのキー情報の配列
+     * @param organization ファイル編成(COB_ORG_*)
+     * @param accessMode アクセスモード(COB_ACCESS_*)
+     * @param lockMode ロック方式(COB_LOCK_*)
+     * @param openMode 現在のオープンモード(COB_OPEN_*)
+     * @param flagOptional SELECT句のOPTIONAL指定の有無
+     * @param lastOpenMode 直近のオープンモード(COB_OPEN_*)
+     * @param special 標準入出力などの特殊ファイルの種別
+     * @param flagNonexistent ファイルが存在しないことを示すフラグ
+     * @param flagEndOfFile ファイル終端に達したことを示すフラグ
+     * @param flagBeginOfFile ファイル先頭に達したことを示すフラグ
+     * @param flagFirstRead 最初の読み込みかどうかを示すフラグ
+     * @param flagReadDone 読み込みが実行済みかどうかを示すフラグ
+     * @param flagSelectFeatures SELECT句で指定された機能(COB_SELECT_*)を表すフラグ
+     * @param flagNeedsNl 次の書き込み前に改行の出力が必要かどうかを示すフラグ
+     * @param flagNeedsTop ページ先頭の処理が必要かどうかを示すフラグ
+     * @param fileVersion ファイルのバージョン
+     * @return organizationに応じて生成されたCobolFileのサブクラスのインスタンス
      */
     public static CobolFile makeCobolFileInstance(
             String selectName,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
@@ -21,7 +21,7 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /** ファイル編成に応じた適切なCobolFileのサブクラスを生成するファクトリクラス. */
-public class CobolFileFactory {
+public final class CobolFileFactory {
 
     /** ユーティリティクラスのインスタンス化を防ぐための private コンストラクタ。 */
     private CobolFileFactory() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -35,30 +35,33 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
 import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/**
+ * COBOL の SORT/MERGE 文の本体アルゴリズムを実装するクラス. メモリ上のキューと一時ファイルを用いた
+ * 外部マージソート,および表(TABLE)のソートを提供する.
+ */
 public class CobolFileSort {
-    /** TODO: 準備中 */
+    /** SORT/MERGE で取り出せるレコードが無くなったことを表す戻り値. */
     protected static final int COBSORTEND = 1;
 
-    /** TODO: 準備中 */
+    /** SORT/MERGE 処理が中断されたことを表す戻り値. */
     protected static final int COBSORTABORT = 2;
 
-    /** TODO: 準備中 */
+    /** 一時ファイルの入出力でエラーが発生したことを表す戻り値. */
     protected static final int COBSORTFILEERR = 3;
 
-    /** TODO: 準備中 */
+    /** SORT/MERGE が初期化されていないことを表す戻り値. */
     protected static final int COBSORTNOTOPEN = 4;
 
-    /** TODO: 準備中 */
+    /** キーを昇順で扱うことを表す定数. */
     protected static final int COB_ASCENDING = 0;
 
-    /** TODO: 準備中 */
+    /** キーを降順で扱うことを表す定数. */
     protected static final int COB_DESCENDING = 1;
 
     private static String cob_process_id = "";
     private static int cob_iteration = 0;
 
-    /** TODO: 準備中 */
+    /** SORT/MERGE でメモリ上に保持するレコード群に割り当てる最大バイト数. */
     protected static int cob_sort_memory = 128 * 1024 * 1024;
 
     // Javaの標準ライブラリでソートするならtrue
@@ -68,11 +71,11 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのsort_cmpsの実装
      *
-     * @param s1 TODO: 準備中
-     * @param s2 TODO: 準備中
-     * @param size TODO: 準備中
-     * @param col TODO: 準備中
-     * @return TODO: 準備中
+     * @param s1 比較する 1 つ目のバイト列
+     * @param s2 比較する 2 つ目のバイト列
+     * @param size 比較するバイト数
+     * @param col 文字の照合順序. nullの場合はバイト値をそのまま比較する
+     * @return s1がs2より小さいとき負,等しいとき0,大きいとき正の値
      */
     private static int sortCmps(
             CobolDataStorage s1, CobolDataStorage s2, int size, CobolDataStorage col) {
@@ -103,10 +106,10 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_file_sort_compareの実装
      *
-     * @param k1 TODO: 準備中
-     * @param k2 TODO: 準備中
-     * @param pointer TODO: 準備中
-     * @return TODO: 準備中
+     * @param k1 比較する 1 つ目のレコード
+     * @param k2 比較する 2 つ目のレコード
+     * @param pointer 比較キーの定義(keys)と照合順序を保持するCobolFile
+     * @return k1がk2より前に並ぶとき負,後に並ぶとき正の値. すべてのキーが等しい場合は投入順(一意番号)で比較する
      */
     private static int sortCompare(CobolItem k1, CobolItem k2, CobolFile pointer) {
         CobolFile f = pointer;
@@ -154,7 +157,7 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_free_listの実装
      *
-     * @param q TODO: 準備中
+     * @param q 解放対象のCobolItemの連結リストの先頭
      */
     private static void cob_free_list(CobolItem q) {
         // nothing to do
@@ -163,8 +166,8 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_new_itemの実装
      *
-     * @param hp TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @return フリーリストから再利用した,または新規生成したCobolItem
      */
     private static CobolItem newItem(CobolSort hp) {
         CobolItem q;
@@ -180,7 +183,7 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_tmpfileの実装
      *
-     * @return TODO: 準備中
+     * @return 生成した一時ファイルのFileIO. 生成に失敗した場合はnull
      */
     private static FileIO tmpfile() {
         FileIO fp = new FileIO();
@@ -227,9 +230,9 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_get_temp_fileの実装
      *
-     * @param hp TODO: 準備中
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @param n 対象とする一時ファイルの番号
+     * @return 一時ファイルが利用できない(fpがnull)場合true,利用できる場合false
      */
     private static boolean getTempFile(CobolSort hp, int n) {
         if (hp.getFile()[n].getFp() == null) {
@@ -249,8 +252,8 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_sort_queuesの実装
      *
-     * @param hp TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @return ソート済みのレコードが格納された最終的なキューの番号
      */
     private static int sortQueues(CobolSort hp) {
         CobolItem q;
@@ -317,9 +320,9 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_read_itemの実装
      *
-     * @param hp TODO: 準備中
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @param n 読み込み元の一時ファイル/キューの番号
+     * @return 読み込みに失敗した場合1,成功またはブロック終端に達した場合0
      */
     private static int readItem(CobolSort hp, int n) {
         FileIO fp = hp.getFile()[n].getFp();
@@ -344,9 +347,9 @@ public class CobolFileSort {
     /**
      * writeBlock内で使う補助メソッド
      *
-     * @param fp TODO: 準備中
-     * @param q TODO: 準備中
-     * @param hp TODO: 準備中
+     * @param fp 書き込み先の一時ファイル
+     * @param q 書き込む 1 レコード
+     * @param hp SORT/MERGE の実行状態
      * @return 書き込み失敗時true,それ以外はfalse
      */
     private static boolean writeItem(FileIO fp, CobolItem q, CobolSort hp) {
@@ -364,9 +367,9 @@ public class CobolFileSort {
     /**
      * libcob/fileio.cのcob_write_blockの実装
      *
-     * @param hp TODO: 準備中
-     * @param n TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @param n 書き出すキューの番号
+     * @return 書き込みに失敗した場合1,成功した場合0
      */
     private static int writeBlock(CobolSort hp, int n) {
         FileIO fp = hp.getFile()[hp.getDestinationFile()].getFp();
@@ -392,9 +395,10 @@ public class CobolFileSort {
     }
 
     /**
-     * libcob/fileio.cのcob_copy_checkの実装
+     * libcob/fileio.cのcob_copy_checkの実装. fromのレコードをtoのレコードへコピーし,
+     * toの方が大きい場合は不足分を空白で埋める.
      *
-     * @param from TODO: 準備中
+     * @param from コピー元のCobolFile
      */
     private static void copyCheck(CobolFile to, CobolFile from) {
         CobolDataStorage toptr = to.record.getDataStorage();
@@ -416,10 +420,11 @@ public class CobolFileSort {
     }
 
     /**
-     * libcob/fileio.cのcob_file_sort_processの実装
+     * libcob/fileio.cのcob_file_sort_processの実装. メモリ上でソートし,一時ファイルを使用した場合は
+     * 各ブロックを繰り返しマージして最終的なソート結果を得る.
      *
-     * @param hp TODO: 準備中
-     * @return TODO: 準備中
+     * @param hp SORT/MERGE の実行状態
+     * @return 正常に完了した場合0,一時ファイルの入出力に失敗した場合COBSORTFILEERR
      */
     private static int sortProcess(CobolSort hp) {
         hp.setRetrieving(1);
@@ -509,10 +514,10 @@ public class CobolFileSort {
     }
 
     /**
-     * libcob/fileio.cのcob_file_sort_submitの実装
+     * libcob/fileio.cのcob_file_sort_submitの実装. 1 レコードをソート対象として投入する.
      *
-     * @param p TODO: 準備中
-     * @return TODO: 準備中
+     * @param p 投入するレコードのデータ
+     * @return 正常に投入できた場合0,エラーの場合はCOBSORTNOTOPEN等のエラーコード
      */
     private static int sortSubmit(CobolFile f, CobolDataStorage p) {
 
@@ -579,10 +584,10 @@ public class CobolFileSort {
     }
 
     /**
-     * libcob/fileio.cのcob_file_sort_retrieveの実装
+     * libcob/fileio.cのcob_file_sort_retrieveの実装. ソート済みのレコードを 1 件取り出す.
      *
-     * @param p TODO: 準備中
-     * @return TODO: 準備中
+     * @param p 取り出したレコードを格納する領域
+     * @return 正常に取り出せた場合0,全レコードを取り出し終えた場合COBSORTEND,エラーの場合はエラーコード
      */
     private static int sortRetrieve(CobolFile f, CobolDataStorage p) {
         CobolSort hp = f.filex;
@@ -700,13 +705,13 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_initの実装
     /**
-     * TODO: 準備中
+     * SORT/MERGE を初期化する. CobolSortの実行状態を生成してファイルに関連付け,キー配列と照合順序を準備する.
      *
-     * @param f TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param collatingSequence TODO: 準備中
-     * @param sortReturn TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param f SORT/MERGE の対象となる整列用ファイル
+     * @param nkeys 比較キーの数
+     * @param collatingSequence 文字の照合順序. nullの場合は現在のモジュールの照合順序を用いる
+     * @param sortReturn SORT-RETURN 特殊レジスタ相当の結果コードを格納する領域
+     * @param fnstatus FILE STATUS を格納する項目
      */
     public static void sortInit(
             CobolFile f,
@@ -742,13 +747,13 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_initの実装
     /**
-     * TODO: 準備中
+     * SORT/MERGE を初期化する. 照合順序を指定しない場合に用いる多重定義で,常に現在のモジュールの照合順序を使用する.
      *
-     * @param f TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param collatingSequence TODO: 準備中
-     * @param sortReturn TODO: 準備中
-     * @param fnstatus TODO: 準備中
+     * @param f SORT/MERGE の対象となる整列用ファイル
+     * @param nkeys 比較キーの数
+     * @param collatingSequence 照合順序を表す整数(この多重定義では無視され,常にnullとして扱われる)
+     * @param sortReturn SORT-RETURN 特殊レジスタ相当の結果コードを格納する領域
+     * @param fnstatus FILE STATUS を格納する項目
      */
     public static void sortInit(
             CobolFile f,
@@ -761,12 +766,12 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_init_keyの実装
     /**
-     * TODO: 準備中
+     * SORT/MERGE の比較キーを 1 つ登録する.
      *
-     * @param f TODO: 準備中
-     * @param flag TODO: 準備中
-     * @param field TODO: 準備中
-     * @param offset TODO: 準備中
+     * @param f SORT/MERGE の対象となる整列用ファイル
+     * @param flag 昇順(COB_ASCENDING)か降順(COB_DESCENDING)かを表すフラグ
+     * @param field キーとなる項目
+     * @param offset レコード先頭からのキーの相対位置
      */
     public static void sortInitKey(CobolFile f, int flag, AbstractCobolField field, int offset) {
         f.keys[f.nkeys].setFlag(flag);
@@ -777,10 +782,10 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_usingの実装
     /**
-     * TODO: 準備中
+     * USING 指定の入力ファイルを順に読み,全レコードをソート対象として投入する.
      *
-     * @param sortFile TODO: 準備中
-     * @param dataFile TODO: 準備中
+     * @param sortFile レコードを投入する整列用ファイル
+     * @param dataFile USING で指定された入力ファイル
      */
     public static void sortUsing(CobolFile sortFile, CobolFile dataFile) {
         dataFile.open(CobolFile.COB_OPEN_INPUT, 0, null);
@@ -800,12 +805,12 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_givingの実装
     /**
-     * TODO: 準備中
+     * ソート済みのレコードを順に取り出し,GIVING 指定の出力ファイル群へ書き出す.
      *
-     * @param sortFile TODO: 準備中
-     * @param varcnt TODO: 準備中
-     * @param fbase TODO: 準備中
-     * @throws CobolStopRunException TODO: 準備中
+     * @param sortFile ソート済みレコードの取り出し元となる整列用ファイル
+     * @param varcnt 出力ファイルの数
+     * @param fbase GIVING で指定された出力ファイルの配列
+     * @throws CobolStopRunException 出力ファイルへの書き込み中に実行停止が発生した場合
      */
     public static void sortGiving(CobolFile sortFile, int varcnt, CobolFile... fbase)
             throws CobolStopRunException {
@@ -881,9 +886,9 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_sort_closeの実装
     /**
-     * TODO: 準備中
+     * SORT/MERGE を終了し,使用したメモリと一時ファイルを解放する.
      *
-     * @param f TODO: 準備中
+     * @param f 後始末を行う整列用ファイル
      */
     public static void sortClose(CobolFile f) {
         AbstractCobolField fnstatus = null;
@@ -905,9 +910,9 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_releaseの実装
     /**
-     * TODO: 準備中
+     * RELEASE 文の処理を行い,ファイルの現レコードをソート対象として投入する.
      *
-     * @param f TODO: 準備中
+     * @param f RELEASE 文の対象となる整列用ファイル
      */
     public static void performRelease(CobolFile f) {
         AbstractCobolField fnstatus = null;
@@ -932,9 +937,9 @@ public class CobolFileSort {
 
     // libcob/fileio.cのcob_file_returnの実装
     /**
-     * TODO: 準備中
+     * RETURN 文の処理を行い,ソート済みレコードを 1 件ファイルの現レコードへ取り出す.
      *
-     * @param f TODO: 準備中
+     * @param f RETURN 文の対象となる整列用ファイル
      */
     public static void performReturn(CobolFile f) {
         AbstractCobolField fnstatus = null;
@@ -987,20 +992,20 @@ public class CobolFileSort {
                             CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0, 0, 0, null));
 
     /**
-     * TODO: 準備中
+     * 表(TABLE)のソートを初期化する. 照合順序を指定しない場合に用いる多重定義で,常に現在のモジュールの照合順序を使用する.
      *
-     * @param nkeys TODO: 準備中
-     * @param collatingSequence TODO: 準備中
+     * @param nkeys 比較キーの数
+     * @param collatingSequence 照合順序を表す整数(この多重定義では無視され,常にnullとして扱われる)
      */
     public static void sortTableInit(int nkeys, int collatingSequence) {
         sortTableInit(nkeys, null);
     }
 
     /**
-     * TODO: 準備中
+     * 表(TABLE)のソートを初期化する. キー配列と照合順序を準備する.
      *
-     * @param nkeys TODO: 準備中
-     * @param collatingSequence TODO: 準備中
+     * @param nkeys 比較キーの数
+     * @param collatingSequence 文字の照合順序. nullの場合は現在のモジュールの照合順序を用いる
      */
     public static void sortTableInit(int nkeys, CobolDataStorage collatingSequence) {
         sortNKeys = 0;
@@ -1015,11 +1020,11 @@ public class CobolFileSort {
     }
 
     /**
-     * TODO: 準備中
+     * 表(TABLE)ソートの比較キーを 1 つ登録する.
      *
-     * @param flag TODO: 準備中
-     * @param field TODO: 準備中
-     * @param offset TODO: 準備中
+     * @param flag 昇順(COB_ASCENDING)か降順(COB_DESCENDING)かを表すフラグ
+     * @param field キーとなる項目
+     * @param offset レコード先頭からのキーの相対位置
      */
     public static void sortTableInitKey(int flag, AbstractCobolField field, int offset) {
         if (sortKeys[sortNKeys] == null) {
@@ -1034,10 +1039,11 @@ public class CobolFileSort {
     }
 
     /**
-     * TODO: 準備中
+     * 表(TABLE)を登録済みのキーに従ってソートする. 添字の配列に対してクイックソートを行い,
+     * その結果に従って表の要素を並べ替える.
      *
-     * @param f TODO: 準備中
-     * @param n TODO: 準備中
+     * @param f ソート対象の表の先頭要素を表す項目
+     * @param n 表の要素数
      */
     public static void sortTable(AbstractCobolField f, int n) {
         int recordSize = f.getSize();

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolItem.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolItem.java
@@ -20,7 +20,7 @@ package jp.osscons.opensourcecobol.libcobj.file;
 
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
-/** TODO: 準備中 */
+/** SORT/MERGE でメモリ上に読み込んだ 1 レコードを表す連結リストの要素. */
 class CobolItem {
     private CobolItem next;
     private int endOfBlock;
@@ -29,115 +29,115 @@ class CobolItem {
     private CobolDataStorage unique = new CobolDataStorage(new byte[8]);
     private CobolDataStorage item;
 
-    /** TODO: 準備中 */
+    /** 連結リストの次要素をnull,ブロック終端フラグを0にして初期化する. */
     CobolItem() {
         this.next = null;
         this.endOfBlock = 0;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リスト上で次に位置する要素を取得する.
      *
-     * @return TODO: 準備中
+     * @return 次のCobolItem. 末尾の場合はnull
      */
     CobolItem getNext() {
         return next;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リスト上で次に位置する要素を設定する.
      *
-     * @param next TODO: 準備中
+     * @param next 次のCobolItem
      */
     void setNext(CobolItem next) {
         this.next = next;
     }
 
     /**
-     * TODO: 準備中
+     * このレコードがブロックの終端であるかを表すフラグを取得する.
      *
-     * @return TODO: 準備中
+     * @return ブロックの終端なら1,そうでなければ0
      */
     int getEndOfBlock() {
         return endOfBlock;
     }
 
     /**
-     * TODO: 準備中
+     * このレコードがブロックの終端であるかを表すフラグを設定する.
      *
-     * @param endOfBlock TODO: 準備中
+     * @param endOfBlock ブロックの終端なら1,そうでなければ0
      */
     void setEndOfBlock(int endOfBlock) {
         this.endOfBlock = endOfBlock;
     }
 
     /**
-     * TODO: 準備中
+     * このレコードの実際のサイズ(可変長レコードの長さ)を取得する.
      *
-     * @return TODO: 準備中
+     * @return レコードのサイズ(バイト数)
      */
     int getRecordSize() {
         return recordSize;
     }
 
     /**
-     * TODO: 準備中
+     * このレコードの実際のサイズ(可変長レコードの長さ)を設定する.
      *
-     * @param recordSize TODO: 準備中
+     * @param recordSize レコードのサイズ(バイト数)
      */
     void setRecordSize(int recordSize) {
         this.recordSize = recordSize;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへ書き込む際に各レコードの先頭へ付加するブロック区切り用のバイトを取得する.
      *
-     * @return TODO: 準備中
+     * @return ブロック区切り用のバイト
      */
     byte getBlockByte() {
         return blockByte;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへ書き込む際に各レコードの先頭へ付加するブロック区切り用のバイトを設定する.
      *
-     * @param blockByte TODO: 準備中
+     * @param blockByte ブロック区切り用のバイト
      */
     void setBlockByte(byte blockByte) {
         this.blockByte = blockByte;
     }
 
     /**
-     * TODO: 準備中
+     * レコードの投入順を表す一意な番号(安定ソートのために使うキー)を取得する.
      *
-     * @return TODO: 準備中
+     * @return 8バイトで表現された一意な番号を保持するCobolDataStorage
      */
     CobolDataStorage getUnique() {
         return unique;
     }
 
     /**
-     * TODO: 準備中
+     * レコードの投入順を表す一意な番号(安定ソートのために使うキー)を設定する.
      *
-     * @param unique TODO: 準備中
+     * @param unique 8バイトで表現された一意な番号を保持するCobolDataStorage
      */
     void setUnique(CobolDataStorage unique) {
         this.unique = unique;
     }
 
     /**
-     * TODO: 準備中
+     * レコードのデータ本体を取得する.
      *
-     * @return TODO: 準備中
+     * @return レコードのデータ本体を保持するCobolDataStorage
      */
     CobolDataStorage getItem() {
         return item;
     }
 
     /**
-     * TODO: 準備中
+     * レコードのデータ本体を設定する.
      *
-     * @param item TODO: 準備中
+     * @param item レコードのデータ本体を保持するCobolDataStorage
      */
     void setItem(CobolDataStorage item) {
         this.item = item;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolLineSequentialFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolLineSequentialFile.java
@@ -23,37 +23,37 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/** 行順編成ファイル(LINE SEQUENTIAL)のI/Oを実装するCobolFileのサブクラス. */
 public class CobolLineSequentialFile extends CobolFile {
 
     /**
-     * TODO: 準備中
+     * 行順編成ファイルを表すインスタンスを生成する.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
+     * @param selectName SELECT句で指定されたファイルの内部名.
+     * @param fileStatus FILE STATUS句に対応するファイル状態コードを格納するバイト配列.
+     * @param assign ASSIGN句で指定された割り当て先(物理ファイル名等)を保持する変数.
+     * @param record レコード領域を表す変数.
+     * @param recordSize 実際のレコード長を格納する変数.
+     * @param recordMin 最小レコード長.
+     * @param recordMax 最大レコード長.
+     * @param nkeys キーの数.
+     * @param keys ファイルのキー情報の配列.
+     * @param organization ファイル編成を表す値.
+     * @param accessMode アクセスモード(順/動的/乱).
+     * @param lockMode ファイルのロック方式.
+     * @param openMode 現在のオープンモード.
+     * @param flagOptional SELECT句にOPTIONALが指定されているかどうかを表すフラグ.
+     * @param lastOpenMode 最後に開いたときのオープンモード.
+     * @param special 特殊ファイル(標準入出力等)の種別.
+     * @param flagNonexistent ファイルが存在しないかどうかを表すフラグ.
+     * @param flagEndOfFile ファイル終端に達したかどうかを表すフラグ.
+     * @param flagBeginOfFile ファイル先頭に達したかどうかを表すフラグ.
+     * @param flagFirstRead 最初の読み込みかどうかを表すフラグ.
+     * @param flagReadDone 読み込みが行われたかどうかを表すフラグ.
+     * @param flagSelectFeatures SELECT句で指定された機能(FILE STATUS/EXTERNAL/LINAGE/SPLIT KEY)の有無を表すビットフラグ.
+     * @param flagNeedsNl 次の書き込み前に改行の出力が必要かどうかを表すフラグ.
+     * @param flagNeedsTop 次の書き込み前にページ先頭の処理が必要かどうかを表すフラグ.
+     * @param fileVersion ファイル構造のバージョン.
      */
     public CobolLineSequentialFile(
             String selectName,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolRelativeFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolRelativeFile.java
@@ -25,55 +25,55 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
-/** TODO: 準備中 */
+/** 相対編成ファイル(RELATIVE)のI/Oを実装するCobolFileのサブクラス. */
 public class CobolRelativeFile extends CobolFile {
 
-    /** TODO: 準備中 */
+    /** START文でキーと相対レコード番号を等値(=)で比較することを表す定数. */
     protected static final int COB_EQ = 1;
 
-    /** TODO: 準備中 */
+    /** START文でキーと相対レコード番号を小なり(&lt;)で比較することを表す定数. */
     protected static final int COB_LT = 2;
 
-    /** TODO: 準備中 */
+    /** START文でキーと相対レコード番号を以下(&lt;=)で比較することを表す定数. */
     protected static final int COB_LE = 3;
 
-    /** TODO: 準備中 */
+    /** START文でキーと相対レコード番号を大なり(&gt;)で比較することを表す定数. */
     protected static final int COB_GT = 4;
 
-    /** TODO: 準備中 */
+    /** START文でキーと相対レコード番号を以上(&gt;=)で比較することを表す定数. */
     protected static final int COB_GE = 5;
 
     RandomAccessFile fp;
     byte[] size = new byte[8];
 
     /**
-     * TODO: 準備中
+     * 相対編成ファイルを表すインスタンスを生成する.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
+     * @param selectName SELECT句で指定されたファイルの内部名.
+     * @param fileStatus FILE STATUS句に対応するファイル状態コードを格納するバイト配列.
+     * @param assign ASSIGN句で指定された割り当て先(物理ファイル名等)を保持する変数.
+     * @param record レコード領域を表す変数.
+     * @param recordSize 実際のレコード長を格納する変数.
+     * @param recordMin 最小レコード長.
+     * @param recordMax 最大レコード長.
+     * @param nkeys キーの数.
+     * @param keys ファイルのキー情報の配列.
+     * @param organization ファイル編成を表す値.
+     * @param accessMode アクセスモード(順/動的/乱).
+     * @param lockMode ファイルのロック方式.
+     * @param openMode 現在のオープンモード.
+     * @param flagOptional SELECT句にOPTIONALが指定されているかどうかを表すフラグ.
+     * @param lastOpenMode 最後に開いたときのオープンモード.
+     * @param special 特殊ファイル(標準入出力等)の種別.
+     * @param flagNonexistent ファイルが存在しないかどうかを表すフラグ.
+     * @param flagEndOfFile ファイル終端に達したかどうかを表すフラグ.
+     * @param flagBeginOfFile ファイル先頭に達したかどうかを表すフラグ.
+     * @param flagFirstRead 最初の読み込みかどうかを表すフラグ.
+     * @param flagReadDone 読み込みが行われたかどうかを表すフラグ.
+     * @param flagSelectFeatures SELECT句で指定された機能(FILE STATUS/EXTERNAL/LINAGE/SPLIT KEY)の有無を表すビットフラグ.
+     * @param flagNeedsNl 次の書き込み前に改行の出力が必要かどうかを表すフラグ.
+     * @param flagNeedsTop 次の書き込み前にページ先頭の処理が必要かどうかを表すフラグ.
+     * @param fileVersion ファイル構造のバージョン.
      */
     public CobolRelativeFile(
             String selectName,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSequentialFile.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSequentialFile.java
@@ -23,37 +23,37 @@ import java.nio.ByteBuffer;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
-/** TODO: 準備中 */
+/** 順編成ファイル(SEQUENTIAL)のI/Oを実装するCobolFileのサブクラス. */
 public class CobolSequentialFile extends CobolFile {
 
     /**
-     * TODO: 準備中
+     * 順編成ファイルを表すインスタンスを生成する.
      *
-     * @param selectName TODO: 準備中
-     * @param fileStatus TODO: 準備中
-     * @param assign TODO: 準備中
-     * @param record TODO: 準備中
-     * @param recordSize TODO: 準備中
-     * @param recordMin TODO: 準備中
-     * @param recordMax TODO: 準備中
-     * @param nkeys TODO: 準備中
-     * @param keys TODO: 準備中
-     * @param organization TODO: 準備中
-     * @param accessMode TODO: 準備中
-     * @param lockMode TODO: 準備中
-     * @param openMode TODO: 準備中
-     * @param flagOptional TODO: 準備中
-     * @param lastOpenMode TODO: 準備中
-     * @param special TODO: 準備中
-     * @param flagNonexistent TODO: 準備中
-     * @param flagEndOfFile TODO: 準備中
-     * @param flagBeginOfFile TODO: 準備中
-     * @param flagFirstRead TODO: 準備中
-     * @param flagReadDone TODO: 準備中
-     * @param flagSelectFeatures TODO: 準備中
-     * @param flagNeedsNl TODO: 準備中
-     * @param flagNeedsTop TODO: 準備中
-     * @param fileVersion TODO: 準備中
+     * @param selectName SELECT句で指定されたファイルの内部名.
+     * @param fileStatus FILE STATUS句に対応するファイル状態コードを格納するバイト配列.
+     * @param assign ASSIGN句で指定された割り当て先(物理ファイル名等)を保持する変数.
+     * @param record レコード領域を表す変数.
+     * @param recordSize 実際のレコード長を格納する変数.
+     * @param recordMin 最小レコード長.
+     * @param recordMax 最大レコード長.
+     * @param nkeys キーの数.
+     * @param keys ファイルのキー情報の配列.
+     * @param organization ファイル編成を表す値.
+     * @param accessMode アクセスモード(順/動的/乱).
+     * @param lockMode ファイルのロック方式.
+     * @param openMode 現在のオープンモード.
+     * @param flagOptional SELECT句にOPTIONALが指定されているかどうかを表すフラグ.
+     * @param lastOpenMode 最後に開いたときのオープンモード.
+     * @param special 特殊ファイル(標準入出力等)の種別.
+     * @param flagNonexistent ファイルが存在しないかどうかを表すフラグ.
+     * @param flagEndOfFile ファイル終端に達したかどうかを表すフラグ.
+     * @param flagBeginOfFile ファイル先頭に達したかどうかを表すフラグ.
+     * @param flagFirstRead 最初の読み込みかどうかを表すフラグ.
+     * @param flagReadDone 読み込みが行われたかどうかを表すフラグ.
+     * @param flagSelectFeatures SELECT句で指定された機能(FILE STATUS/EXTERNAL/LINAGE/SPLIT KEY)の有無を表すビットフラグ.
+     * @param flagNeedsNl 次の書き込み前に改行の出力が必要かどうかを表すフラグ.
+     * @param flagNeedsTop 次の書き込み前にページ先頭の処理が必要かどうかを表すフラグ.
+     * @param fileVersion ファイル構造のバージョン.
      */
     public CobolSequentialFile(
             String selectName,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolSort.java
@@ -21,7 +21,7 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
-/** TODO: 準備中 */
+/** SORT/MERGE の実行状態(入出力ファイル,比較キー,マージ用のキューと一時ファイル等)を保持するクラス. */
 class CobolSort {
     private CobolFile pointer;
     private CobolItem empty;
@@ -39,7 +39,7 @@ class CobolSort {
     private MemoryStruct[] queue = new MemoryStruct[4];
     private FileStruct[] file = new FileStruct[4];
 
-    /** TODO: 準備中 */
+    /** マージ用の 4 本のキュー(MemoryStruct)と 4 本の一時ファイル(FileStruct)を生成して初期化する. */
     CobolSort() {
         for (int i = 0; i < 4; ++i) {
             this.queue[i] = new MemoryStruct();
@@ -48,270 +48,270 @@ class CobolSort {
     }
 
     /**
-     * TODO: 準備中
+     * SORT/MERGE の対象となるCobolFileを取得する.
      *
-     * @return TODO: 準備中
+     * @return SORT/MERGE の対象となるCobolFile
      */
     CobolFile getPointer() {
         return pointer;
     }
 
     /**
-     * TODO: 準備中
+     * SORT/MERGE の対象となるCobolFileを設定する.
      *
-     * @param pointer TODO: 準備中
+     * @param pointer SORT/MERGE の対象となるCobolFile
      */
     void setPointer(CobolFile pointer) {
         this.pointer = pointer;
     }
 
     /**
-     * TODO: 準備中
+     * 再利用可能な空きCobolItemを繋いだフリーリストの先頭を取得する.
      *
-     * @return TODO: 準備中
+     * @return 空きCobolItemのフリーリストの先頭
      */
     CobolItem getEmpty() {
         return empty;
     }
 
     /**
-     * TODO: 準備中
+     * 再利用可能な空きCobolItemを繋いだフリーリストの先頭を設定する.
      *
-     * @param empty TODO: 準備中
+     * @param empty 空きCobolItemのフリーリストの先頭
      */
     void setEmpty(CobolItem empty) {
         this.empty = empty;
     }
 
     /**
-     * TODO: 準備中
+     * SORT/MERGE の結果コード(SORT-RETURN 特殊レジスタ相当. エラー時に16が設定される)を保持する領域を取得する.
      *
-     * @return TODO: 準備中
+     * @return SORT-RETURN 特殊レジスタ相当の領域
      */
     CobolDataStorage getSortReturn() {
         return sortReturn;
     }
 
     /**
-     * TODO: 準備中
+     * SORT/MERGE の結果コード(SORT-RETURN 特殊レジスタ相当. エラー時に16が設定される)を保持する領域を設定する.
      *
-     * @param sortReturn TODO: 準備中
+     * @param sortReturn SORT-RETURN 特殊レジスタ相当の領域
      */
     void setSortReturn(CobolDataStorage sortReturn) {
         this.sortReturn = sortReturn;
     }
 
     /**
-     * TODO: 準備中
+     * ファイル状態(FILE STATUS)を格納する項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return FILE STATUS を格納する項目
      */
     AbstractCobolField getFnstatus() {
         return fnstatus;
     }
 
     /**
-     * TODO: 準備中
+     * ファイル状態(FILE STATUS)を格納する項目を設定する.
      *
-     * @param fnstatus TODO: 準備中
+     * @param fnstatus FILE STATUS を格納する項目
      */
     void setFnstatus(AbstractCobolField fnstatus) {
         this.fnstatus = fnstatus;
     }
 
     /**
-     * TODO: 準備中
+     * 次に投入するレコードへ割り当てる一意番号(レコード投入ごとに増加し,安定ソートに用いる)を取得する.
      *
-     * @return TODO: 準備中
+     * @return 次に割り当てる一意番号
      */
     int getUnique() {
         return unique;
     }
 
     /**
-     * TODO: 準備中
+     * 次に投入するレコードへ割り当てる一意番号(レコード投入ごとに増加し,安定ソートに用いる)を設定する.
      *
-     * @param unique TODO: 準備中
+     * @param unique 次に割り当てる一意番号
      */
     void setUnique(int unique) {
         this.unique = unique;
     }
 
     /**
-     * TODO: 準備中
+     * ソートが完了し取り出し(RETURN)フェーズに入っているかを表すフラグを取得する.
      *
-     * @return TODO: 準備中
+     * @return 取り出しフェーズに入っていれば0以外,そうでなければ0
      */
     int getRetrieving() {
         return retrieving;
     }
 
     /**
-     * TODO: 準備中
+     * ソートが完了し取り出し(RETURN)フェーズに入っているかを表すフラグを設定する.
      *
-     * @param retrieving TODO: 準備中
+     * @param retrieving 取り出しフェーズに入っていれば0以外,そうでなければ0
      */
     void setRetrieving(int retrieving) {
         this.retrieving = retrieving;
     }
 
     /**
-     * TODO: 準備中
+     * メモリに収まらず一時ファイルを用いた外部マージソートを行っているかを表すフラグを取得する.
      *
-     * @return TODO: 準備中
+     * @return 一時ファイルを使用していれば0以外,そうでなければ0
      */
     int getFilesUsed() {
         return filesUsed;
     }
 
     /**
-     * TODO: 準備中
+     * メモリに収まらず一時ファイルを用いた外部マージソートを行っているかを表すフラグを設定する.
      *
-     * @param filesUsed TODO: 準備中
+     * @param filesUsed 一時ファイルを使用していれば0以外,そうでなければ0
      */
     void setFilesUsed(int filesUsed) {
         this.filesUsed = filesUsed;
     }
 
     /**
-     * TODO: 準備中
+     * ソート対象レコード 1 件のサイズ(バイト数)を取得する.
      *
-     * @return TODO: 準備中
+     * @return レコード 1 件のサイズ(バイト数)
      */
     int getSize() {
         return size;
     }
 
     /**
-     * TODO: 準備中
+     * ソート対象レコード 1 件のサイズ(バイト数)を設定する.
      *
-     * @param size TODO: 準備中
+     * @param size レコード 1 件のサイズ(バイト数)
      */
     void setSize(int size) {
         this.size = size;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルからの読み込み単位のサイズ(レコードサイズ + 一意番号 8 バイト)を取得する.
      *
-     * @return TODO: 準備中
+     * @return 読み込み単位のサイズ(バイト数)
      */
     int getrSize() {
         return rSize;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルからの読み込み単位のサイズ(レコードサイズ + 一意番号 8 バイト)を設定する.
      *
-     * @param rSize TODO: 準備中
+     * @param rSize 読み込み単位のサイズ(バイト数)
      */
     void setrSize(int rSize) {
         this.rSize = rSize;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへの書き込み単位のサイズ(レコードサイズ + 一意番号 8 バイト + ブロックバイト 1 バイト)を取得する.
      *
-     * @return TODO: 準備中
+     * @return 書き込み単位のサイズ(バイト数)
      */
     int getwSize() {
         return wSize;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへの書き込み単位のサイズ(レコードサイズ + 一意番号 8 バイト + ブロックバイト 1 バイト)を設定する.
      *
-     * @param wSize TODO: 準備中
+     * @param wSize 書き込み単位のサイズ(バイト数)
      */
     void setwSize(int wSize) {
         this.wSize = wSize;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへ書き出す前にメモリ上に保持できるレコード数の上限を取得する.
      *
-     * @return TODO: 準備中
+     * @return メモリ上に保持できるレコード数の上限
      */
     int getMemory() {
         return memory;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへ書き出す前にメモリ上に保持できるレコード数の上限を設定する.
      *
-     * @param memory TODO: 準備中
+     * @param memory メモリ上に保持できるレコード数の上限
      */
     void setMemory(int memory) {
         this.memory = memory;
     }
 
     /**
-     * TODO: 準備中
+     * ソート済みブロックの書き込み先となる一時ファイルの番号を取得する.
      *
-     * @return TODO: 準備中
+     * @return 書き込み先の一時ファイルの番号
      */
     int getDestinationFile() {
         return destinationFile;
     }
 
     /**
-     * TODO: 準備中
+     * ソート済みブロックの書き込み先となる一時ファイルの番号を設定する.
      *
-     * @param destinationFile TODO: 準備中
+     * @param destinationFile 書き込み先の一時ファイルの番号
      */
     void setDestinationFile(int destinationFile) {
         this.destinationFile = destinationFile;
     }
 
     /**
-     * TODO: 準備中
+     * 取り出し(RETURN)時にソート済みレコードを読み出す元となるキュー/一時ファイルの番号を取得する.
      *
-     * @return TODO: 準備中
+     * @return 取り出し元のキュー/一時ファイルの番号
      */
     int getRetrievalQueue() {
         return retrievalQueue;
     }
 
     /**
-     * TODO: 準備中
+     * 取り出し(RETURN)時にソート済みレコードを読み出す元となるキュー/一時ファイルの番号を設定する.
      *
-     * @param retrievalQueue TODO: 準備中
+     * @param retrievalQueue 取り出し元のキュー/一時ファイルの番号
      */
     void setRetrievalQueue(int retrievalQueue) {
         this.retrievalQueue = retrievalQueue;
     }
 
     /**
-     * TODO: 準備中
+     * マージ処理で用いるメモリ上のキュー(4 本)の配列を取得する.
      *
-     * @return TODO: 準備中
+     * @return メモリ上のキュー(MemoryStruct)の配列
      */
     MemoryStruct[] getQueue() {
         return queue;
     }
 
     /**
-     * TODO: 準備中
+     * マージ処理で用いるメモリ上のキュー(4 本)の配列を設定する.
      *
-     * @param queue TODO: 準備中
+     * @param queue メモリ上のキュー(MemoryStruct)の配列
      */
     void setQueue(MemoryStruct[] queue) {
         this.queue = queue;
     }
 
     /**
-     * TODO: 準備中
+     * マージ処理で用いる一時ファイル(4 本)の配列を取得する.
      *
-     * @return TODO: 準備中
+     * @return 一時ファイル(FileStruct)の配列
      */
     FileStruct[] getFile() {
         return file;
     }
 
     /**
-     * TODO: 準備中
+     * マージ処理で用いる一時ファイル(4 本)の配列を設定する.
      *
-     * @param file TODO: 準備中
+     * @param file 一時ファイル(FileStruct)の配列
      */
     void setFile(FileStruct[] file) {
         this.file = file;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileIO.java
@@ -29,7 +29,7 @@ import java.nio.channels.NonReadableChannelException;
 import java.nio.channels.NonWritableChannelException;
 import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 
-/** TODO: 準備中 */
+/** FileChannelや標準入出力をラップし,COBOLファイルの低水準な読み書き・バッファ処理・ロックを担うクラス. */
 class FileIO {
 
     private FileChannel fc;
@@ -48,7 +48,7 @@ class FileIO {
     private int writeBufferEndIndex = 0;
     private byte[] writeBuffer;
 
-    /** TODO: 準備中 */
+    /** 標準入出力を利用する状態でインスタンスを生成し,読み込みバッファを初期化する. */
     FileIO() {
         this.useStdOut = true;
         this.useStdIn = true;
@@ -59,19 +59,19 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * 直前の読み込みでファイル終端に達したかどうかを返す.
      *
-     * @return TODO: 準備中
+     * @return ファイル終端に達している場合はtrue.
      */
     boolean isAtEnd() {
         return this.atEnd;
     }
 
     /**
-     * TODO: 準備中
+     * 読み書き対象のFileChannelとファイルロックを設定し,標準入出力の使用を無効にする.
      *
-     * @param fc TODO: 準備中
-     * @param fl TODO: 準備中
+     * @param fc 読み書きに使用するFileChannel.
+     * @param fl ファイルに対して取得したロック(不要な場合はnull).
      */
     void setChannel(FileChannel fc, FileLock fl) {
         this.fc = fc;
@@ -81,10 +81,10 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * RandomAccessFileから得たFileChannelとファイルロックを設定し,標準入出力の使用を無効にする.
      *
-     * @param ra TODO: 準備中
-     * @param fl TODO: 準備中
+     * @param ra 読み書きに使用するRandomAccessFile.
+     * @param fl ファイルに対して取得したロック(不要な場合はnull).
      */
     void setRandomAccessFile(RandomAccessFile ra, FileLock fl) {
         this.useStdOut = false;
@@ -94,27 +94,27 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * 標準出力を使用する状態に設定する.
      *
-     * @param out TODO: 準備中
+     * @param out 出力先のPrintStream.
      */
     void setOut(PrintStream out) {
         this.useStdOut = true;
     }
 
     /**
-     * TODO: 準備中
+     * 標準入力を使用する状態に設定する.
      *
-     * @param in TODO: 準備中
+     * @param in 入力元のInputStream.
      */
     void setIn(InputStream in) {
         this.useStdIn = true;
     }
 
     /**
-     * TODO: 準備中
+     * 指定したサイズの書き込みバッファを確保し初期化する.
      *
-     * @param bufferSize TODO: 準備中
+     * @param bufferSize 確保する書き込みバッファのサイズ(バイト数).
      */
     void prepareWriteBuffer(int bufferSize) {
         if (bufferSize > 0) {
@@ -132,11 +132,11 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * FileChannelからbytesにデータを読み込む(標準入力使用時は未実装).
      *
-     * @param bytes TODO: 準備中
-     * @param size TODO: 準備中
-     * @return TODO: 準備中
+     * @param bytes 読み込んだデータを格納するバイト配列.
+     * @param size 読み込むバイト数.
+     * @return 読み込みに成功した場合は1,ファイル終端または失敗の場合は0.
      */
     int read(byte[] bytes, int size) {
         if (useStdIn) {
@@ -161,12 +161,12 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * FileChannelから1バイトずつsizeバイトをstorageに読み込む.
      *
-     * @param storage TODO: 準備中
-     * @param size TODO: 準備中
-     * @return TODO: 準備中
-     * @throws IOException TODO: 準備中
+     * @param storage 読み込んだデータを格納する領域.
+     * @param size 読み込むバイト数.
+     * @return 実際に読み込めたバイト数.
+     * @throws IOException FileChannelが未設定の場合,または読み込みに失敗した場合.
      */
     int read(CobolDataStorage storage, int size) throws IOException {
         if (useStdIn) {
@@ -213,11 +213,12 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * bytesの先頭sizeバイトをファイルに書き込む.
+     * 書き込みバッファに空きがあればバッファに蓄積し,空きがなければバッファを出力してから書き込む.
      *
-     * @param bytes TODO: 準備中
-     * @param size TODO: 準備中
-     * @return TODO: 準備中
+     * @param bytes 書き込むデータを格納したバイト配列.
+     * @param size 書き込むバイト数.
+     * @return 書き込みに成功した場合はtrue.
      */
     boolean write(byte[] bytes, int size) {
         if (this.fc == null) {
@@ -241,11 +242,12 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * storageの先頭sizeバイトをファイルに書き込む.
+     * 書き込みバッファに空きがあればバッファに蓄積し,空きがなければバッファを出力してから書き込む.
      *
-     * @param storage TODO: 準備中
-     * @param size TODO: 準備中
-     * @return TODO: 準備中
+     * @param storage 書き込むデータを格納した領域.
+     * @param size 書き込むバイト数.
+     * @return 書き込みに成功した場合はtrue.
      */
     boolean write(CobolDataStorage storage, int size) {
         if (this.fc == null) {
@@ -273,10 +275,10 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * 1バイトをファイルに書き込む.書き込みバッファに空きがあればバッファに蓄積する.
      *
-     * @param val TODO: 準備中
-     * @return TODO: 準備中
+     * @param val 書き込むバイト値.
+     * @return 成功した場合は書き込んだバイト値,FileChannelが未設定の場合は0,失敗した場合は-1.
      */
     byte putc(byte val) {
         if (this.fc == null) {
@@ -302,9 +304,9 @@ class FileIO {
     }
 
     /**
-     * TODO: 準備中
+     * ファイルから1バイトを読み込む.
      *
-     * @return TODO: 準備中
+     * @return 読み込んだバイト値,FileChannelが未設定の場合は0,ファイル終端または失敗の場合は-1.
      */
     int getc() {
         if (this.fc == null) {
@@ -347,7 +349,7 @@ class FileIO {
         }
     }
 
-    /** TODO: 準備中 */
+    /** 書き込みバッファの内容を出力してからファイルを閉じる. */
     void close() {
         if (!useStdOut && !useStdIn && this.fc != null) {
             try {
@@ -360,7 +362,7 @@ class FileIO {
         }
     }
 
-    /** TODO: 準備中 */
+    /** 書き込みバッファの内容を出力し,ファイルの内容をディスクへ強制的に反映する. */
     void flush() {
         if (!useStdOut) {
             try {
@@ -372,18 +374,18 @@ class FileIO {
         }
     }
 
-    /** TODO: 準備中 */
+    /** seekの起点をファイル先頭とすることを表す定数. */
     static final int SEEK_SET = 0;
 
-    /** TODO: 準備中 */
+    /** seekの起点を現在の読み書き位置とすることを表す定数. */
     static final int SEEK_CUR = 1;
 
     /**
-     * TODO: 準備中
+     * 指定した起点からoffsetバイトの位置へファイルの読み書き位置を移動する.
      *
-     * @param offset TODO: 準備中
-     * @param origin TODO: 準備中
-     * @return TODO: 準備中
+     * @param offset 起点からの移動量(バイト数).
+     * @param origin 移動の起点(SEEK_SETまたはSEEK_CUR).
+     * @return 移動に成功した場合はtrue.
      */
     boolean seek(long offset, int origin) {
         if (!useStdOut && !useStdIn) {
@@ -405,10 +407,10 @@ class FileIO {
         return true;
     }
 
-    /** TODO: 準備中 */
+    /** シークに関する初期化を行う(現在の実装では何も行わない). */
     void seekInit() {}
 
-    /** TODO: 準備中 */
+    /** ファイルの読み書き位置を先頭に戻す. */
     void rewind() {
         if (!useStdOut && !useStdIn) {
             try {
@@ -419,7 +421,7 @@ class FileIO {
         }
     }
 
-    /** TODO: 準備中 */
+    /** ファイルに対して取得したロックを解放する. */
     void releaseLock() {
         if ((!useStdOut || !useStdIn) && this.fl != null) {
             try {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileStruct.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/FileStruct.java
@@ -18,42 +18,42 @@
  */
 package jp.osscons.opensourcecobol.libcobj.file;
 
-/** TODO: 準備中 */
+/** SORT/MERGE のマージ処理で用いる 1 つの一時ファイルと,そこに残っているブロック数を束ねる構造. */
 class FileStruct {
     private FileIO fp;
     private int count;
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへの入出力を行うFileIOを取得する.
      *
-     * @return TODO: 準備中
+     * @return この一時ファイルの入出力を担うFileIO
      */
     FileIO getFp() {
         return fp;
     }
 
     /**
-     * TODO: 準備中
+     * 一時ファイルへの入出力を行うFileIOを設定する.
      *
-     * @param fp TODO: 準備中
+     * @param fp この一時ファイルの入出力を担うFileIO
      */
     void setFp(FileIO fp) {
         this.fp = fp;
     }
 
     /**
-     * TODO: 準備中
+     * この一時ファイルに残っているブロック数を取得する.
      *
-     * @return TODO: 準備中
+     * @return 一時ファイルに残っているブロック数
      */
     int getCount() {
         return count;
     }
 
     /**
-     * TODO: 準備中
+     * この一時ファイルに残っているブロック数を設定する.
      *
-     * @param count TODO: 準備中
+     * @param count 一時ファイルに残っているブロック数
      */
     void setCount(int count) {
         this.count = count;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
@@ -20,7 +20,10 @@ package jp.osscons.opensourcecobol.libcobj.file;
 
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
-/** TODO: 準備中 */
+/**
+ * COBOLのLINAGE句に関する情報を保持するクラス.
+ * 帳票の1ページの本体行数,フッタ・上下余白の行数,およびLINAGE-COUNTERの状態を保持する.
+ */
 public class Linage {
     private AbstractCobolField linage;
     private AbstractCobolField linageCtr;
@@ -33,162 +36,162 @@ public class Linage {
     private int linBot;
 
     /**
-     * TODO: 準備中
+     * 1ページの本体行数(LINAGE句のLINES)を表すCOBOLデータ項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return 1ページの本体行数を表すCOBOLデータ項目
      */
     AbstractCobolField getLinage() {
         return linage;
     }
 
     /**
-     * TODO: 準備中
+     * 1ページの本体行数(LINAGE句のLINES)を表すCOBOLデータ項目を設定する.
      *
-     * @param linage TODO: 準備中
+     * @param linage 1ページの本体行数を表すCOBOLデータ項目
      */
     public void setLinage(AbstractCobolField linage) {
         this.linage = linage;
     }
 
     /**
-     * TODO: 準備中
+     * 現在のページ内行位置を表すLINAGE-COUNTERのCOBOLデータ項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return LINAGE-COUNTERを表すCOBOLデータ項目
      */
     AbstractCobolField getLinageCtr() {
         return linageCtr;
     }
 
     /**
-     * TODO: 準備中
+     * 現在のページ内行位置を表すLINAGE-COUNTERのCOBOLデータ項目を設定する.
      *
-     * @param linageCtr TODO: 準備中
+     * @param linageCtr LINAGE-COUNTERを表すCOBOLデータ項目
      */
     public void setLinageCtr(AbstractCobolField linageCtr) {
         this.linageCtr = linageCtr;
     }
 
     /**
-     * TODO: 準備中
+     * フッタ開始行(FOOTING AT)を表すCOBOLデータ項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return フッタ開始行を表すCOBOLデータ項目
      */
     AbstractCobolField getLatfoot() {
         return latfoot;
     }
 
     /**
-     * TODO: 準備中
+     * フッタ開始行(FOOTING AT)を表すCOBOLデータ項目を設定する.
      *
-     * @param latfoot TODO: 準備中
+     * @param latfoot フッタ開始行を表すCOBOLデータ項目
      */
     public void setLatfoot(AbstractCobolField latfoot) {
         this.latfoot = latfoot;
     }
 
     /**
-     * TODO: 準備中
+     * ページ上部の余白行数(LINES AT TOP)を表すCOBOLデータ項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return ページ上部の余白行数を表すCOBOLデータ項目
      */
     AbstractCobolField getLattop() {
         return lattop;
     }
 
     /**
-     * TODO: 準備中
+     * ページ上部の余白行数(LINES AT TOP)を表すCOBOLデータ項目を設定する.
      *
-     * @param lattop TODO: 準備中
+     * @param lattop ページ上部の余白行数を表すCOBOLデータ項目
      */
     public void setLattop(AbstractCobolField lattop) {
         this.lattop = lattop;
     }
 
     /**
-     * TODO: 準備中
+     * ページ下部の余白行数(LINES AT BOTTOM)を表すCOBOLデータ項目を取得する.
      *
-     * @return TODO: 準備中
+     * @return ページ下部の余白行数を表すCOBOLデータ項目
      */
     AbstractCobolField getLatbot() {
         return latbot;
     }
 
     /**
-     * TODO: 準備中
+     * ページ下部の余白行数(LINES AT BOTTOM)を表すCOBOLデータ項目を設定する.
      *
-     * @param latbot TODO: 準備中
+     * @param latbot ページ下部の余白行数を表すCOBOLデータ項目
      */
     public void setLatbot(AbstractCobolField latbot) {
         this.latbot = latbot;
     }
 
     /**
-     * TODO: 準備中
+     * 1ページの本体行数の現在値(整数)を取得する.
      *
-     * @return TODO: 準備中
+     * @return 1ページの本体行数
      */
     int getLinLines() {
         return linLines;
     }
 
     /**
-     * TODO: 準備中
+     * 1ページの本体行数の現在値(整数)を設定する.
      *
-     * @param linLines TODO: 準備中
+     * @param linLines 1ページの本体行数
      */
     public void setLinLines(int linLines) {
         this.linLines = linLines;
     }
 
     /**
-     * TODO: 準備中
+     * フッタ開始行の現在値(整数)を取得する.
      *
-     * @return TODO: 準備中
+     * @return フッタ開始行
      */
     int getLinFoot() {
         return linFoot;
     }
 
     /**
-     * TODO: 準備中
+     * フッタ開始行の現在値(整数)を設定する.
      *
-     * @param linFoot TODO: 準備中
+     * @param linFoot フッタ開始行
      */
     public void setLinFoot(int linFoot) {
         this.linFoot = linFoot;
     }
 
     /**
-     * TODO: 準備中
+     * ページ上部の余白行数の現在値(整数)を取得する.
      *
-     * @return TODO: 準備中
+     * @return ページ上部の余白行数
      */
     int getLinTop() {
         return linTop;
     }
 
     /**
-     * TODO: 準備中
+     * ページ上部の余白行数の現在値(整数)を設定する.
      *
-     * @param linTop TODO: 準備中
+     * @param linTop ページ上部の余白行数
      */
     public void setLinTop(int linTop) {
         this.linTop = linTop;
     }
 
     /**
-     * TODO: 準備中
+     * ページ下部の余白行数の現在値(整数)を取得する.
      *
-     * @return TODO: 準備中
+     * @return ページ下部の余白行数
      */
     int getLinBot() {
         return linBot;
     }
 
     /**
-     * TODO: 準備中
+     * ページ下部の余白行数の現在値(整数)を設定する.
      *
-     * @param linBot TODO: 準備中
+     * @param linBot ページ下部の余白行数
      */
     public void setLinBot(int linBot) {
         this.linBot = linBot;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/MemoryStruct.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/MemoryStruct.java
@@ -18,67 +18,67 @@
  */
 package jp.osscons.opensourcecobol.libcobj.file;
 
-/** TODO: 準備中 */
+/** SORT/MERGE でメモリ上に読み込んだレコード(CobolItem)の連結リストを表す構造. 先頭・末尾・要素数を保持する. */
 class MemoryStruct {
     private CobolItem first;
     private CobolItem last;
     private int count;
 
-    /** TODO: 準備中 */
+    /** 空の連結リストとして初期化する. 先頭と末尾をnullにする. */
     MemoryStruct() {
         this.first = null;
         this.last = null;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの先頭要素を取得する.
      *
-     * @return TODO: 準備中
+     * @return 連結リストの先頭のCobolItem
      */
     CobolItem getFirst() {
         return first;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの先頭要素を設定する.
      *
-     * @param first TODO: 準備中
+     * @param first 連結リストの先頭とするCobolItem
      */
     void setFirst(CobolItem first) {
         this.first = first;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの末尾要素を取得する.
      *
-     * @return TODO: 準備中
+     * @return 連結リストの末尾のCobolItem
      */
     CobolItem getLast() {
         return last;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの末尾要素を設定する.
      *
-     * @param last TODO: 準備中
+     * @param last 連結リストの末尾とするCobolItem
      */
     void setLast(CobolItem last) {
         this.last = last;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの要素数を取得する.
      *
-     * @return TODO: 準備中
+     * @return 連結リストに含まれる要素数
      */
     int getCount() {
         return count;
     }
 
     /**
-     * TODO: 準備中
+     * 連結リストの要素数を設定する.
      *
-     * @param count TODO: 準備中
+     * @param count 連結リストに含まれる要素数
      */
     void setCount(int count) {
         this.count = count;


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/787 についてのPR

# 概要

`libcobj` の `file` パッケージ（`jp.osscons.opensourcecobol.libcobj.file`）配下のクラスについて、Javadoc を整備しました。従来 `TODO: 準備中` となっていたフィールドやメソッドのコメントを、実際の役割を説明する内容に置き換え、ソースコードの可読性・保守性を向上させます。

本 PR は Javadoc（コメント）の追記・修正のみで、動作に関わるロジックの変更は含みません。

# 変更点

- `file` パッケージ配下の以下 12 クラスについて Javadoc を整備しました。
  - `CobolFile.java`
  - `CobolFileFactory.java`
  - `CobolFileSort.java`
  - `CobolItem.java`
  - `CobolLineSequentialFile.java`
  - `CobolRelativeFile.java`
  - `CobolSequentialFile.java`
  - `CobolSort.java`
  - `FileIO.java`
  - `FileStruct.java`
  - `Linage.java`
  - `MemoryStruct.java`
- `TODO: 準備中` となっていたコメントを、フィールド・メソッドの実際の役割を説明する内容に置き換えました。
- ファイル編成・アクセス方式・I/O 操作種別などの定数について、意味が分かるように説明を追加しました。

# その他

- 本 PR ではコメントのみを変更しており、ロジックの変更はありません。
- 索引編成（INDEXED）関連のクラス（`CobolFileKey` / `CobolIndexedFile` / `IndexedCursor` / `IndexedFile` / `KeyComponent`）は、別 PR（#843）で対応するため本 PR の対象外としています。
