### PR TITLE
Start every JVM in the test suites with -XX:-UsePerfData

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -357,7 +357,11 @@ EXTRA_DIST = $(srcdir)/package.m4 \
 	$(esql_misc_DEPENDENCIES) \
 	$(esql_sql_data_DEPENDENCIES) \
 	$(esql_utf8_DEPENDENCIES) \
-	embed_db_info.sh
+	embed_db_info.sh \
+	jvm-wrapper/java \
+	jvm-wrapper/javac \
+	jvm-wrapper/javap \
+	jvm-wrapper/jar
 
 DISTCLEANFILES = atconfig
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -900,7 +900,11 @@ EXTRA_DIST = $(srcdir)/package.m4 \
 	$(esql_misc_DEPENDENCIES) \
 	$(esql_sql_data_DEPENDENCIES) \
 	$(esql_utf8_DEPENDENCIES) \
-	embed_db_info.sh
+	embed_db_info.sh \
+	jvm-wrapper/java \
+	jvm-wrapper/javac \
+	jvm-wrapper/javap \
+	jvm-wrapper/jar
 
 DISTCLEANFILES = atconfig
 ESQL_TESTS = esql-basic esql-sqlca esql-cobol-data esql-misc esql-sql-data esql-utf8

--- a/tests/atlocal-win.env
+++ b/tests/atlocal-win.env
@@ -8,6 +8,32 @@ PATHSEP=";"
 IS_WINDOWS="1"
 export COBJ COBJ_IDX PATHSEP IS_WINDOWS
 
+# Run every JVM the tests start with -XX:-UsePerfData, so that concurrent
+# start-ups cannot collide over the hsperfdata file and print a warning that
+# breaks unrelated tests.  See tests/jvm-wrapper/java.
+# The real tools have to be resolved before the wrappers go on PATH,
+# otherwise the wrappers would find themselves.  Reading this file a second
+# time in the same shell would do exactly that, so it is done only once.
+case ":${PATH}:" in
+*":${abs_srcdir}/jvm-wrapper:"*)
+  ;;
+*)
+  COB4J_REAL_JAVA=`command -v java`
+  COB4J_REAL_JAVAC=`command -v javac`
+  COB4J_REAL_JAVAP=`command -v javap`
+  COB4J_REAL_JAR=`command -v jar`
+  export COB4J_REAL_JAVA COB4J_REAL_JAVAC COB4J_REAL_JAVAP COB4J_REAL_JAR
+  PATH="${abs_srcdir}/jvm-wrapper:${PATH}"
+  ;;
+esac
+
+# cobj.exe starts javac through the Windows command interpreter, which cannot
+# run the POSIX wrapper script, so that javac gets the flag directly instead.
+# The jar that cobj starts is not reachable this way: cobj puts COB_JAVA_FLAGS
+# on the javac command line only.
+COB_JAVA_FLAGS="-J-XX:-UsePerfData"
+export COB_JAVA_FLAGS
+
 # Compiler flags
 FLAGS="-std=cobol2002 -debug -Wall"
 CONF_JP_COMPAT="-conf=C:/opensourcecobol4j/config/jp-compat.conf"

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -27,6 +27,26 @@ COB_BIGENDIAN="@COB_BIGENDIAN@"
 COB_SPLITKEY_FLAGS="@COB_SPLITKEY_FLAGS@"
 COB_HAS_ISAM="@COB_HAS_ISAM@"
 PATH="${abs_top_builddir}/cobj:${abs_top_builddir}/bin:${abs_top_builddir}/libcob/.libs:${PATH}"
+
+# Run every JVM the tests start with -XX:-UsePerfData, so that concurrent
+# start-ups cannot collide over /tmp/hsperfdata_<user>/<pid> and print a
+# warning that breaks unrelated tests.  See tests/jvm-wrapper/java.
+# The real tools have to be resolved before the wrappers go on PATH,
+# otherwise the wrappers would find themselves.  Reading this file a second
+# time in the same shell would do exactly that, so it is done only once.
+case ":${PATH}:" in
+*":${abs_srcdir}/jvm-wrapper:"*)
+  ;;
+*)
+  COB4J_REAL_JAVA=`command -v java`
+  COB4J_REAL_JAVAC=`command -v javac`
+  COB4J_REAL_JAVAP=`command -v javap`
+  COB4J_REAL_JAR=`command -v jar`
+  export COB4J_REAL_JAVA COB4J_REAL_JAVAC COB4J_REAL_JAVAP COB4J_REAL_JAR
+  PATH="${abs_srcdir}/jvm-wrapper:${PATH}"
+  ;;
+esac
+
 CONF_JP_COMPAT="-conf=${abs_top_builddir}/config/jp-compat.conf"
 CONF_LIMIT_TEST="-conf=${abs_top_builddir}/config/boundary-limit.conf"
 COBJ="${abs_top_builddir}/cobj/cobj"

--- a/tests/command-line-options.src/B.at
+++ b/tests/command-line-options.src/B.at
@@ -14,7 +14,7 @@ AT_CHECK([javap -l prog | grep -i 'line [0-9]\+: [0-9]' ], [1])
 
 AT_CHECK([rm *.java *.class])
 
-AT_CHECK([COB_JAVA_FLAGS="-g" ${COBJ} prog.cbl])
+AT_CHECK([COB_JAVA_FLAGS="$COB_JAVA_FLAGS -g" ${COBJ} prog.cbl])
 AT_CHECK([javap -l prog | grep -i 'line [0-9]\+: [0-9]' ], [1])
 
 AT_CLEANUP

--- a/tests/file-lock.src/access-different-record.at
+++ b/tests/file-lock.src/access-different-record.at
@@ -134,12 +134,12 @@ function run_test() {
     rm -f playground-record-lock-*
 
     if test "$OPERATION2" == "$OPERATION_WRITE"; then
-        java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1_FOR_WRITE@<:@$OPERATION1@:>@} > prog1.log &
+        java ${PROGRAM_ID_TABLE1_FOR_WRITE@<:@$OPERATION1@:>@} > prog1.log &
     else
-        java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+        java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     fi
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock.src/access-same-record.at
+++ b/tests/file-lock.src/access-same-record.at
@@ -112,9 +112,9 @@ function run_test() {
 
     rm -f playground-record-lock-*
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock.src/lock-file.at
+++ b/tests/file-lock.src/lock-file.at
@@ -189,12 +189,12 @@ function run_test() {
 
     ${COBJ} ${PROGRAM_NAME_1}.cbl ${PROGRAM_NAME_2}.cbl make_indexed_file${TEST_ID}.cbl
 
-    java -Xlog:perf+memops=off make_indexed_file${TEST_ID}
+    java make_indexed_file${TEST_ID}
 
-    java -Xlog:perf+memops=off $PROGRAM_NAME_1 &
+    java $PROGRAM_NAME_1 &
     PID1=$!
 
-    java -Xlog:perf+memops=off $PROGRAM_NAME_2 > ${TEST_ID}.log &
+    java $PROGRAM_NAME_2 > ${TEST_ID}.log &
     PID2=$!
 
     wait $PID1 $PID2
@@ -365,7 +365,7 @@ AT_DATA([run.sh], [
 set -e
 
 COMPILER="${COBJ}"
-RUNNER="java -Xlog:perf+memops=off"
+RUNNER="java"
 
 rm -f file.dat shared1.dat shared2.dat
 

--- a/tests/file-lock2.src/input-mode.at
+++ b/tests/file-lock2.src/input-mode.at
@@ -106,9 +106,9 @@ function run_test() {
 
     rm -f playground-record-lock-*
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock2.src/lock-mode-automatic.at
+++ b/tests/file-lock2.src/lock-mode-automatic.at
@@ -119,9 +119,9 @@ function run_test() {
 
     rm -f playground-record-lock-* f.dat pro1.log prog2.log
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock2.src/lock-mode-clause.at
+++ b/tests/file-lock2.src/lock-mode-clause.at
@@ -120,9 +120,9 @@ function run_test() {
 
     rm -f playground-record-lock-* f.dat pro1.log prog2.log
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock2.src/old-file.at
+++ b/tests/file-lock2.src/old-file.at
@@ -44,7 +44,7 @@ AT_DATA([open_file_status.at], [
 
 AT_CHECK([${COBJ} open_file_status.at])
 AT_CHECK([cp ../../file-lock.src/indexed-file/old_indexed_file.dat indexed_file.dat])
-AT_CHECK([java -Xlog:perf+memops=off open_file_status], [0],
+AT_CHECK([java open_file_status], [0],
 [92
 92
 92

--- a/tests/file-lock2.src/open-input.at
+++ b/tests/file-lock2.src/open-input.at
@@ -115,9 +115,9 @@ function run_test() {
 
     rm -f playground-record-lock-* f.dat pro1.log prog2.log
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock2.src/open-start-write-rewrite.at
+++ b/tests/file-lock2.src/open-start-write-rewrite.at
@@ -124,9 +124,9 @@ function run_test() {
 
     rm -f playground-record-lock-* f.dat pro1.log prog2.log
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2

--- a/tests/file-lock2.src/release-lock.at
+++ b/tests/file-lock2.src/release-lock.at
@@ -133,9 +133,9 @@ function run_test() {
 
     rm -f playground-record-lock-* f.dat pro1.log prog2.log
 
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
+    java ${PROGRAM_ID_TABLE1@<:@$OPERATION1@:>@} > prog1.log &
     PID1=$!
-    java -Xlog:perf+memops=off ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
+    java ${PROGRAM_ID_TABLE2@<:@$OPERATION2@:>@} > prog2.log &
     PID2=$!
 
     wait $PID1 $PID2
@@ -435,9 +435,9 @@ AT_DATA([p2.cbl], [
 ])
 
 AT_DATA([run.sh], [
-    java -Xlog:perf+memops=off p1 > p1.log &
+    java p1 > p1.log &
     PID1=$!
-    java -Xlog:perf+memops=off p2 > p2.log &
+    java p2 > p2.log &
     PID2=$!
     wait $PID1 $PID2
 ])
@@ -570,9 +570,9 @@ AT_DATA([p2.cbl], [
 ])
 
 AT_DATA([run.sh], [
-    java -Xlog:perf+memops=off p1 > p1.log &
+    java p1 > p1.log &
     PID1=$!
-    java -Xlog:perf+memops=off p2 > p2.log &
+    java p2 > p2.log &
     PID2=$!
     wait $PID1 $PID2
 ])

--- a/tests/file-lock2.src/same-process.at
+++ b/tests/file-lock2.src/same-process.at
@@ -120,5 +120,5 @@ AT_DATA([prog.cbl], [
 ])
 
 AT_CHECK([${COBJ} prog.cbl])
-AT_CHECK([java -Xlog:perf+memops=off prog])
+AT_CHECK([java prog])
 AT_CLEANUP

--- a/tests/jvm-wrapper/jar
+++ b/tests/jvm-wrapper/jar
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# `jar` wrapper used only while the autotest suites run.
+# See tests/jvm-wrapper/java for why the flag is needed; jar is a JVM too,
+# and it takes runtime options through -J.
+
+case "${COB4J_REAL_JAR}" in
+"" | */jvm-wrapper/jar)
+  echo "$0: COB4J_REAL_JAR does not point at a real jar" >&2
+  exit 127
+  ;;
+esac
+
+exec "${COB4J_REAL_JAR}" -J-XX:-UsePerfData "$@"

--- a/tests/jvm-wrapper/java
+++ b/tests/jvm-wrapper/java
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# `java` wrapper used only while the autotest suites run.
+#
+# On start-up a JVM creates the file /tmp/hsperfdata_<user>/<pid>.  When
+# several JVMs start at nearly the same time one of them can find that file
+# still locked by another process, and it then writes
+#
+#   [warning][perf,memops] Cannot use file /tmp/hsperfdata_<user>/<pid>
+#                          because it is locked by another process (errno = 11)
+#
+# to its output.  Almost every autotest check requires the output to match
+# exactly, so the warning turns an unrelated test red.  -XX:-UsePerfData makes
+# the JVM skip the file entirely, so there is nothing left to contend for.
+# The only thing lost is that these JVMs no longer show up in jps/jstat, which
+# the tests never use.
+#
+# The wrappers cover the java, javac, javap and jar calls written in the test
+# sources as well as the javac and jar that cobj itself starts, because cobj
+# runs them through a shell and therefore resolves them from PATH.
+#
+# COB4J_REAL_JAVA is resolved in atlocal before this directory is put on PATH;
+# without it the wrapper would find itself again and loop forever.
+
+case "${COB4J_REAL_JAVA}" in
+"" | */jvm-wrapper/java)
+  echo "$0: COB4J_REAL_JAVA does not point at a real java" >&2
+  exit 127
+  ;;
+esac
+
+exec "${COB4J_REAL_JAVA}" -XX:-UsePerfData "$@"

--- a/tests/jvm-wrapper/javac
+++ b/tests/jvm-wrapper/javac
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# `javac` wrapper used only while the autotest suites run.
+# See tests/jvm-wrapper/java for why the flag is needed; javac is a JVM too,
+# and it takes runtime options through -J.
+
+case "${COB4J_REAL_JAVAC}" in
+"" | */jvm-wrapper/javac)
+  echo "$0: COB4J_REAL_JAVAC does not point at a real javac" >&2
+  exit 127
+  ;;
+esac
+
+exec "${COB4J_REAL_JAVAC}" -J-XX:-UsePerfData "$@"

--- a/tests/jvm-wrapper/javap
+++ b/tests/jvm-wrapper/javap
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# `javap` wrapper used only while the autotest suites run.
+# See tests/jvm-wrapper/java for why the flag is needed; javap is a JVM too,
+# and it takes runtime options through -J.
+
+case "${COB4J_REAL_JAVAP}" in
+"" | */jvm-wrapper/javap)
+  echo "$0: COB4J_REAL_JAVAP does not point at a real javap" >&2
+  exit 127
+  ;;
+esac
+
+exec "${COB4J_REAL_JAVAP}" -J-XX:-UsePerfData "$@"


### PR DESCRIPTION
## 概要

[#871](https://github.com/opensourcecobol/opensourcecobol4j/pull/871) の「既知の注意点」で挙げた、JVM の `hsperfdata` の競合による flaky な失敗への対処です。あちらは SQLite が主眼で、この問題は独立しているため別 PR にしています。#871 とは独立して適用でき、順序の依存もありません。

フォークのリポジトリに出した [yutaro-sakamoto/opensourcecobol4j#29](https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/29) と同じ内容です。

## 原因

JVM は起動時に `/tmp/hsperfdata_<user>/<pid>` を作ります。複数の JVM がほぼ同時に起動すると、そのファイルが他プロセスにロックされていることがあり、次の警告が **標準出力** に混ざります。

```
[warning][perf,memops] Cannot use file /tmp/hsperfdata_root/3002
                       because it is locked by another process (errno = 11)
```

autotest の検査はほとんどが出力の完全一致を要求するため、INDEXED ファイルとも SQLite とも無関係な `ref-mod.at` のようなテストが赤くなります。

並列実行は原因ではなく増幅要因です。file-lock 系のテストは 1 つのテストケース内で 2 つの JVM を起動するため、直列実行の時点ですでに同時起動は起きていました。`-Xlog:perf+memops=off` が file-lock 系にだけ付いているのはそのためです。したがって並列度を下げても解決しません。

## 対処

`tests/jvm-wrapper/` に `java` / `javac` / `javap` / `jar` のラッパーを置き、テスト環境 (`atlocal` / `atlocal-win.env`) の PATH 先頭に追加して `-XX:-UsePerfData` を付与します。

- `-Xlog:perf+memops=off` は警告を黙らせるだけで、JVM はファイルを作りに行き競合も起き続けます。`-XX:-UsePerfData` はファイル自体を作らないので、競合の原因が消えます。失うのは `jps` / `jstat` から見えなくなることだけで、テストでは不要です。不要になった記述は file-lock 系から削除しました。
- PATH 経由にすることで、テストソースに書かれた呼び出し (`java` 888 箇所、`javac` 34 箇所) だけでなく、**cobj 自身が起動する `javac` / `jar`** も覆えます。`cobj/cobj.c` の `process()` はコマンドをシェル経由で実行するため PATH から解決されます。この起動は `.at` ファイルには現れないので、テスト内の呼び出し箇所を書き換える方法では原理的に届きません。
- `JAVA_TOOL_OPTIONS` / `JDK_JAVA_OPTIONS` は「Picked up ...」を標準エラー出力に出すため使えません。autotest は多くの検査で標準エラー出力が空であることを要求します。

### 安全策

- ラッパーが自分自身を呼ばないよう、実体は PATH に追加する **前** に `atlocal` で解決します。同じシェルで `atlocal` を 2 回読んでも二重に追加しないようガードし、ラッパー側も自分自身を指していた場合は実行を拒否します。
- ラッパーは成功時に何も出力せず、`exec` するので終了コードもそのまま伝わります。

### 既知の非対応

- Windows では `cobj.exe` が cmd.exe 経由で `javac` を起動するためラッパーが効きません。ここは `COB_JAVA_FLAGS` で直接フラグを渡しています。ただし cobj は `COB_JAVA_FLAGS` を `javac` のコマンドラインにしか埋め込まないため、cobj が起動する `jar` は Windows では未対応のままです。
- Windows の NIST テストは `atlocal` を読まないため対象外です。

## 検証

- `command-line-options` を `-j4` で実行し 39/39 成功。`javap` を使う `-B` / `-g` と、cobj が `jar` を起動する `-jar` / `-single-jar` を含みます。
- `file-lock` を `-j4` で 4/4、`file-lock2` を直列で 10/10 成功。
- ラッパー経由で `java -XX:+PrintFlagsFinal -version` が `UsePerfData = false {command line}` を報告することを確認。
- `atlocal` を 3 回読み込んでも PATH のラッパーエントリは 1 つのままで、`java` / `javap` とも正常に動作。
- 同じ内容をフォーク側の CI (全 86 ジョブ、Linux・Windows 双方) で green を確認済みです。

なお `file-lock2` を `-j4` で実行すると #871 が対象としている sqlite-jdbc のメッセージで失敗します。これは develop に #871 がまだ入っていないためで、本 PR とは別の問題です。

---

## Summary

This addresses the JVM `hsperfdata` flakiness noted under "Known caveats" in [#871](https://github.com/opensourcecobol/opensourcecobol4j/pull/871). That PR is about SQLite and this is an independent problem, so it is filed separately. It applies independently of #871, in either order.

Same content as [yutaro-sakamoto/opensourcecobol4j#29](https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/29) on the fork.

## Cause

A JVM creates `/tmp/hsperfdata_<user>/<pid>` on start-up. When several JVMs start at nearly the same time one of them can find that file locked by another process and write this warning to **stdout**:

```
[warning][perf,memops] Cannot use file /tmp/hsperfdata_root/3002
                       because it is locked by another process (errno = 11)
```

Almost every autotest check requires the output to match exactly, so a test such as `ref-mod.at` — unrelated to INDEXED files or SQLite — turns red.

Parallel execution is an amplifier, not the cause. The file-lock tests start two JVMs inside a single test case, so concurrent start-ups already happened under serial execution — which is why `-Xlog:perf+memops=off` is present only in those tests. Lowering the level of parallelism therefore does not fix it.

## The fix

Wrappers for `java`, `javac`, `javap` and `jar` live in `tests/jvm-wrapper/` and are put early on `PATH` by the test environment (`atlocal` / `atlocal-win.env`), where they add `-XX:-UsePerfData`.

- `-Xlog:perf+memops=off` only mutes the warning while the JVM keeps creating the file and keeps contending for it. `-XX:-UsePerfData` never creates the file, so the contention cannot happen. The only cost is that those JVMs become invisible to `jps` / `jstat`, which the tests do not need. The now-redundant flag is removed from the file-lock tests.
- Going through `PATH` covers not only the calls written in the test sources (888 bare `java`, 34 `javac`) but also the **`javac` and `jar` that cobj itself starts**: `process()` in `cobj/cobj.c` runs the command through a shell, so they resolve from `PATH`. Those start-ups appear nowhere in the `.at` files, so editing the call sites in the tests could never reach them.
- `JAVA_TOOL_OPTIONS` and `JDK_JAVA_OPTIONS` are unusable: both print a "Picked up ..." notice to stderr, and autotest requires an empty stderr in most checks.

### Safeguards

- The real tools are resolved in `atlocal` **before** the wrapper directory goes on `PATH`, so a wrapper cannot call itself. Reading `atlocal` twice in one shell no longer adds the directory again, and each wrapper refuses to run if its variable points back at itself.
- The wrappers print nothing on success and `exec`, so exit codes pass through unchanged.

### Known gaps

- On Windows `cobj.exe` starts `javac` through the command interpreter, which cannot run a POSIX wrapper script, so that javac receives the flag through `COB_JAVA_FLAGS` instead. cobj puts `COB_JAVA_FLAGS` on the `javac` command line only, so the `jar` it starts remains uncovered on Windows.
- The Windows NIST tests do not read `atlocal` and are therefore out of scope.

## Verification

- `command-line-options` at `-j4`: 39/39, including `-B` / `-g` which run `javap`, and `-jar` / `-single-jar` where cobj starts `jar`.
- `file-lock` at `-j4`: 4/4. `file-lock2` serially: 10/10.
- Through the wrapper, `java -XX:+PrintFlagsFinal -version` reports `UsePerfData = false {command line}`.
- Sourcing `atlocal` three times leaves exactly one wrapper entry on `PATH`, with `java` and `javap` still working.
- The same content is green on the fork's CI across all 86 jobs, on both Linux and Windows.

Note that `file-lock2` at `-j4` fails with the sqlite-jdbc message that #871 addresses. That is because develop does not have #871 yet; it is a separate problem from this PR.
