### PR TITLE
Drop support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,6 @@ jobs:
           dnf -y update
           dnf install -y gcc make autoconf diffutils gettext bison flex
 
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y java-21-amazon-corretto-devel gcc make autoconf diffutils gettext tar gzip bison flex
-
       - name: Checkout opensource COBOL 4J
         uses: actions/checkout@v7
       

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
     needs: check-workflows
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
@@ -60,7 +60,7 @@ jobs:
           - "misc"
           - "file-lock"
           - "file-lock2"
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -83,7 +83,7 @@ jobs:
           - "file-lock"
           - "file-lock2"
           #- "misc"
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-other.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -94,7 +94,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-esql.yml
     with:
       os: ${{ matrix.os }}
@@ -103,7 +103,7 @@ jobs:
     needs: build-utf8
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-esql-utf8.yml
     with:
       os: ${{ matrix.os }}
@@ -121,7 +121,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-cobj-api.yml
     with:
       os: ${{ matrix.os }}
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["IC", "IF", "IX", "NC", "OB", "RL", "SG", "SM", "SQ", "ST"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}
@@ -157,7 +157,7 @@ jobs:
     strategy:
       matrix:
         test_name: ["CM", "DB", "RW"]
-        os: ["ubuntu:24.04", "almalinux:9", "amazonlinux:2023"]
+        os: ["ubuntu:24.04", "almalinux:9"]
     uses: ./.github/workflows/test-nist.yml
     with:
       test-name: ${{ matrix.test_name }}

--- a/.github/workflows/test-cobj-api.yml
+++ b/.github/workflows/test-cobj-api.yml
@@ -31,7 +31,6 @@ jobs:
           name: opensourcecobol4j-${{ env.ARTIFACT_NAME }}-opt_${{ inputs.configure-args }}
 
       - uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -47,17 +46,6 @@ jobs:
         run: |
           dnf -y update
           dnf install -y gcc make diffutils glibc-gconv-extra
-
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make diffutils tar gzip
-
-      - name: Install Java
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf install -y java-11-amazon-corretto-devel
 
       - name: Install opensource COBOL 4J
         run: |

--- a/.github/workflows/test-esql-examples.yml
+++ b/.github/workflows/test-esql-examples.yml
@@ -43,19 +43,7 @@ jobs:
         with:
           name: opensourcecobol4j-${{ env.ARTIFACT_NAME }}-opt_
 
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make diffutils tar gzip
-
-      - name: Install Java on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf install -y java-11-amazon-corretto-devel
-
       - uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/test-esql-utf8.yml
+++ b/.github/workflows/test-esql-utf8.yml
@@ -43,19 +43,7 @@ jobs:
         with:
           name: opensourcecobol4j-${{ env.ARTIFACT_NAME }}-opt_--enable-utf8
 
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make diffutils tar gzip
-
-      - name: Install Java on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf install -y java-11-amazon-corretto-devel
-
       - uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/test-esql.yml
+++ b/.github/workflows/test-esql.yml
@@ -43,19 +43,7 @@ jobs:
         with:
           name: opensourcecobol4j-${{ env.ARTIFACT_NAME }}-opt_
 
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make diffutils tar gzip
-
-      - name: Install Java on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf install -y java-11-amazon-corretto-devel
-
       - uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/test-nist.yml
+++ b/.github/workflows/test-nist.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Install Java
         uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -54,17 +53,6 @@ jobs:
         run: |
           dnf -y update
           dnf install -y gcc make perl
-
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make perl tar gzip
-      
-      - name: Install Java
-        if: inputs.os == 'amazonlinux:2023'
-        run:
-          dnf install -y java-11-amazon-corretto-devel
 
       - name: Install opensource COBOL 4J
         run: |

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -34,7 +34,6 @@ jobs:
           name: opensourcecobol4j-${{ env.ARTIFACT_NAME }}-opt_${{ inputs.configure-args }}
 
       - uses: actions/setup-java@v5
-        if: inputs.os != 'amazonlinux:2023'
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -55,17 +54,6 @@ jobs:
           cd nkf-2_1_3
           make
           make install
-
-      - name: Install dependencies on Amazon Linux 2023
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf -y update
-          dnf install -y gcc make diffutils tar gzip unzip wget nkf
-
-      - name: Install Java
-        if: inputs.os == 'amazonlinux:2023'
-        run: |
-          dnf install -y java-11-amazon-corretto-devel
 
       - name: Install opensource COBOL 4J
         run: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ opensource COBOL 4J is tested with the following platforms and dependencies:
 
 * Ubuntu 24.04 and OpenJDK 21
 * AlmaLinux 9 and OpenJDK 11
-* Amazon Linux 2023 and OpenJDK 21
 
 If you want to check requirements of older versions, see [doc/requirements-all.md](./doc/requirements-all.md).
 
@@ -41,13 +40,6 @@ sudo apt-get install -y default-jdk build-essential bison flex gettext texinfo l
 ```
 dnf -y update
 dnf install -y java-11-openjdk-devel gcc make bison flex automake autoconf diffutils gettext
-```
-
-#### Amazon Linux 2023
-
-```
-dnf -y update
-dnf install -y java-21-amazon-corretto-devel gcc make bison flex automake autoconf diffutils gettext tar gzip
 ```
 
 ### Install opensource COBOL 4J

--- a/README_JP.md
+++ b/README_JP.md
@@ -16,7 +16,6 @@ opensource COBOL 4Jは、下記の環境でテストされています：
 
 * Ubuntu 24.04 と OpenJDK 21
 * AlmaLinux 9 と OpenJDK 11
-* Amazon Linux 2023 と OpenJDK 21
 
 古いバージョンの動作環境については、[doc/requirements-all.md](./doc/requirements-all.md)をご覧ください。
 
@@ -36,12 +35,6 @@ sudo apt-get install -y default-jdk build-essential bison flex gettext texinfo l
 ```
 dnf -y update
 dnf install -y java-11-openjdk-devel gcc make bison flex automake autoconf diffutils gettext
-```
-
-#### Amazon Linux 2023
-```
-dnf -y update
-dnf install -y java-21-amazon-corretto-devel gcc make bison flex automake autoconf diffutils gettext tar gzip
 ```
 
 ### opensource COBOL 4Jのインストール


### PR DESCRIPTION
## 概要

Amazon Linux 2023 のサポートを打ち切ります。

## 変更内容

- `.github/workflows/pull-request.yml`: 全ジョブのマトリクスから `amazonlinux:2023` を削除
- 再利用可能ワークフロー (`build.yml`, `test-other.yml`, `test-nist.yml`, `test-esql.yml`, `test-esql-utf8.yml`, `test-esql-examples.yml`, `test-cobj-api.yml`): Amazon Linux 2023 専用の依存関係インストールステップと Amazon Corretto のインストールステップを削除。あわせて `actions/setup-java` に付いていた `if: inputs.os != 'amazonlinux:2023'` という条件も不要になったので削除
- `README.md`, `README_JP.md`: 動作環境の一覧とインストール手順から Amazon Linux 2023 を削除

`doc/requirements-all.md` はリリース済みの各バージョンが対象としていた動作環境の記録なので、過去の記録として変更していません。次回リリース時に追加される行から Amazon Linux 2023 を外す運用になります。

## 動機

**Amazon Linux 2023 のサポートは、Ubuntu・AlmaLinux・Windows がサポートされている現在では重要ではありません。**
Ubuntu (Debian 系)、AlmaLinux (RHEL 系)、Windows がカバーされていれば、実用上の環境はほぼ網羅できています。Amazon Linux 2023 は RHEL 系であり、AlmaLinux 9 のテストと大きく重複しています。

そのうえで、**CI が大幅に軽量になることが期待されます**。pull request 時のマトリクスから 1 OS 分がまるごと減るため、build・test-other・test-nist・test-esql・test-cobj-api などの各ジョブが OS ごとに展開されている分だけジョブ数が削減されます。加えて、Amazon Linux 2023 では `actions/setup-java` が使えず、コンテナ内で `dnf install java-*-amazon-corretto-devel` を都度実行していたため、この OS 固有のセットアップ時間もなくなります。

---

## Summary

This PR drops support for Amazon Linux 2023.

## Changes

- `.github/workflows/pull-request.yml`: removed `amazonlinux:2023` from every job matrix
- Reusable workflows (`build.yml`, `test-other.yml`, `test-nist.yml`, `test-esql.yml`, `test-esql-utf8.yml`, `test-esql-examples.yml`, `test-cobj-api.yml`): removed the Amazon Linux 2023-specific dependency and Amazon Corretto installation steps. The now-unnecessary `if: inputs.os != 'amazonlinux:2023'` conditions on `actions/setup-java` were removed as well
- `README.md`, `README_JP.md`: removed Amazon Linux 2023 from the list of supported environments and from the installation instructions

`doc/requirements-all.md` is left untouched: it is a historical record of the environments each already-released version targeted. Amazon Linux 2023 will simply be absent from the row added for the next release.

## Motivation

**Amazon Linux 2023 support is not important now that Ubuntu, AlmaLinux and Windows are supported.**
With Ubuntu (Debian family), AlmaLinux (RHEL family) and Windows covered, practical deployment environments are already well represented. Amazon Linux 2023 is itself a RHEL-family distribution, so its coverage overlaps heavily with the AlmaLinux 9 jobs.

On top of that, **the CI is expected to become considerably lighter**. Removing one OS from the pull request matrix removes one job per matrix entry across build, test-other, test-nist, test-esql, test-cobj-api and friends. Amazon Linux 2023 also could not use `actions/setup-java` and had to run `dnf install java-*-amazon-corretto-devel` inside the container on every job, so that OS-specific setup time disappears too.
