### PR TITLE
Consolidate pending Dependabot updates and upgrade CI to Ubuntu 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       image: ${{ inputs.os }}
     steps: 
       - uses: actions/setup-java@v5
-        if: inputs.os == 'ubuntu:24.04'
+        if: inputs.os == 'ubuntu:26.04'
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -32,8 +32,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential gettext autoconf bison flex

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -60,7 +60,7 @@ jobs:
           - "misc"
           - "file-lock"
           - "file-lock2"
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -83,7 +83,7 @@ jobs:
           - "file-lock"
           - "file-lock2"
           #- "misc"
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -94,7 +94,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-esql.yml
     with:
       os: ${{ matrix.os }}
@@ -103,7 +103,7 @@ jobs:
     needs: build-utf8
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-esql-utf8.yml
     with:
       os: ${{ matrix.os }}
@@ -112,7 +112,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-esql-examples.yml
     with:
       os: ${{ matrix.os }}
@@ -121,7 +121,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-cobj-api.yml
     with:
       os: ${{ matrix.os }}
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -157,7 +157,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:26.04", "almalinux:9", "amazonlinux:2023"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
           - "file-lock"
           - "file-lock2"
           - "misc"
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -87,7 +87,7 @@ jobs:
           - "cobj-idx"
           - "file-lock2"
           #- "misc"
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -98,7 +98,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-esql.yml
     with:
       os: ${{ matrix.os }}
@@ -107,7 +107,7 @@ jobs:
     needs: build-utf8
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-esql-utf8.yml
     with:
       os: ${{ matrix.os }}
@@ -116,7 +116,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-esql-examples.yml
     with:
       os: ${{ matrix.os }}
@@ -125,7 +125,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-cobj-api.yml
     with:
       os: ${{ matrix.os }}
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -149,7 +149,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:24.04"]
+        os: ["ubuntu:26.04"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/.github/workflows/test-cobj-api.yml
+++ b/.github/workflows/test-cobj-api.yml
@@ -36,8 +36,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential

--- a/.github/workflows/test-esql-examples.yml
+++ b/.github/workflows/test-esql-examples.yml
@@ -60,8 +60,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential

--- a/.github/workflows/test-esql-utf8.yml
+++ b/.github/workflows/test-esql-utf8.yml
@@ -60,8 +60,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential

--- a/.github/workflows/test-esql.yml
+++ b/.github/workflows/test-esql.yml
@@ -60,8 +60,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential

--- a/.github/workflows/test-nist.yml
+++ b/.github/workflows/test-nist.yml
@@ -43,8 +43,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -39,8 +39,8 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install dependencies on Ubuntu 24.04
-        if: inputs.os == 'ubuntu:24.04'
+      - name: Install dependencies on Ubuntu 26.04
+        if: inputs.os == 'ubuntu:26.04'
         run: |
           apt-get update -y
           apt-get install -y build-essential unzip nkf

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: '21'
       
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2.0.0
+        uses: microsoft/setup-msbuild@v3.0.0
 
       - name: Checkout opensource COBOL 4J
         uses: actions/checkout@v7

--- a/.github/workflows/windows-generate-test-scripts.yml
+++ b/.github/workflows/windows-generate-test-scripts.yml
@@ -10,7 +10,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:24.04
+      image: ubuntu:26.04
     steps:
       - name: Install dependencies
         run: |

--- a/cobj/reserved.c
+++ b/cobj/reserved.c
@@ -834,7 +834,7 @@ cb_tree lookup_system_name(const char *name) {
 }
 
 int lookup_reserved_word(const char *name) {
-  struct reserved *p;
+  const struct reserved *p;
   struct noreserve *noresptr;
 
   p = bsearch(name, reserved_words, NUM_RESERVED_WORDS, sizeof(struct reserved),
@@ -854,9 +854,9 @@ int lookup_reserved_word(const char *name) {
   return 0;
 }
 
-struct cb_intrinsic_table *lookup_intrinsic(const char *name,
-                                            const int checkres) {
-  struct cb_intrinsic_table *cbp;
+const struct cb_intrinsic_table *lookup_intrinsic(const char *name,
+                                                  const int checkres) {
+  const struct cb_intrinsic_table *cbp;
   struct noreserve *noresptr;
 
   if (checkres) {

--- a/cobj/scanner.c
+++ b/cobj/scanner.c
@@ -2455,7 +2455,7 @@ YY_RULE_SETUP
 
 	struct cb_word			*word;
 	struct cb_level_78		*p78;
-	struct cb_intrinsic_table	*cbp;
+	const struct cb_intrinsic_table	*cbp;
 	cb_tree				x;
 	int				token;
 

--- a/cobj/scanner.l
+++ b/cobj/scanner.l
@@ -644,7 +644,7 @@ H\"[^\"\n]*\" {
 
 	struct cb_word			*word;
 	struct cb_level_78		*p78;
-	struct cb_intrinsic_table	*cbp;
+	const struct cb_intrinsic_table	*cbp;
 	cb_tree				x;
 	int				token;
 

--- a/cobj/scanner.l.m4
+++ b/cobj/scanner.l.m4
@@ -658,7 +658,7 @@ ifdef(M4.I18N_UTF8,>>>>>
 <<<<<)
 	struct cb_word			*word;
 	struct cb_level_78		*p78;
-	struct cb_intrinsic_table	*cbp;
+	const struct cb_intrinsic_table	*cbp;
 	cb_tree				x;
 	int				token;
 

--- a/cobj/tree.c
+++ b/cobj/tree.c
@@ -354,7 +354,8 @@ static int cb_name_1(char *s, cb_tree x) {
   return strlen(orig);
 }
 
-static cb_tree make_intrinsic(cb_tree name, struct cb_intrinsic_table *cbp,
+static cb_tree make_intrinsic(cb_tree name,
+                              const struct cb_intrinsic_table *cbp,
                               cb_tree args, cb_tree field, cb_tree refmod) {
   struct cb_intrinsic *x;
 
@@ -2640,14 +2641,14 @@ struct cb_sql_host_var *cb_sql_host_var_list_add(struct cb_sql_host_var *list,
  */
 
 cb_tree cb_build_any_intrinsic(cb_tree args) {
-  struct cb_intrinsic_table *cbp;
+  const struct cb_intrinsic_table *cbp;
 
   cbp = lookup_intrinsic("LENGTH", 0);
   return make_intrinsic(NULL, cbp, args, NULL, NULL);
 }
 
 cb_tree cb_build_intrinsic(cb_tree name, cb_tree args, cb_tree refmod) {
-  struct cb_intrinsic_table *cbp;
+  const struct cb_intrinsic_table *cbp;
   cb_tree x;
   int numargs;
 

--- a/cobj/tree.h
+++ b/cobj/tree.h
@@ -1039,7 +1039,7 @@ struct cb_intrinsic {
   cb_tree name;
   cb_tree args;
   cb_tree intr_field; /* Field to use */
-  struct cb_intrinsic_table *intr_tab;
+  const struct cb_intrinsic_table *intr_tab;
   cb_tree offset;
   cb_tree length;
 };
@@ -1047,8 +1047,8 @@ struct cb_intrinsic {
 #define CB_INTRINSIC(x) (CB_TREE_CAST(CB_TAG_INTRINSIC, struct cb_intrinsic, x))
 #define CB_INTRINSIC_P(x) (CB_TREE_TAG(x) == CB_TAG_INTRINSIC)
 
-extern struct cb_intrinsic_table *lookup_intrinsic(const char *name,
-                                                   const int checkres);
+extern const struct cb_intrinsic_table *lookup_intrinsic(const char *name,
+                                                         const int checkres);
 extern cb_tree cb_build_intrinsic(cb_tree name, cb_tree args, cb_tree refmod);
 extern cb_tree cb_build_any_intrinsic(cb_tree args);
 

--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     application
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.diffplug.spotless") version "8.8.0"
+    id("com.diffplug.spotless") version "7.2.1"
     id("java")
     id("maven-publish")
     pmd

--- a/libcobj/app/build.gradle.kts
+++ b/libcobj/app/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     application
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.diffplug.spotless") version "7.2.1"
+    id("com.diffplug.spotless") version "8.8.0"
     id("java")
     id("maven-publish")
     pmd
@@ -34,14 +34,14 @@ tasks {
 dependencies {
     implementation("com.google.guava:guava:33.5.0-jre")
     implementation("org.xerial:sqlite-jdbc:3.51.0.0")
-    implementation("commons-cli:commons-cli:1.10.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.13.4")
+    implementation("commons-cli:commons-cli:1.11.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.14.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.testcontainers:testcontainers:1.21.0")
     testImplementation("org.testcontainers:junit-jupiter:1.21.0")
     testImplementation("org.testcontainers:postgresql:1.21.0")
     implementation("org.json:json:20250517")
-    spotbugs("com.github.spotbugs:spotbugs:4.8.6")
+    spotbugs("com.github.spotbugs:spotbugs:4.10.3")
 
     implementation("org.slf4j:slf4j-api:2.0.17")
     runtimeOnly("org.slf4j:slf4j-simple:2.0.17")

--- a/libcobj/settings.gradle.kts
+++ b/libcobj/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "opensourcecobol4j"

--- a/libcobj/settings.gradle.kts
+++ b/libcobj/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }
 
 rootProject.name = "opensourcecobol4j"


### PR DESCRIPTION
## 概要

マージされずに残っている Dependabot の Pull Request を1つにまとめる。あわせて CI で使用する Ubuntu コンテナイメージを 24.04 から 26.04 に更新する。

Dependabot の Pull Request 自体が古くなっているため、各 Pull Request が提案しているバージョンではなく、現時点で入手可能な最新バージョンを採用している。

> [!NOTE]
> この Pull Request の内容は、フォーク側リポジトリに先に提出した yutaro-sakamoto/opensourcecobol4j#16 と同一である。あちらは当該フォークの `main` ブランチ向けで、こちらは同じ変更を本リポジトリの `develop` ブランチ向けに cherry-pick したものである。
> なお yutaro-sakamoto/opensourcecobol4j#16 は既に当該フォークの `main` ブランチへマージ済みである。

### 取り込んだ更新

| 対象 | 変更 | 元の Pull Request | 備考 |
| --- | --- | --- | --- |
| `microsoft/setup-msbuild` | v2.0.0 → v3.0.0 | #812 | |
| `commons-cli:commons-cli` | 1.10.0 → 1.11.0 | #743 | |
| `org.junit.jupiter:junit-jupiter` | 5.13.4 → 5.14.4 | #739 | 5.x 系の最新版 |
| `com.github.spotbugs:spotbugs` | 4.8.6 → 4.10.3 | #730 | 提案は 4.9.8 |

### 取り込まなかった更新

以下は新しいメジャーバージョンが Java 17 以上を要求するため見送った。libcobj は Java 8 向けにコンパイルしており、almalinux:9 でのビルドと cobj-api のテストでは Gradle を Java 11 で実行しているため、これらを更新すると使用する Java のバージョンを引き上げる必要がある。

- `com.diffplug.spotless` 8.x (#723) — 7.2.1 のまま
- `org.gradle.toolchains.foojay-resolver-convention` 1.0.0 (#644) — 0.10.0 のまま
- `org.junit.jupiter:junit-jupiter` 6.x — 上記のとおり 5.14.4 に留めた

### Ubuntu 26.04 への更新

CI のワークフローが使用するコンテナイメージを `ubuntu:24.04` から `ubuntu:26.04` に変更した。

これに伴い `cobj/reserved.c` のビルドが `-Werror=discarded-qualifiers` で失敗するようになったため、C コード側を修正した。glibc 2.42 の `bsearch` は検索対象の配列の `const` 修飾子を維持するように宣言されている。`reserved.c` が検索している 2 つのテーブルはいずれも `const` 宣言されているため戻り値も `const` となり、`const` なしのポインタへ代入できない。`const` をキャストで外すのではなく、`lookup_intrinsic` の戻り値の型とその呼び出し側に `const` を伝播させて対応した。

---

## Summary

This pull request consolidates the Dependabot pull requests that are still open and unmerged, and upgrades the Ubuntu container image used by CI from 24.04 to 26.04.

Because the Dependabot pull requests themselves have become outdated, each dependency is bumped to the latest version available today rather than the version proposed in the corresponding pull request.

> [!NOTE]
> The content of this pull request is identical to yutaro-sakamoto/opensourcecobol4j#16, which was submitted first against the `main` branch of that fork. This one is the same change cherry-picked onto the `develop` branch of this repository.
> Note that yutaro-sakamoto/opensourcecobol4j#16 has already been merged into the `main` branch of that fork.

### Applied updates

| Dependency | Change | Original pull request | Note |
| --- | --- | --- | --- |
| `microsoft/setup-msbuild` | v2.0.0 → v3.0.0 | #812 | |
| `commons-cli:commons-cli` | 1.10.0 → 1.11.0 | #743 | |
| `org.junit.jupiter:junit-jupiter` | 5.13.4 → 5.14.4 | #739 | Latest 5.x release |
| `com.github.spotbugs:spotbugs` | 4.8.6 → 4.10.3 | #730 | 4.9.8 was proposed |

### Skipped updates

The following updates are skipped because the new major versions require Java 17 or later. libcobj is compiled for Java 8, and Gradle is invoked with Java 11 in the almalinux:9 build and in the cobj-api test, so applying them would require raising the Java version used to build and test libcobj.

- `com.diffplug.spotless` 8.x (#723) — kept at 7.2.1
- `org.gradle.toolchains.foojay-resolver-convention` 1.0.0 (#644) — kept at 0.10.0
- `org.junit.jupiter:junit-jupiter` 6.x — kept on the 5.x line as noted above

### Ubuntu 26.04 upgrade

The container image used by the CI workflows is changed from `ubuntu:24.04` to `ubuntu:26.04`.

This made the build of `cobj/reserved.c` fail with `-Werror=discarded-qualifiers`. glibc 2.42 declares `bsearch` so that it preserves the `const` qualifier of the searched array. Both tables searched in `reserved.c` are declared `const`, so the returned pointer is `const` as well and cannot be assigned to a non-const pointer. Rather than casting the qualifier away, the `const` qualifier is propagated through the return type of `lookup_intrinsic` and its callers.

