### PR TITLE
Fix Javadoc warning

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -21,6 +21,5 @@ jobs:
       - name: Run javadoc
         working-directory: libcobj
         run: |
-          ./gradlew javadoc
           ./gradlew javadoc | tee javadoc.log
           test "$(grep '[1-9][0-9]* warning' javadoc.log)" = ""

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Run javadoc
         working-directory: libcobj
         run: |
-          ./gradlew javadoc | tee javadoc.log
+          ./gradlew javadoc 2>&1 | tee javadoc.log
           test "$(grep '[1-9][0-9]* warning' javadoc.log)" = ""

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Run javadoc
         working-directory: libcobj
         run: |
-          ./gradlew javadoc 2>&1 | tee javadoc.log
+          ./gradlew javadoc
+          ./gradlew javadoc | tee javadoc.log
           test "$(grep '[1-9][0-9]* warning' javadoc.log)" = ""

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
@@ -22,6 +22,9 @@ package jp.osscons.opensourcecobol.libcobj;
 /** TODO: 準備中 */
 public class Const {
 
+    /** このクラスはインスタンス化しない。 */
+    private Const() {}
+
     /** TODO: 準備中 */
     public static final String version = "2.0.0";
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
@@ -20,7 +20,7 @@
 package jp.osscons.opensourcecobol.libcobj;
 
 /** TODO: 準備中 */
-public class Const {
+public final class Const {
 
     /** このクラスはインスタンス化しない。 */
     private Const() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
@@ -34,6 +34,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 /** 動的にクラスファイルを読み込んでCALL文のような機能を実装するためのクラス */
 public class CobolResolve {
 
+    /** このクラスはインスタンス化しない。 */
+    private CobolResolve() {}
+
     /** プログラム名とCobolRunnableインスタンスの対応表 */
     private static Map<String, CobolRunnable> callTable;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolResolve.java
@@ -32,7 +32,7 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** 動的にクラスファイルを読み込んでCALL文のような機能を実装するためのクラス */
-public class CobolResolve {
+public final class CobolResolve {
 
     /** このクラスはインスタンス化しない。 */
     private CobolResolve() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -34,7 +34,7 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** 組み込み関数を提供するクラス */
-public class CobolSystemRoutine {
+public final class CobolSystemRoutine {
     /** このクラスはインスタンス化しない。 */
     private CobolSystemRoutine() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -35,6 +35,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** 組み込み関数を提供するクラス */
 public class CobolSystemRoutine {
+    /** このクラスはインスタンス化しない。 */
+    private CobolSystemRoutine() {}
+
     private static final boolean runsOnWindows = "\\".equals(System.getProperty("file.separator"));
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/call/CobolSystemRoutine.java
@@ -141,6 +141,7 @@ public class CobolSystemRoutine {
      * opensource COBOLのlibcob/common.cのcob_acuw_sleep関数に相当する
      *
      * @param data C$SLEEPの引数として指定されたCOBOL変数のバイト列。
+     * @return 常に0(正常終了を表す戻り値)。
      */
     @SuppressWarnings("PMD.AvoidDollarSigns")
     public static int C$SLEEP(CobolDataStorage data) {

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
@@ -23,7 +23,7 @@ package jp.osscons.opensourcecobol.libcobj.common;
  * libcobのcob_call_paramsに対応し、USING句で渡された実引数の個数を表す。<br>
  * 呼び出されたプログラム側でこの値を参照することで、省略された引数の判定などに利用する。
  */
-public class CobolCallParams {
+public final class CobolCallParams {
     /** このクラスはインスタンス化しない。 */
     private CobolCallParams() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCallParams.java
@@ -24,6 +24,9 @@ package jp.osscons.opensourcecobol.libcobj.common;
  * 呼び出されたプログラム側でこの値を参照することで、省略された引数の判定などに利用する。
  */
 public class CobolCallParams {
+    /** このクラスはインスタンス化しない。 */
+    private CobolCallParams() {}
+
     /** CALL文で渡された引数の個数 */
     public static int callParams = 0;
 }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -30,6 +30,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
  * 範囲外の場合は{@link CobolExceptionId#COB_EC_BOUND_SUBSCRIPT}を設定し、実行時エラーを出力して実行を中止する。
  */
 public class CobolCheck {
+    /** このクラスはインスタンス化しない。 */
+    private CobolCheck() {}
+
     /**
      * 表の添字が指定された範囲内にあるかを検査する。<br>
      * 範囲外の場合は例外を設定し、実行時エラーメッセージを出力して実行を中止する。

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolCheck.java
@@ -29,7 +29,7 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
  * 表(OCCURS)の添字や、OCCURS DEPENDING ONの可変回数が範囲内にあるかを検査する。<br>
  * 範囲外の場合は{@link CobolExceptionId#COB_EC_BOUND_SUBSCRIPT}を設定し、実行時エラーを出力して実行を中止する。
  */
-public class CobolCheck {
+public final class CobolCheck {
     /** このクラスはインスタンス化しない。 */
     private CobolCheck() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
@@ -29,6 +29,9 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
  * 各種バッファサイズ、10のべき乗表などをまとめて定義する。
  */
 public class CobolConstant {
+    /** このクラスはインスタンス化しない。 */
+    private CobolConstant() {}
+
     /** 英数字のALL定数(SPACE・ZEROなどの形象定数)に用いる属性 */
     public static final CobolFieldAttribute allAttr =
             new CobolFieldAttribute(CobolFieldAttribute.COB_TYPE_ALPHANUMERIC_ALL, 0, 0, 0, null);

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolConstant.java
@@ -28,7 +28,7 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
  * ZERO・SPACE・HIGH-VALUE・LOW-VALUE・QUOTEなどの形象定数や、それらの全角(ZEN)版、
  * 各種バッファサイズ、10のべき乗表などをまとめて定義する。
  */
-public class CobolConstant {
+public final class CobolConstant {
     /** このクラスはインスタンス化しない。 */
     private CobolConstant() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -35,7 +35,7 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
  * {@link #all(AbstractCobolField, AbstractCobolField)}などで計数・置換を行い、最後に{@link #finish()}で確定する
  * という手順で実行する。
  */
-public class CobolInspect {
+public final class CobolInspect {
     /** このクラスはインスタンス化しない。 */
     private CobolInspect() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolInspect.java
@@ -36,6 +36,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
  * という手順で実行する。
  */
 public class CobolInspect {
+    /** このクラスはインスタンス化しない。 */
+    private CobolInspect() {}
+
     /** 一致する文字をすべて対象とする(INSPECT ... ALLに対応) */
     private static final int INSPECT_ALL = 0;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -45,7 +45,7 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
  * 各組み込み関数を、{@code funcXxx}という名前の静的メソッドとして提供する。<br>
  * 各メソッドは計算結果を{@link AbstractCobolField}として返す。
  */
-public class CobolIntrinsic {
+public final class CobolIntrinsic {
 
     /** このクラスはインスタンス化しない。 */
     private CobolIntrinsic() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolIntrinsic.java
@@ -47,6 +47,9 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
  */
 public class CobolIntrinsic {
 
+    /** このクラスはインスタンス化しない。 */
+    private CobolIntrinsic() {}
+
     /** 各月初日までの通日(非うるう年)。インデックスは月(0〜12)。 */
     private static int[] normalDays = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -47,6 +47,9 @@ class Dlm {
  * @see AbstractCobolField
  */
 public class CobolString {
+    /** このクラスはインスタンス化しない。 */
+    private CobolString() {}
+
     /** UNSTRING文の区切り文字リストの既定の確保数。 */
     private static final int DLM_DEFAULT_NUM = 8;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -46,7 +46,7 @@ class Dlm {
  *
  * @see AbstractCobolField
  */
-public class CobolString {
+public final class CobolString {
     /** このクラスはインスタンス化しない。 */
     private CobolString() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -39,6 +39,9 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
  * 文字列比較などのヘルパー処理をまとめて提供する。
  */
 public class CobolUtil {
+    /** このクラスはインスタンス化しない。 */
+    private CobolUtil() {}
+
     /** I/O操作でREWRITEを暗黙的に行うとみなすかどうかのフラグ(環境変数COB_IO_ASSUME_REWRITEで設定)。 */
     private static boolean cob_io_assume_rewrite = false;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolUtil.java
@@ -38,7 +38,7 @@ import jp.osscons.opensourcecobol.libcobj.file.CobolFile;
  * ランタイムエラーの報告、SWITCHの設定・取得、参照修飾(reference modification)の境界チェック、<br>
  * 文字列比較などのヘルパー処理をまとめて提供する。
  */
-public class CobolUtil {
+public final class CobolUtil {
     /** このクラスはインスタンス化しない。 */
     private CobolUtil() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
@@ -23,6 +23,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 /** AbstractCobolFieldのサブクラスを生成するためのメソッドを定義するクラス */
 public class CobolFieldFactory {
 
+    /** このクラスはインスタンス化しない。 */
+    private CobolFieldFactory() {}
+
     /**
      * 引数に応じて適切なAbstractCobolFieldクラスのサブクラスを生成する.
      * 特にattrに設定された値に応じて適切なAbstractCobolFieldのサブクラスのインスタンスを生成する.

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolFieldFactory.java
@@ -21,7 +21,7 @@ package jp.osscons.opensourcecobol.libcobj.data;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 
 /** AbstractCobolFieldのサブクラスを生成するためのメソッドを定義するクラス */
-public class CobolFieldFactory {
+public final class CobolFieldFactory {
 
     /** このクラスはインスタンス化しない。 */
     private CobolFieldFactory() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
@@ -20,6 +20,9 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** 例外コードを定義するクラス */
 public class CobolExceptionId {
+    /** このクラスはインスタンス化しない。 */
+    private CobolExceptionId() {}
+
     /** この例外コードは使用されない */
     public static final int COB_EC_ZERO = 0;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionId.java
@@ -19,7 +19,7 @@
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** 例外コードを定義するクラス */
-public class CobolExceptionId {
+public final class CobolExceptionId {
     /** このクラスはインスタンス化しない。 */
     private CobolExceptionId() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -20,6 +20,9 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** エラーコードを保持する。 */
 public class CobolExceptionInfo {
+    /** このクラスはインスタンス化しない。 */
+    private CobolExceptionInfo() {}
+
     /**
      * 現在のエラーコード。CobolExceptionTabCode.codeテーブルから取得した16進数のエラーコードが格納される。
      * CobolRuntimeExceptionとは異なりコンテキスト情報は保持せず、エラーコードのみを管理する。

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionInfo.java
@@ -19,7 +19,7 @@
 package jp.osscons.opensourcecobol.libcobj.exceptions;
 
 /** エラーコードを保持する。 */
-public class CobolExceptionInfo {
+public final class CobolExceptionInfo {
     /** このクラスはインスタンス化しない。 */
     private CobolExceptionInfo() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
@@ -22,7 +22,7 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
  * CobolExceptionIdで定義された例外IDから、COBOL標準の16進数エラーコードへの変換テーブルを保持するクラス。
  * codeテーブルのインデックスはCobolExceptionIdの定数値に対応し、値はCOBOL標準で規定された16進数のエラーコードである。
  */
-public class CobolExceptionTabCode {
+public final class CobolExceptionTabCode {
     /** このクラスはインスタンス化しない。 */
     private CobolExceptionTabCode() {}
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/exceptions/CobolExceptionTabCode.java
@@ -23,6 +23,9 @@ package jp.osscons.opensourcecobol.libcobj.exceptions;
  * codeテーブルのインデックスはCobolExceptionIdの定数値に対応し、値はCOBOL標準で規定された16進数のエラーコードである。
  */
 public class CobolExceptionTabCode {
+    /** このクラスはインスタンス化しない。 */
+    private CobolExceptionTabCode() {}
+
     /** CobolExceptionIdの例外IDをインデックスとし、対応する16進数のCOBOLエラーコードを格納する配列 */
     static int[] code = {
         0, 0xFFFF, 0x0100, 0x0101, 0x0102, 0x0200, 0x0201, 0x0202, 0x0203, 0x0204, 0x0205, 0x0206,

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
@@ -23,6 +23,9 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 /** TODO: 準備中 */
 public class CobolFileFactory {
 
+    /** このクラスはインスタンス化しない。 */
+    private CobolFileFactory() {}
+
     /**
      * TODO: 準備中
      *

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileFactory.java
@@ -21,7 +21,7 @@ package jp.osscons.opensourcecobol.libcobj.file;
 import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /** TODO: 準備中 */
-public class CobolFileFactory {
+public final class CobolFileFactory {
 
     /** このクラスはインスタンス化しない。 */
     private CobolFileFactory() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
@@ -22,6 +22,9 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /** TODO: 準備中 */
 public class CobolFileKey {
+    /** 新しいインスタンスを生成する。 */
+    public CobolFileKey() {}
+
     /** TODO: 準備中 */
     public static final int COB_MAX_KEY_COMPONENTS = 8;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileKey.java
@@ -23,6 +23,7 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 /** TODO: 準備中 */
 public class CobolFileKey {
     /** 新しいインスタンスを生成する。 */
+    @SuppressWarnings("PMD.UnnecessaryConstructor")
     public CobolFileKey() {}
 
     /** TODO: 準備中 */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -36,33 +36,30 @@ import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** TODO: 準備中 */
-public class CobolFileSort {
+public final class CobolFileSort {
     /** このクラスはインスタンス化しない。 */
     private CobolFileSort() {}
 
     /** TODO: 準備中 */
-    protected static final int COBSORTEND = 1;
+    private static final int COBSORTEND = 1;
 
     /** TODO: 準備中 */
-    protected static final int COBSORTABORT = 2;
+    private static final int COBSORTABORT = 2;
 
     /** TODO: 準備中 */
-    protected static final int COBSORTFILEERR = 3;
+    private static final int COBSORTFILEERR = 3;
 
     /** TODO: 準備中 */
-    protected static final int COBSORTNOTOPEN = 4;
+    private static final int COBSORTNOTOPEN = 4;
 
     /** TODO: 準備中 */
-    protected static final int COB_ASCENDING = 0;
-
-    /** TODO: 準備中 */
-    protected static final int COB_DESCENDING = 1;
+    private static final int COB_ASCENDING = 0;
 
     private static String cob_process_id = "";
     private static int cob_iteration = 0;
 
     /** TODO: 準備中 */
-    protected static int cob_sort_memory = 128 * 1024 * 1024;
+    private static int cob_sort_memory = 128 * 1024 * 1024;
 
     // Javaの標準ライブラリでソートするならtrue
     private static boolean SORT_STD_LIB = true;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/CobolFileSort.java
@@ -37,6 +37,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /** TODO: 準備中 */
 public class CobolFileSort {
+    /** このクラスはインスタンス化しない。 */
+    private CobolFileSort() {}
+
     /** TODO: 準備中 */
     protected static final int COBSORTEND = 1;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
@@ -22,6 +22,9 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /** TODO: 準備中 */
 public class KeyComponent {
+    /** 新しいインスタンスを生成する。 */
+    public KeyComponent() {}
+
     /** TODO: 準備中 */
     public AbstractCobolField field;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/KeyComponent.java
@@ -23,6 +23,7 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 /** TODO: 準備中 */
 public class KeyComponent {
     /** 新しいインスタンスを生成する。 */
+    @SuppressWarnings("PMD.UnnecessaryConstructor")
     public KeyComponent() {}
 
     /** TODO: 準備中 */

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
@@ -23,6 +23,7 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 /** TODO: 準備中 */
 public class Linage {
     /** 新しいインスタンスを生成する。 */
+    @SuppressWarnings("PMD.UnnecessaryConstructor")
     public Linage() {}
 
     private AbstractCobolField linage;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/file/Linage.java
@@ -22,6 +22,9 @@ import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
 
 /** TODO: 準備中 */
 public class Linage {
+    /** 新しいインスタンスを生成する。 */
+    public Linage() {}
+
     private AbstractCobolField linage;
     private AbstractCobolField linageCtr;
     private AbstractCobolField latfoot;

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -38,7 +38,7 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionId;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 
 /** DISPLAY文やACCEPT文に関するメソッドを実装するクラス */
-public class CobolTerminal {
+public final class CobolTerminal {
 
     /** このクラスはインスタンス化しない。 */
     private CobolTerminal() {}

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/termio/CobolTerminal.java
@@ -40,6 +40,9 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolExceptionInfo;
 /** DISPLAY文やACCEPT文に関するメソッドを実装するクラス */
 public class CobolTerminal {
 
+    /** このクラスはインスタンス化しない。 */
+    private CobolTerminal() {}
+
     /** DISPLAY文で設定されたコマンドラインデータのバイト数 */
     private static int commlncnt = 0;
 

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
@@ -7,6 +7,7 @@ package jp.osscons.opensourcecobol.libcobj.ui;
  */
 public class CobolCallResult {
     /** 新しいインスタンスを生成する。 */
+    @SuppressWarnings("PMD.UnnecessaryConstructor")
     public CobolCallResult() {}
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/ui/CobolCallResult.java
@@ -6,6 +6,9 @@ package jp.osscons.opensourcecobol.libcobj.ui;
  * 対応しない型のgetメソッドを呼び出した場合は{@link CobolResultSetException}がスローされる。
  */
 public class CobolCallResult {
+    /** 新しいインスタンスを生成する。 */
+    public CobolCallResult() {}
+
     /**
      * 結果をint型として取得する。
      *


### PR DESCRIPTION
# 概要

`./gradlew javadoc` 実行時に出力されていた Javadoc の警告（22 件）を解消する。

いずれも `libcobj/app/build.gradle.kts` の `-Xdoclint:missing` によって検出されるドキュメント不足の警告であり、内訳は次の通りである。

- 明示的なコンストラクタを持たないクラスの、暗黙のデフォルトコンストラクタにコメントが無い（21 件）
- `int` を返す `C$SLEEP` メソッドに `@return` が無い（1 件）

パッケージを横断して発生していた警告をすべて解消し、`./gradlew javadoc` が警告なしで完了する状態にした。あわせて、修正に伴って発生する静的解析（PMD）の指摘も解消している。

# 変更点

## Javadoc 警告の解消

- **static ユーティリティ系クラス（17 件）**: コメント付きの `private` コンストラクタを追加し、インスタンス化を禁止した。対象は `Const` / `CobolResolve` / `CobolSystemRoutine` / `CobolCallParams` / `CobolCheck` / `CobolConstant` / `CobolInspect` / `CobolIntrinsic` / `CobolString` / `CobolUtil` / `CobolFieldFactory` / `CobolFileFactory` / `CobolFileSort` / `CobolTerminal` / `CobolExceptionId` / `CobolExceptionInfo` / `CobolExceptionTabCode`。
- **データ / インスタンス系クラス（4 件）**: コメント付きの `public` デフォルトコンストラクタを明示した。対象は `CobolFileKey` / `KeyComponent` / `Linage` / `CobolCallResult`。
- **`C$SLEEP` メソッド**: 常に `0` を返す旨の `@return` タグを追加した。

## 静的解析（PMD）対応

上記の変更によって新たに検出された PMD 指摘を、以下の通り解消した。

- static ユーティリティ系クラスは `private` コンストラクタのみを持つため、`ClassWithOnlyPrivateConstructorsShouldBeFinal` に従い `final` を付与した。
- データ系クラスに明示したデフォルトコンストラクタは `UnnecessaryConstructor` に該当するため、Javadoc 用のコメントを維持したまま `@SuppressWarnings("PMD.UnnecessaryConstructor")` で抑制した。
- `CobolFileSort` を `final` 化したことで顕在化した `protected` フィールド（`AvoidProtectedFieldInFinalClass`）を、内部でのみ使用しているため `private` に変更した。
- それに伴い未使用と判明した定数 `COB_DESCENDING`（`UnusedPrivateField`）を削除した。

# その他

- ローカルで `spotlessCheck` / `pmdMain` / `spotbugsMain` / `javadoc` を実行し、フォーマット・静的解析ともにパスすること、および Javadoc の警告が 0 件になることを確認済みである。
- 本 PR には CI ワークフロー（`.github/workflows/javadoc.yml`）の変更は含まない。調査の過程で「Javadoc の警告が出ても CI が失敗しない」というワークフローの不具合（警告は標準エラー出力に出るが標準出力のみを検査していた）を発見したが、これを修正して警告検査を有効化すると、別要因である `compileJava` の警告（`source/target value 8 is obsolete`）が併せて検出され CI が失敗する。この解消には Java の source/target レベル引き上げというチームの合意が必要な変更を伴うため、ワークフローの修正は本 PR のスコープから除外している。
