### PR TITLE
Remove Optional from CobolControl to speed up the generated control flow

### DIFF
--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3280,9 +3280,9 @@ static void joutput_call(struct cb_call *p) {
 
 static void joutput_goto_1(cb_tree x) {
   joutput_prefix();
-  joutput("if(true) return Optional.of(contList[");
+  joutput("if(true) return contList[");
   joutput_label_variable(CB_LABEL(cb_ref(x)));
-  joutput("]);");
+  joutput("];");
   joutput_newline();
 }
 
@@ -3306,16 +3306,15 @@ static void joutput_goto(struct cb_goto *p) {
   } else if (p->target == NULL) {
     needs_exit_prog = 1;
     if (cb_flag_implicit_init) {
-      joutput_line(
-          "if(true) return Optional.of(contList[contList.length - 1]);");
+      joutput_line("if(true) return contList[contList.length - 1];");
     } else {
       joutput_line("if (!CobolModule.isQueueEmpty()) {");
-      joutput_line("  return Optional.of(contList[contList.length - 1]);");
+      joutput_line("  return contList[contList.length - 1];");
       joutput_line("}");
     }
   } else if (p->target == cb_int1) {
     needs_exit_prog = 1;
-    joutput_line("if(true) return Optional.of(contList[contList.length - 1]);");
+    joutput_line("if(true) return contList[contList.length - 1];");
   } else {
     joutput_goto_1(p->target);
   }
@@ -3331,14 +3330,15 @@ static void joutput_perform_call(struct cb_label *lb, struct cb_label *le) {
     joutput_prefix();
     joutput("CobolControl.perform(contList, ");
     joutput_label_variable(lb);
-    joutput(").run();\n");
+    joutput(");\n");
   } else {
     joutput_line("/* PERFORM %s THRU %s */", lb->name, le->name);
-    joutput_line("CobolControl.performThrough(contList, ");
+    joutput_prefix();
+    joutput("CobolControl.performThrough(contList, ");
     joutput_label_variable(lb);
     joutput(", ");
     joutput_label_variable(le);
-    joutput(").run();\n");
+    joutput(");\n");
   }
 
   cb_id++;
@@ -3475,7 +3475,7 @@ static void joutput_sort_proc(struct cb_sort_proc *p) {
     joutput_prefix();
     joutput("CobolControl.perform(contList, ");
     joutput_label_variable(lb);
-    joutput(").run();\n");
+    joutput(");\n");
   } else {
     joutput_line("/* PERFORM %s THRU %s */", lb->name, le->name);
     joutput_prefix();
@@ -3483,7 +3483,7 @@ static void joutput_sort_proc(struct cb_sort_proc *p) {
     joutput_label_variable(lb);
     joutput(", ");
     joutput_label_variable(le);
-    joutput(").run();\n");
+    joutput(");\n");
   }
 
   cb_id++;
@@ -4222,11 +4222,11 @@ static void joutput_stmt(cb_tree x, enum joutput_stmt_type output_type) {
     // the end of the previous label.
     if (flag_execution_end == EXECUTION_NORMAL) {
       joutput_prefix();
-      joutput("return Optional.of(contList[");
+      joutput("return contList[");
       joutput_label_variable_by_value(++control_counter);
-      joutput("]);\n");
+      joutput("];\n");
     } else {
-      joutput_line("return Optional.of(CobolControl.pure());");
+      joutput_line("return null;");
     }
     joutput_indent_level -= 2;
     joutput_line("}");
@@ -4271,9 +4271,8 @@ static void joutput_stmt(cb_tree x, enum joutput_stmt_type output_type) {
     joutput_newline();
 
     joutput_indent_level += 2;
-    joutput_line(
-        "public Optional<CobolControl> run() throws CobolRuntimeException, "
-        "CobolStopRunException {");
+    joutput_line("public CobolControl run() throws CobolRuntimeException, "
+                 "CobolStopRunException {");
     joutput_indent_level += 2;
 
     if (cb_flag_trace) {
@@ -6627,9 +6626,8 @@ static void joutput_execution_list(struct cb_program *prog) {
   joutput_indent_level += 2;
   joutput_line("new CobolControl(0, CobolControl.LabelType.label) {");
   joutput_indent_level += 2;
-  joutput_line(
-      "public Optional<CobolControl> run() throws CobolRuntimeException, "
-      "CobolStopRunException {");
+  joutput_line("public CobolControl run() throws CobolRuntimeException, "
+               "CobolStopRunException {");
   joutput_indent_level += 2;
   cb_tree l;
   flag_execution_begin = EXECUTION_NORMAL;
@@ -6717,7 +6715,7 @@ static void joutput_execution_list(struct cb_program *prog) {
     joutput_newline();
   }
 
-  joutput_line("return Optional.of(CobolControl.pure());");
+  joutput_line("return null;");
   joutput_indent_level -= 2;
   joutput_line("}");
   joutput_indent_level -= 2;
@@ -6732,12 +6730,10 @@ static void joutput_execution_entry_func() {
   joutput_line("public void execEntry(int start) throws CobolRuntimeException, "
                "CobolStopRunException {");
   joutput_indent_level += 2;
-  joutput_line(
-      "Optional<CobolControl> nextLabel = Optional.of(contList[start]);");
-  joutput_line("while(nextLabel.isPresent()) {");
+  joutput_line("CobolControl nextLabel = contList[start];");
+  joutput_line("while(nextLabel != null) {");
   joutput_indent_level += 2;
-  joutput_line("CobolControl section = nextLabel.get();");
-  joutput_line("nextLabel = section.run();");
+  joutput_line("nextLabel = nextLabel.run();");
   joutput_indent_level -= 2;
   joutput_line("}");
   joutput_indent_level -= 2;
@@ -6860,7 +6856,6 @@ void codegen(struct cb_program *prog, const int nested, char **program_id_list,
   joutput_line("import jp.osscons.opensourcecobol.libcobj.file.*;");
   joutput_line("import jp.osscons.opensourcecobol.libcobj.ui.*;");
   joutput_line("import jp.osscons.opensourcecobol.libcobj.sql.*;");
-  joutput_line("import java.util.Optional;");
   joutput("\n");
 
   /*if (!cb_flag_no_cobol_comment) {

--- a/cobj/codegen.c
+++ b/cobj/codegen.c
@@ -3306,15 +3306,15 @@ static void joutput_goto(struct cb_goto *p) {
   } else if (p->target == NULL) {
     needs_exit_prog = 1;
     if (cb_flag_implicit_init) {
-      joutput_line("if(true) return contList[contList.length - 1];");
+      joutput_line("if(true) return null; /* exit program */");
     } else {
       joutput_line("if (!CobolModule.isQueueEmpty()) {");
-      joutput_line("  return contList[contList.length - 1];");
+      joutput_line("  return null; /* exit program */");
       joutput_line("}");
     }
   } else if (p->target == cb_int1) {
     needs_exit_prog = 1;
-    joutput_line("if(true) return contList[contList.length - 1];");
+    joutput_line("if(true) return null; /* exit program */");
   } else {
     joutput_goto_1(p->target);
   }
@@ -4226,7 +4226,7 @@ static void joutput_stmt(cb_tree x, enum joutput_stmt_type output_type) {
       joutput_label_variable_by_value(++control_counter);
       joutput("];\n");
     } else {
-      joutput_line("return null;");
+      joutput_line("return null; /* no more control to run */");
     }
     joutput_indent_level -= 2;
     joutput_line("}");
@@ -6715,13 +6715,12 @@ static void joutput_execution_list(struct cb_program *prog) {
     joutput_newline();
   }
 
-  joutput_line("return null;");
+  joutput_line("return null; /* no more control to run */");
   joutput_indent_level -= 2;
   joutput_line("}");
   joutput_indent_level -= 2;
   joutput_line("},");
 
-  joutput_line("CobolControl.pure()");
   joutput_indent_level -= 2;
   joutput_line("};");
 }

--- a/doc/converted_Java_file_JP.md
+++ b/doc/converted_Java_file_JP.md
@@ -275,7 +275,7 @@ public CobolControl[] contList = {
         // LAST-PROC SECTIONの処理
         //...
     },
-    new CobolControl(l_LAST_PROC__LAST_MESSAGE, CobolControl.LabelType.paragraph) {
+    new CobolControl(l_LAST_PROC__LAST_MESSAGE, CobolControl.LabelType.label) {
         // LAST-MESSAGEの処理
         //...
     }
@@ -287,7 +287,7 @@ public CobolControl[] contList = {
 
 ```java
 new CobolControl(l_SUB__A_01, CobolControl.LabelType.label) {
-  public Optional<CobolControl> run() throws CobolRuntimeException, CobolGoBackException, CobolStopRunException {
+  public CobolControl run() throws CobolRuntimeException, CobolStopRunException {
     /* prog.cbl:13: DISPLAY */
     {
       CobolTerminal.display (0, 1, 1, c_1);
@@ -297,7 +297,7 @@ new CobolControl(l_SUB__A_01, CobolControl.LabelType.label) {
       CobolTerminal.display (0, 1, 1, c_2);
     }
 
-    return Optional.of(contList[l_SUB__A_02]);
+    return contList[l_SUB__A_02];
   }
 }
 ```
@@ -306,13 +306,13 @@ A-02の処理は以下のように変換される。
 
 ```java
 new CobolControl(l_SUB__A_02, CobolControl.LabelType.label) {
-  public Optional<CobolControl> run() throws CobolRuntimeException, CobolGoBackException, CobolStopRunException {
+  public CobolControl run() throws CobolRuntimeException, CobolStopRunException {
     /* prog.cbl:16: DISPLAY */
     {
       CobolTerminal.display (0, 1, 1, c_3);
     }
 
-    return Optional.of(contList[l_LAST_PROC]);
+    return contList[l_LAST_PROC];
   }
 }
 ```
@@ -320,19 +320,35 @@ new CobolControl(l_SUB__A_02, CobolControl.LabelType.label) {
 CobolControlクラスは、opensource COBOL 4Jが提供するランタイムであるlibcobj.jarに含まれるクラスである。
 runメソッドに、実際の処理が記述され、その他必要な情報はメンバ変数に格納される。
 
+runメソッドの戻り値は、その段落・節の実行後に続けて実行すべきCobolControlである。
+続けて実行すべき処理が無い場合(手続き部の末尾に到達した場合等)は`null`を返す。
+生成されたコードでは、この戻り値が`null`になるまでrunメソッドを繰り返し呼び出すことで、
+段落・節の連続実行(フォールスルー)を実現している。
+
+```java
+public void execEntry(int start) throws CobolRuntimeException, CobolStopRunException {
+  CobolControl nextLabel = contList[start];
+  while(nextLabel != null) {
+    nextLabel = nextLabel.run();
+  }
+}
+```
+
 CobolControlの配列contListを使って、PROCEDURE DIVISION内の処理を実行する。
 
 opensource COBOL 4Jでは、PERFORM文やGO TO文はCobolControlクラスの機能を利用して呼び出しやジャンプを実現するメソッドを用意している。
 PERFORM文やGO TO文はこれらのメソッドを呼び出すコードへと変換される。
+`CobolControl.perform`はその場で指定された段落・節を実行するstaticメソッドであり、
+`PERFORM ... THRU ...`文の場合は`CobolControl.performThrough`が使用される。
 ```java
-CobolControl.perform(contList, l_SUB__A_01).run();
+CobolControl.perform(contList, l_SUB__A_01);
 
-CobolControl.perform(contList, l_SUB__A_02).run();
+CobolControl.perform(contList, l_SUB__A_02);
 
-CobolControl.perform(contList, l_SUB).run();
+CobolControl.perform(contList, l_SUB);
 
 {
-  if(true) return Optional.of(contList[l_LAST_PROC          ]);
+  if(true) return contList[l_LAST_PROC          ];
 
 }
 ```

--- a/doc/converted_Java_file_JP.md
+++ b/doc/converted_Java_file_JP.md
@@ -267,7 +267,7 @@ public CobolControl[] contList = {
         // A-01の処理
         //...
     },
-    new CobolControl(l_SUB__A_01, CobolControl.LabelType.label) {
+    new CobolControl(l_SUB__A_02, CobolControl.LabelType.label) {
         // A-02の処理
         //...
     },

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
@@ -22,11 +22,12 @@ import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /**
- * COBOLの手続き部における制御の流れ(PERFORM文・GO TO文)を表現する抽象クラス<br>
+ * COBOLの手続き部における1つの段落・節を表す抽象クラス<br>
  * 各段落・節を1つのCobolControlとして表し、{@link #run()}でその単位を実行する。<br>
  * {@link #run()}は実行後に続けて実行すべき次の制御を返すことで、段落の連続実行(フォールスルー)を表現する。<br>
- * 続けて実行すべき制御が無いことは{@code null}で表す。実行のたびに生成される{@link java.util.Optional}を
- * 用いないことで、手続き部の実行に伴うオブジェクト生成を抑えている。
+ * 続けて実行すべき制御が無い場合は{@code null}を返す。<br>
+ * PERFORM文は{@link #perform(CobolControl[], int)}および{@link #performThrough(CobolControl[], int,
+ * int)}に変換され、GO TO文は移行先のCobolControlを{@link #run()}の戻り値として返すコードに変換される。
  */
 public abstract class CobolControl {
     /** 制御単位の種別(段落か節か)を表す列挙型 */
@@ -36,15 +37,6 @@ public abstract class CobolControl {
         /** 節(section)を表す */
         section,
     }
-
-    /** 何も実行しない制御単位。状態を持たないため単一のインスタンスを使い回す。 */
-    private static final CobolControl PURE =
-            new CobolControl() {
-                @Override
-                public CobolControl run() {
-                    return null;
-                }
-            };
 
     /**
      * この制御単位を実行する。
@@ -76,15 +68,6 @@ public abstract class CobolControl {
     public CobolControl(int contId, LabelType type) {
         this.contId = contId;
         this.type = type;
-    }
-
-    /**
-     * 何も実行せず、続きの制御も持たない空の制御単位を返す。
-     *
-     * @return 何も行わない制御単位
-     */
-    public static CobolControl pure() {
-        return PURE;
     }
 
     /**

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolControl.java
@@ -18,14 +18,15 @@
  */
 package jp.osscons.opensourcecobol.libcobj.common;
 
-import java.util.Optional;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
 import jp.osscons.opensourcecobol.libcobj.exceptions.CobolStopRunException;
 
 /**
  * COBOLの手続き部における制御の流れ(PERFORM文・GO TO文)を表現する抽象クラス<br>
  * 各段落・節を1つのCobolControlとして表し、{@link #run()}でその単位を実行する。<br>
- * {@link #run()}は実行後に続けて実行すべき次の制御を返すことで、段落の連続実行(フォールスルー)を表現する。
+ * {@link #run()}は実行後に続けて実行すべき次の制御を返すことで、段落の連続実行(フォールスルー)を表現する。<br>
+ * 続けて実行すべき制御が無いことは{@code null}で表す。実行のたびに生成される{@link java.util.Optional}を
+ * 用いないことで、手続き部の実行に伴うオブジェクト生成を抑えている。
  */
 public abstract class CobolControl {
     /** 制御単位の種別(段落か節か)を表す列挙型 */
@@ -36,15 +37,23 @@ public abstract class CobolControl {
         section,
     }
 
+    /** 何も実行しない制御単位。状態を持たないため単一のインスタンスを使い回す。 */
+    private static final CobolControl PURE =
+            new CobolControl() {
+                @Override
+                public CobolControl run() {
+                    return null;
+                }
+            };
+
     /**
      * この制御単位を実行する。
      *
-     * @return 続けて実行すべき次の制御。続きがない場合は空の{@link Optional}
+     * @return 続けて実行すべき次の制御。続きがない場合は{@code null}
      * @throws CobolRuntimeException 実行中に実行時例外が発生した場合
      * @throws CobolStopRunException 実行中にSTOP RUNが実行された場合
      */
-    public abstract Optional<CobolControl> run()
-            throws CobolRuntimeException, CobolStopRunException;
+    public abstract CobolControl run() throws CobolRuntimeException, CobolStopRunException;
 
     /** この制御単位を識別するID(段落・節の通し番号)。未設定の場合は-1 */
     public int contId = -1;
@@ -70,78 +79,51 @@ public abstract class CobolControl {
     }
 
     /**
-     * 何も実行せず、続きの制御も持たない空の制御単位を生成する。
+     * 何も実行せず、続きの制御も持たない空の制御単位を返す。
      *
      * @return 何も行わない制御単位
      */
     public static CobolControl pure() {
-        return new CobolControl() {
-            @Override
-            public Optional<CobolControl> run()
-                    throws CobolRuntimeException, CobolStopRunException {
-                return Optional.empty();
-            }
-        };
+        return PURE;
     }
 
     /**
-     * GO TO文に相当し、指定された制御単位へ制御を移す制御単位を生成する。
-     *
-     * @param cont 制御の移行先となる制御単位
-     * @return 移行先を実行する制御単位
-     */
-    public static CobolControl goTo(CobolControl cont) {
-        return new CobolControl() {
-            @Override
-            public Optional<CobolControl> run()
-                    throws CobolRuntimeException, CobolStopRunException {
-                return cont.run();
-            }
-        };
-    }
-
-    /**
-     * PERFORM ... THRU ...文に相当し、begin番目からend番目までの制御単位を順に実行する制御単位を生成する。<br>
+     * PERFORM ... THRU ...文に相当し、begin番目からend番目までの制御単位を順に実行する。<br>
      * 終端が節の場合は、後続の段落も含めて節の終わりまで実行する。
      *
      * @param contList 段落・節を格納した制御単位の配列
      * @param begin 実行を開始する制御単位のインデックス
      * @param end 実行を終了する制御単位のインデックス
-     * @return 指定範囲を実行する制御単位
+     * @throws CobolRuntimeException 実行中に実行時例外が発生した場合
+     * @throws CobolStopRunException 実行中にSTOP RUNが実行された場合
      */
-    public static CobolControl performThrough(CobolControl[] contList, int begin, int end) {
-        return new CobolControl() {
-            @Override
-            public Optional<CobolControl> run()
-                    throws CobolRuntimeException, CobolStopRunException {
-                Optional<CobolControl> nextCont = Optional.of(contList[begin]);
-                LabelType endType = contList[end].type;
-                int executedProgramId;
-                do {
-                    CobolControl cont = nextCont.get();
-                    executedProgramId = cont.contId;
-                    nextCont = cont.run();
-                } while (nextCont.isPresent() && executedProgramId != end);
+    public static void performThrough(CobolControl[] contList, int begin, int end)
+            throws CobolRuntimeException, CobolStopRunException {
+        CobolControl nextCont = contList[begin];
+        final LabelType endType = contList[end].type;
+        int executedProgramId;
+        do {
+            executedProgramId = nextCont.contId;
+            nextCont = nextCont.run();
+        } while (nextCont != null && executedProgramId != end);
 
-                if (endType == LabelType.section) {
-                    while (nextCont.isPresent() && nextCont.get().type == LabelType.label) {
-                        CobolControl cont = nextCont.get();
-                        nextCont = cont.run();
-                    }
-                }
-                return Optional.of(CobolControl.pure());
+        if (endType == LabelType.section) {
+            while (nextCont != null && nextCont.type == LabelType.label) {
+                nextCont = nextCont.run();
             }
-        };
+        }
     }
 
     /**
-     * PERFORM文に相当し、指定された単一の段落・節を実行する制御単位を生成する。
+     * PERFORM文に相当し、指定された単一の段落・節を実行する。
      *
      * @param contList 段落・節を格納した制御単位の配列
      * @param labelId 実行する制御単位のインデックス
-     * @return 指定された制御単位を実行する制御単位
+     * @throws CobolRuntimeException 実行中に実行時例外が発生した場合
+     * @throws CobolStopRunException 実行中にSTOP RUNが実行された場合
      */
-    public static CobolControl perform(CobolControl[] contList, int labelId) {
-        return CobolControl.performThrough(contList, labelId, labelId);
+    public static void perform(CobolControl[] contList, int labelId)
+            throws CobolRuntimeException, CobolStopRunException {
+        performThrough(contList, labelId, labelId);
     }
 }

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
@@ -116,6 +116,24 @@ class CobolControlTest {
     }
 
     @Test
+    void performThroughEndingWithSectionRunsItsFollowingParagraphs() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList =
+                contListOf(
+                        executed,
+                        LabelType.label, // L0: 範囲外の段落
+                        LabelType.label, // L1: 範囲の開始
+                        LabelType.section, // L2: 範囲の終端となる節
+                        LabelType.label, // L3: L2に属する段落
+                        LabelType.label, // L4: L2に属する段落
+                        LabelType.section); // L5: 次の節(実行されない)
+
+        CobolControl.performThrough(contList, 1, 2);
+
+        assertEquals(Arrays.asList("L1", "L2", "L3", "L4"), executed);
+    }
+
+    @Test
     void performOnSectionRunsItsFollowingParagraphs() throws Exception {
         List<String> executed = new ArrayList<>();
         CobolControl[] contList =

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2021-2022 TOKYO SYSTEM HOUSE Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3.0,
+ * or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; see the file COPYING.LIB.  If
+ * not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1301 USA
+ */
+package jp.osscons.opensourcecobol.libcobj.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import jp.osscons.opensourcecobol.libcobj.common.CobolControl.LabelType;
+import org.junit.jupiter.api.Test;
+
+class CobolControlTest {
+
+    /** 実行された順に自身の名前を記録し、配列上の次の要素を返す制御単位。 */
+    private static class Label extends CobolControl {
+        private final String name;
+        private final List<String> executed;
+        private CobolControl next;
+
+        Label(int contId, LabelType type, String name, List<String> executed) {
+            super(contId, type);
+            this.name = name;
+            this.executed = executed;
+        }
+
+        @Override
+        public CobolControl run() {
+            executed.add(name);
+            return next;
+        }
+    }
+
+    /**
+     * 各要素が次の要素へフォールスルーする制御単位の配列を生成する。
+     *
+     * @param executed 実行された制御単位の名前が追記されるリスト
+     * @param types 生成する制御単位の種別(配列の要素数が制御単位の数になる)
+     * @return 生成した制御単位の配列。名前は"L0", "L1", ...となる
+     */
+    private static CobolControl[] contListOf(List<String> executed, LabelType... types) {
+        Label[] contList = new Label[types.length];
+        for (int i = 0; i < types.length; i++) {
+            contList[i] = new Label(i, types[i], "L" + i, executed);
+        }
+        for (int i = 0; i < types.length - 1; i++) {
+            contList[i].next = contList[i + 1];
+        }
+        return contList;
+    }
+
+    @Test
+    void performRunsOnlySpecifiedParagraph() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList =
+                contListOf(executed, LabelType.label, LabelType.label, LabelType.label);
+
+        CobolControl.perform(contList, 1);
+
+        assertEquals(List.of("L1"), executed);
+    }
+
+    @Test
+    void performThroughRunsRangeInclusive() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList =
+                contListOf(
+                        executed,
+                        LabelType.label,
+                        LabelType.label,
+                        LabelType.label,
+                        LabelType.label);
+
+        CobolControl.performThrough(contList, 1, 2);
+
+        assertEquals(List.of("L1", "L2"), executed);
+    }
+
+    @Test
+    void performThroughStopsAtTheEndOfContList() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList = contListOf(executed, LabelType.label, LabelType.label);
+
+        // 最後の制御単位はnull(続きなし)を返すため、endに到達しなくても実行が終わる
+        CobolControl.performThrough(contList, 0, 1);
+
+        assertEquals(List.of("L0", "L1"), executed);
+    }
+
+    @Test
+    void performOnSectionRunsItsFollowingParagraphs() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList =
+                contListOf(
+                        executed,
+                        LabelType.section, // L0: 対象の節
+                        LabelType.label, // L1: L0に属する段落
+                        LabelType.label, // L2: L0に属する段落
+                        LabelType.section, // L3: 次の節(実行されない)
+                        LabelType.label);
+
+        CobolControl.perform(contList, 0);
+
+        assertEquals(List.of("L0", "L1", "L2"), executed);
+    }
+
+    @Test
+    void performThroughEndingWithParagraphDoesNotFallThrough() throws Exception {
+        List<String> executed = new ArrayList<>();
+        CobolControl[] contList =
+                contListOf(executed, LabelType.label, LabelType.label, LabelType.label);
+
+        CobolControl.performThrough(contList, 0, 1);
+
+        assertEquals(List.of("L0", "L1"), executed);
+    }
+}

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolControlTest.java
@@ -21,13 +21,14 @@ package jp.osscons.opensourcecobol.libcobj.common;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import jp.osscons.opensourcecobol.libcobj.common.CobolControl.LabelType;
 import org.junit.jupiter.api.Test;
 
 class CobolControlTest {
 
-    /** 実行された順に自身の名前を記録し、配列上の次の要素を返す制御単位。 */
+    /** 実行された順に自身の名前を記録し、続けて実行すべき制御単位を返す制御単位。 */
     private static class Label extends CobolControl {
         private final String name;
         private final List<String> executed;
@@ -47,13 +48,13 @@ class CobolControlTest {
     }
 
     /**
-     * 各要素が次の要素へフォールスルーする制御単位の配列を生成する。
+     * 各要素が次の要素へフォールスルーする制御単位の配列を生成する。 最後の要素は続きが無いことを表すnullを返す。
      *
      * @param executed 実行された制御単位の名前が追記されるリスト
      * @param types 生成する制御単位の種別(配列の要素数が制御単位の数になる)
      * @return 生成した制御単位の配列。名前は"L0", "L1", ...となる
      */
-    private static CobolControl[] contListOf(List<String> executed, LabelType... types) {
+    private static Label[] contListOf(List<String> executed, LabelType... types) {
         Label[] contList = new Label[types.length];
         for (int i = 0; i < types.length; i++) {
             contList[i] = new Label(i, types[i], "L" + i, executed);
@@ -72,7 +73,7 @@ class CobolControlTest {
 
         CobolControl.perform(contList, 1);
 
-        assertEquals(List.of("L1"), executed);
+        assertEquals(Arrays.asList("L1"), executed);
     }
 
     @Test
@@ -88,18 +89,30 @@ class CobolControlTest {
 
         CobolControl.performThrough(contList, 1, 2);
 
-        assertEquals(List.of("L1", "L2"), executed);
+        assertEquals(Arrays.asList("L1", "L2"), executed);
     }
 
     @Test
-    void performThroughStopsAtTheEndOfContList() throws Exception {
+    void performThroughEndingWithParagraphDoesNotFallThrough() throws Exception {
         List<String> executed = new ArrayList<>();
-        CobolControl[] contList = contListOf(executed, LabelType.label, LabelType.label);
+        CobolControl[] contList =
+                contListOf(executed, LabelType.label, LabelType.label, LabelType.label);
 
-        // 最後の制御単位はnull(続きなし)を返すため、endに到達しなくても実行が終わる
         CobolControl.performThrough(contList, 0, 1);
 
-        assertEquals(List.of("L0", "L1"), executed);
+        assertEquals(Arrays.asList("L0", "L1"), executed);
+    }
+
+    @Test
+    void performThroughStopsWhenControlEndsBeforeEnd() throws Exception {
+        List<String> executed = new ArrayList<>();
+        Label[] contList = contListOf(executed, LabelType.label, LabelType.label, LabelType.label);
+        // L1でGO TOやEXIT PROGRAMにより制御が途切れる状況を再現する
+        contList[1].next = null;
+
+        CobolControl.performThrough(contList, 0, 2);
+
+        assertEquals(Arrays.asList("L0", "L1"), executed);
     }
 
     @Test
@@ -116,17 +129,19 @@ class CobolControlTest {
 
         CobolControl.perform(contList, 0);
 
-        assertEquals(List.of("L0", "L1", "L2"), executed);
+        assertEquals(Arrays.asList("L0", "L1", "L2"), executed);
     }
 
     @Test
-    void performThroughEndingWithParagraphDoesNotFallThrough() throws Exception {
+    void performOnSectionStopsWhenControlEndsInTheSection() throws Exception {
         List<String> executed = new ArrayList<>();
-        CobolControl[] contList =
-                contListOf(executed, LabelType.label, LabelType.label, LabelType.label);
+        Label[] contList =
+                contListOf(executed, LabelType.section, LabelType.label, LabelType.label);
+        // 節に属する段落の途中で制御が途切れる状況を再現する
+        contList[1].next = null;
 
-        CobolControl.performThrough(contList, 0, 1);
+        CobolControl.perform(contList, 0);
 
-        assertEquals(List.of("L0", "L1"), executed);
+        assertEquals(Arrays.asList("L0", "L1"), executed);
     }
 }

--- a/tests/cobj-idx.src/unlock.at
+++ b/tests/cobj-idx.src/unlock.at
@@ -51,7 +51,6 @@ import jp.osscons.opensourcecobol.libcobj.termio.*;
 import jp.osscons.opensourcecobol.libcobj.call.*;
 import jp.osscons.opensourcecobol.libcobj.file.*;
 import jp.osscons.opensourcecobol.libcobj.ui.*;
-import java.util.Optional;
 
 public class force_exit implements CobolRunnable {
   @Override

--- a/tests/file-lock.src/module-sync/setValue.java
+++ b/tests/file-lock.src/module-sync/setValue.java
@@ -7,7 +7,6 @@ import jp.osscons.opensourcecobol.libcobj.termio.*;
 import jp.osscons.opensourcecobol.libcobj.call.*;
 import jp.osscons.opensourcecobol.libcobj.file.*;
 import jp.osscons.opensourcecobol.libcobj.ui.*;
-import java.util.Optional;
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/tests/file-lock.src/module-sync/wait.java
+++ b/tests/file-lock.src/module-sync/wait.java
@@ -7,7 +7,6 @@ import jp.osscons.opensourcecobol.libcobj.termio.*;
 import jp.osscons.opensourcecobol.libcobj.call.*;
 import jp.osscons.opensourcecobol.libcobj.file.*;
 import jp.osscons.opensourcecobol.libcobj.ui.*;
-import java.util.Optional;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;


### PR DESCRIPTION
## 概要

生成されるJavaコードの制御構造(PERFORM文・GO TO文・段落のフォールスルー)を担う `CobolControl` から `java.util.Optional` を排除し、従来どおりの「nullかそれ以外か」で表現するように変更した。

`Optional` は段落を1つ遷移するたびに生成されるうえ、`CobolControl.perform` / `performThrough` は「実行内容を保持する `CobolControl` を新たに生成して返し、呼び出し側がその場で `.run()` する」形になっていたため、PERFORM文1回ごとに無名クラスのインスタンスも生成されていた。いずれも実行のたびに捨てられるだけのオブジェクトである。

## 変更内容

- `CobolControl.run()` の戻り値を `Optional<CobolControl>` から nullable な `CobolControl` に変更した(`null` が「続けて実行すべき制御は無い」を表す)
- `CobolControl.perform` / `performThrough` を、その場で対象の段落・節を実行する `static void` メソッドに変更した
- コードジェネレータから使われていなかった `CobolControl.goTo` を削除した
- 「続けて実行すべき制御が無い」ことの表現が `null` と `contList` 末尾の番兵要素(`CobolControl.pure()`)の2通りあったため `null` に統一し、番兵要素と `CobolControl.pure` を削除した
- 生成されるJavaコードから `import java.util.Optional;` の出力をやめた
- `perform` / `performThrough` のユニットテストを追加した(特に、PERFORM ... THRU の終端が節の場合に後続の段落まで実行するフォールスルー処理を対象とする)

## 生成コードの変化

生成コードの構造は変えていない。`PERFORM ... THRU` が2行に折れていた点はあわせて修正した。

```java
// 変更前                                       // 変更後
public Optional<CobolControl> run() ...         public CobolControl run() ...
return Optional.of(contList[l_X]);              return contList[l_X];
return Optional.of(CobolControl.pure());        return null; /* no more control to run */
CobolControl.perform(contList, l_X).run();      CobolControl.perform(contList, l_X);
CobolControl.performThrough(contList,           CobolControl.performThrough(contList, l_X, l_Y);
l_X, l_Y).run();
```

## 性能測定

20コアのWSL2環境、OpenJDK 21.0.11、JVMはデフォルト設定で測定した。実行時間と割当バイト数は「ウォームアップ20回 + 計測30回」をJVM 3プロセス分繰り返した最小値で、割当バイト数は `ThreadMXBean.getCurrentThreadAllocatedBytes()` による。プロセスのwall時間・最大RSS・Young GC回数は、ウォームアップ無しで1回だけ実行するJVMを `/usr/bin/time -v` で測定した。変更前は本PRのbase(`develop`)をビルドしたもの。

**計測に使ったCOBOLプログラム・計測ドライバ・スクリプトと再現手順は、この本文の末尾に全文を貼ってある。**

制御構造が支配的なプログラム(200万回のループ × [PERFORM 1段落 + PERFORM ... THRU 3段落]、段落の中身は空):

|  | 実行時間(最小) | 割当バイト数/回 | 1反復あたり | プロセスのwall時間 | 最大RSS | Young GC |
| --- | --- | --- | --- | --- | --- | --- |
| 変更前 | 22.4 ms | 167.8 MiB (176,000,208 B) | 88 B | 0.12 s | 184 MB | 2回 |
| 変更後 | 11.1 ms | 144 B | 0 B | 0.07 s | 48 MB | 0回 |

実行時間は50%短縮、ヒープ割当はJITのエスケープ解析後で実質ゼロ(1回の実行あたり144バイト)、最大RSSは74%減、Young GCは2回から0回になった。

実務に近いプログラム(30万回のループ × MOVE・COMPUTEを含む4段落):

|  | 実行時間(最小) | 割当バイト数/回 | 1反復あたり | プロセスのwall時間 | 最大RSS | Young GC |
| --- | --- | --- | --- | --- | --- | --- |
| 変更前 | 95.4 ms | 407.4 MiB (427,193,504 B) | 1424 B | 0.25 s | 229 MB | 4回 |
| 変更後 | 88.7 ms | 382.2 MiB (400,793,440 B) | 1336 B | 0.23 s | 231 MB | 4回 |

割当は6.2%減。1反復あたりの割当減少量は88バイトで、制御構造が支配的なプログラムの88バイト/反復と完全に一致する。つまり消えた割当量そのものは同じで、このプログラムでは数値項目の演算による割当(1反復あたり約1.3KB)が支配的なため相対的な改善率が小さい。実行時間はこの計測では7%短縮だが、同じ比較を別の機会に行うと1.6%だったため、このワークロードでの時間差は計測ごとのばらつきの範囲と考えている。制御構造の比重が高いプログラムほど効果が大きい。

## 動作確認

- PERFORM、PERFORM ... THRU(終端が節の場合を含む)、節のフォールスルー、GO TO、GO TO ... DEPENDING ON、GOBACK、EXIT PROGRAM、CALLによる別プログラムの呼び出し、SORT文のINPUT/OUTPUT PROCEDURE(THRU指定を含む)を網羅したプログラムを変更前後の `cobj` で変換・実行し、生成コードの差分が上記の置き換えのみであること、実行結果が完全に一致することを確認した
- `-ftraceall`、`-debug` を付けた場合も生成コードがコンパイルできることを確認した
- `CobolControl` のユニットテスト、`./check-format`(google-java-format / clang-format)が通ることを確認した

## 互換性に関する注意

`libcobj.jar` の `CobolControl` の公開APIに対する破壊的変更である。古い `cobj` で生成済みのJavaコードは、新しい `libcobj.jar` ではコンパイルも実行もできないため、`cobj` による再生成が必要になる。

なお、このPRでは `CHANGELOG.md` と `libcobj/app/build.gradle.kts` の `version`(現在 `2.0.0`)は変更していない。破壊的変更の記載とバージョンの引き上げはリリース時にまとめて行う。

---

## Summary

This removes `java.util.Optional` from `CobolControl`, the class that implements the control flow (PERFORM, GO TO, and paragraph fall-through) of the generated Java code, and expresses "no continuation" with a plain nullable reference instead.

An `Optional` was allocated on every paragraph transition. On top of that, `CobolControl.perform` / `performThrough` used to build and return a fresh `CobolControl` that the caller immediately `.run()`s, so each PERFORM statement also allocated an anonymous class instance. All of those objects are discarded right after they are created.

## Changes

- `CobolControl.run()` returns a nullable `CobolControl` instead of `Optional<CobolControl>`; `null` means "no control to run next"
- `CobolControl.perform` / `performThrough` are now `static void` methods that run the requested paragraphs directly
- Removed `CobolControl.goTo`, which the code generator never emitted
- "No continuation" used to be expressed in two ways — `null`, and the trailing sentinel element (`CobolControl.pure()`) of `contList`. Unified on `null` and removed both the sentinel element and `CobolControl.pure`
- The generated code no longer emits `import java.util.Optional;`
- Added unit tests for `perform` / `performThrough`, in particular the fall-through that runs the following paragraphs when a PERFORM ... THRU range ends at a section

## Generated code

The structure of the generated code is unchanged. `PERFORM ... THRU` used to be split across two lines, which is fixed here as well.

```java
// before                                       // after
public Optional<CobolControl> run() ...         public CobolControl run() ...
return Optional.of(contList[l_X]);              return contList[l_X];
return Optional.of(CobolControl.pure());        return null; /* no more control to run */
CobolControl.perform(contList, l_X).run();      CobolControl.perform(contList, l_X);
CobolControl.performThrough(contList,           CobolControl.performThrough(contList, l_X, l_Y);
l_X, l_Y).run();
```

## Measurements

Measured on a 20-core WSL2 machine with OpenJDK 21.0.11 and default JVM settings. Time and allocation are the minimum over "20 warmup + 30 measured executions" repeated in 3 JVM processes; allocation comes from `ThreadMXBean.getCurrentThreadAllocatedBytes()`. Process wall time, max RSS and young GC counts come from a JVM that executes the program exactly once, under `/usr/bin/time -v`. The "before" side is a build of this PR's base (`develop`).

**The COBOL programs, the measurement driver, the scripts and the reproduction steps are included in full at the end of this description.**

Control-flow dominated program (2,000,000 iterations of [PERFORM one paragraph + PERFORM ... THRU three paragraphs] with empty paragraph bodies):

|  | time (min) | allocated / run | per iteration | process wall | max RSS | young GC |
| --- | --- | --- | --- | --- | --- | --- |
| before | 22.4 ms | 167.8 MiB (176,000,208 B) | 88 B | 0.12 s | 184 MB | 2 |
| after | 11.1 ms | 144 B | 0 B | 0.07 s | 48 MB | 0 |

50% faster, essentially zero heap allocation once the JIT's escape analysis kicks in (144 bytes per execution), 74% lower max RSS, and young GCs drop from 2 to 0.

More realistic program (300,000 iterations over four paragraphs doing MOVE and COMPUTE):

|  | time (min) | allocated / run | per iteration | process wall | max RSS | young GC |
| --- | --- | --- | --- | --- | --- | --- |
| before | 95.4 ms | 407.4 MiB (427,193,504 B) | 1424 B | 0.25 s | 229 MB | 4 |
| after | 88.7 ms | 382.2 MiB (400,793,440 B) | 1336 B | 0.23 s | 231 MB | 4 |

6.2% less allocation. The allocation saved per iteration is 88 bytes — exactly the same as in the control-flow dominated program. The absolute saving is identical; it just looks small here because numeric field arithmetic allocates about 1.3 KB per iteration and dominates. This run also shows 7% less time, but the same comparison run on another occasion showed 1.6%, so the time difference on this workload is within run-to-run variation. The more control-flow heavy a program is, the larger the gain.

## Verification

- Programs exercising PERFORM, PERFORM ... THRU (including ranges ending at a section), section fall-through, GO TO, GO TO ... DEPENDING ON, GOBACK, EXIT PROGRAM, CALL of another program, and SORT with INPUT / OUTPUT PROCEDURE (including THRU) were translated and run with both the old and the new `cobj`: the only differences in the generated code are the substitutions shown above, and the output is identical
- The generated code still compiles with `-ftraceall` and `-debug`
- The `CobolControl` unit tests and `./check-format` (google-java-format / clang-format) pass

## Compatibility

This is a breaking change to the public `CobolControl` API of `libcobj.jar`. Java sources produced by an older `cobj` will neither compile nor run against the new `libcobj.jar` and must be regenerated.

This PR does not touch `CHANGELOG.md` or `version` in `libcobj/app/build.gradle.kts` (still `2.0.0`); recording the breaking change and bumping the version will be done together at release time.

---

## 付録: 性能計測に使ったプログラムと手順 / Appendix: benchmark programs

### 環境 / Environment

- WSL2 (Ubuntu), 20 コア / 20 cores
- OpenJDK 21.0.11 (build 21.0.11+10-1-24.04.2-Ubuntu)
- JVMはデフォルト設定 (G1 GC、ヒープサイズ指定なし) / default JVM settings

### 手順 / How to reproduce

1. `develop` (変更前) と本ブランチ (変更後) をそれぞれ別のディレクトリに
   `./configure --prefix=<prefix> && make && make install` でビルドする
2. 下記の5ファイルを `bench/` (`bench1.cbl`, `bench2.cbl`, `Bench.java` は `bench/src/`) に置く
3. `./bench.sh <変更前のprefix> <変更後のprefix>` を実行する

`bench.sh` は各prefixの `cobj` でCOBOLをJavaに変換 (`-C`) し、それぞれの `libcobj.jar` に対して
コンパイル・実行して結果をまとめる。

### 測定方法 / Methodology

- **実行時間・割当バイト数**: 生成されたクラスを1つ生成し、`run()` (= COBOLプログラム1回の実行) を
  ウォームアップ20回 + 計測30回呼び出す。これをJVMプロセス3個分繰り返し、1回の実行ごとの経過時間と
  `com.sun.management.ThreadMXBean#getCurrentThreadAllocatedBytes()` の差分を記録して、その最小値を採用する
- **プロセスのwall時間・最大RSS・Young GC回数**: ウォームアップ無しで1回だけ実行するJVMを
  `/usr/bin/time -v` 経由で起動して測定する (JVM起動を含むコールドな1回実行)

<details>
<summary>bench/src/bench1.cbl — 制御構造が支配的なプログラム / control-flow dominated</summary>

```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. BENCH1.
      *> Control-flow dominated benchmark.
      *> 2,000,000 iterations of "PERFORM one paragraph"
      *> plus "PERFORM ... THRU three paragraphs".
      *> The paragraph bodies are empty on purpose so that the measured
      *> cost is the control flow itself (CobolControl.perform /
      *> performThrough and the paragraph-to-paragraph transitions).
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 DUMMY PIC 9 VALUE 0.
       PROCEDURE DIVISION.
       MAIN-PARA.
           PERFORM 2000000 TIMES
               PERFORM P-A
               PERFORM P-B THRU P-D
           END-PERFORM.
           EXIT PROGRAM.
       P-A.
           CONTINUE.
       P-B.
           CONTINUE.
       P-C.
           CONTINUE.
       P-D.
           CONTINUE.
```

</details>

<details>
<summary>bench/src/bench2.cbl — MOVE / COMPUTE が支配的なプログラム / arithmetic dominated</summary>

```cobol
       IDENTIFICATION DIVISION.
       PROGRAM-ID. BENCH2.
      *> More realistic benchmark: 300,000 iterations over four
      *> paragraphs that do MOVE and COMPUTE, so numeric field
      *> handling - not the control flow - dominates the cost.
       DATA DIVISION.
       WORKING-STORAGE SECTION.
       01 CNT  PIC 9(9)    VALUE 0.
       01 TMP  PIC 9(5)V99 VALUE 0.
       01 ACC  PIC 9(9)V99 VALUE 0.
       01 RATE PIC 9V999   VALUE 1.025.
       PROCEDURE DIVISION.
       MAIN-PARA.
           PERFORM 300000 TIMES
               PERFORM CALC-A THRU CALC-D
           END-PERFORM.
           EXIT PROGRAM.
       CALC-A.
           ADD 1 TO CNT.
           MOVE CNT TO TMP.
       CALC-B.
           COMPUTE TMP = TMP * RATE.
       CALC-C.
           COMPUTE ACC = ACC + TMP.
       CALC-D.
           MOVE 0 TO TMP.
```

</details>

<details>
<summary>bench/src/Bench.java — 計測ドライバ / measurement driver</summary>

```java
import com.sun.management.ThreadMXBean;
import java.lang.management.GarbageCollectorMXBean;
import java.lang.management.ManagementFactory;
import jp.osscons.opensourcecobol.libcobj.call.CobolRunnable;

/**
 * Driver for the CobolControl benchmark.
 *
 * <p>usage: java Bench &lt;generated class&gt; &lt;warmup runs&gt; &lt;measured runs&gt;
 *
 * <p>The generated class is instantiated once and its {@code run()} (the whole COBOL program) is
 * called repeatedly. For every measured run the wall time and the bytes allocated on this thread
 * are recorded, and the minimum over all runs is reported. GC counts are printed at the end.
 */
public class Bench {
  public static void main(String[] args) throws Exception {
    String className = args[0];
    int warmup = Integer.parseInt(args[1]);
    int runs = Integer.parseInt(args[2]);

    CobolRunnable prog =
        (CobolRunnable) Class.forName(className).getDeclaredConstructor().newInstance();
    ThreadMXBean bean = (ThreadMXBean) ManagementFactory.getThreadMXBean();

    for (int i = 0; i < warmup; i++) {
      prog.run();
    }

    long bestNanos = Long.MAX_VALUE;
    long bestAlloc = Long.MAX_VALUE;
    long sumNanos = 0;
    long sumAlloc = 0;
    for (int i = 0; i < runs; i++) {
      long a0 = bean.getCurrentThreadAllocatedBytes();
      long t0 = System.nanoTime();
      prog.run();
      long t1 = System.nanoTime();
      long a1 = bean.getCurrentThreadAllocatedBytes();
      long nanos = t1 - t0;
      long alloc = a1 - a0;
      bestNanos = Math.min(bestNanos, nanos);
      bestAlloc = Math.min(bestAlloc, alloc);
      sumNanos += nanos;
      sumAlloc += alloc;
    }

    System.out.printf("class=%s warmup=%d runs=%d%n", className, warmup, runs);
    System.out.printf("time_min_ms=%.2f%n", bestNanos / 1e6);
    System.out.printf("time_avg_ms=%.2f%n", sumNanos / (double) runs / 1e6);
    System.out.printf("alloc_min_bytes=%d%n", bestAlloc);
    System.out.printf("alloc_avg_bytes=%d%n", sumAlloc / runs);
    for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
      System.out.printf(
          "gc_count[%s]=%d gc_time_ms[%s]=%d%n",
          gc.getName(), gc.getCollectionCount(), gc.getName(), gc.getCollectionTime());
    }
  }
}
```

</details>

<details>
<summary>bench/bench.sh — 変換・コンパイル・実行 / translate, compile and run</summary>

```bash
#!/bin/bash
# Measure the effect of PR #21 (removing Optional from CobolControl) on the
# control flow of the generated Java code.
#
#   usage: ./bench.sh <before-prefix> <after-prefix>
#
#     <before-prefix>, <after-prefix>
#         opensource COBOL 4J install prefixes (what you passed to
#         ./configure --prefix=...), one built before the change and one after.
#         Both <prefix>/bin/cobj and
#         <prefix>/lib/opensourcecobol4j/libcobj.jar must exist.
#
#   env: WARMUP=20 RUNS=30 REPEAT=3
#
# For each variant and each program:
#   * REPEAT JVMs x (WARMUP + RUNS) executions -> minimum in-JVM time and
#     minimum allocated bytes per execution (allocation comes from
#     com.sun.management.ThreadMXBean#getCurrentThreadAllocatedBytes)
#   * one cold JVM executing the program exactly once under /usr/bin/time -v
#     -> process wall time, max RSS, GC counts
set -eu

if [ $# -ne 2 ]; then
  sed -n '2,18p' "$0"
  exit 1
fi

HERE="$(cd "$(dirname "$0")" && pwd)"
BEFORE_ROOT=$(cd "$1" && pwd)
AFTER_ROOT=$(cd "$2" && pwd)

WARMUP=${WARMUP:-20}
RUNS=${RUNS:-30}
REPEAT=${REPEAT:-3}
PROGS="BENCH1 BENCH2"

rm -rf "$HERE"/java "$HERE"/classes "$HERE"/raw
mkdir -p "$HERE"/raw

for which in before after; do
  case $which in
    before) root=$BEFORE_ROOT ;;
    after)  root=$AFTER_ROOT ;;
  esac
  jar="$root/lib/opensourcecobol4j/libcobj.jar"
  mkdir -p "$HERE/java/$which" "$HERE/classes/$which"

  for src in "$HERE"/src/*.cbl; do
    "$root/bin/cobj" -C -j "$HERE/java/$which" "$src"
  done
  javac -cp "$jar" -d "$HERE/classes/$which" \
    "$HERE/java/$which"/*.java "$HERE/src/Bench.java"

  cp="$jar:$HERE/classes/$which"
  for prog in $PROGS; do
    for r in $(seq 1 "$REPEAT"); do
      echo "[$which] $prog: JVM $r/$REPEAT (warmup=$WARMUP runs=$RUNS)"
      java -cp "$cp" Bench "$prog" "$WARMUP" "$RUNS" \
        > "$HERE/raw/$prog.$which.$r.txt"
    done
    echo "[$which] $prog: single cold execution"
    /usr/bin/time -v java -cp "$cp" Bench "$prog" 0 1 \
      > "$HERE/raw/$prog.$which.single.txt" \
      2> "$HERE/raw/$prog.$which.single.time.txt"
  done
done

python3 "$HERE/summarize.py" "$HERE/raw" "$WARMUP" "$RUNS" "$REPEAT" \
  | tee "$HERE/results.md"
```

</details>

<details>
<summary>bench/summarize.py — 集計 / summarize into a markdown table</summary>

```python
#!/usr/bin/env python3
"""Turn the raw output of bench.sh into a markdown report.

usage: summarize.py <raw dir> <warmup> <runs> <repeat>
"""

import glob
import os
import re
import sys

raw_dir, warmup, runs, repeat = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]

PROGS = [
    (
        "BENCH1",
        "BENCH1: control-flow dominated "
        "(2,000,000 x [PERFORM one paragraph + PERFORM THRU three paragraphs])",
        2_000_000,
    ),
    (
        "BENCH2",
        "BENCH2: MOVE / COMPUTE dominated (300,000 x four paragraphs)",
        300_000,
    ),
]


def read_kv(path):
    kv = {}
    with open(path) as f:
        for line in f:
            for part in line.rstrip("\n").split(" "):
                if "=" in part:
                    k, v = part.split("=", 1)
                    kv[k] = v
    return kv


def in_jvm(prog, which):
    """Minimum time / allocation per execution over every measured JVM."""
    times, allocs = [], []
    for path in sorted(glob.glob(os.path.join(raw_dir, f"{prog}.{which}.[0-9]*.txt"))):
        kv = read_kv(path)
        times.append(float(kv["time_min_ms"]))
        allocs.append(int(kv["alloc_min_bytes"]))
    return min(times), max(times), min(allocs)


def single(prog, which):
    """The cold single-execution process: wall time, max RSS, young GC count."""
    body = open(os.path.join(raw_dir, f"{prog}.{which}.single.txt")).read()
    young = int(re.search(r"gc_count\[G1 Young Generation\]=(\d+)", body).group(1))

    time_txt = open(os.path.join(raw_dir, f"{prog}.{which}.single.time.txt")).read()
    wall_txt = re.search(r"Elapsed \(wall clock\) time[^\n]*", time_txt).group(0).split()[-1]
    wall = 0.0
    for part in wall_txt.split(":"):
        wall = wall * 60 + float(part)
    rss = int(re.search(r"Maximum resident set size \(kbytes\): (\d+)", time_txt).group(1))
    return wall, rss / 1024.0, young


def fmt_bytes(n):
    if n >= 1024 * 1024:
        return f"{n / 1048576.0:.1f} MiB ({n:,} B)"
    if n >= 1024:
        return f"{n / 1024.0:.1f} KiB ({n:,} B)"
    return f"{n} B"


print(f"<!-- warmup={warmup} measured runs={runs} JVMs per variant={repeat} -->")
print()
for prog, title, iters in PROGS:
    tb, tb_worst, ab = in_jvm(prog, "before")
    ta, ta_worst, aa = in_jvm(prog, "after")
    wb, rb, gb = single(prog, "before")
    wa, ra, ga = single(prog, "after")

    print(f"### {title}")
    print()
    print("|  | time (min) | allocated / run | allocated / iteration "
          "| process wall | max RSS | young GC |")
    print("| --- | --- | --- | --- | --- | --- | --- |")
    for label, t, a, w, r, g in (
        ("before", tb, ab, wb, rb, gb),
        ("after", ta, aa, wa, ra, ga),
    ):
        print(
            f"| {label} | {t:.1f} ms | {fmt_bytes(a)} | {a / iters:.0f} B "
            f"| {w:.2f} s | {r:.0f} MB | {g} |"
        )
    print()
    print(
        f"time {(1 - ta / tb) * 100:+.1f}%, allocation {(1 - aa / ab) * 100:+.1f}%, "
        f"max RSS {(1 - ra / rb) * 100:+.1f}% (positive = improvement); "
        f"slowest of the {repeat} JVM minima: before {tb_worst:.1f} ms, after {ta_worst:.1f} ms"
    )
    print()
```

</details>
