### PR TITLE
Run the ESQL test suites in parallel with -j4

### DIFF
--- a/.github/workflows/test-esql-utf8.yml
+++ b/.github/workflows/test-esql-utf8.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run ESQL UTF-8 tests
         id: esql-utf8
         working-directory: tests/
-        run: ./esql-utf8
+        run: ./esql-utf8 -j4
 
       - name: Upload test logs if tests fail
         if: failure()

--- a/.github/workflows/test-esql.yml
+++ b/.github/workflows/test-esql.yml
@@ -100,11 +100,11 @@ jobs:
       - name: Run ESQL tests
         working-directory: tests/
         run: |
-          ./esql-basic
-          ./esql-sqlca
-          ./esql-cobol-data
-          ./esql-misc
-          ./esql-sql-data
+          ./esql-basic -j4
+          ./esql-sqlca -j4
+          ./esql-cobol-data -j4
+          ./esql-misc -j4
+          ./esql-sql-data -j4
 
       - name: Upload test logs if tests fail
         if: failure()

--- a/.github/workflows/windows-test-esql.yml
+++ b/.github/workflows/windows-test-esql.yml
@@ -91,12 +91,12 @@ jobs:
       run: |
         export PATH="/tmp/diff-wrapper:$PATH"
         cd tests
-        ./esql-basic
-        ./esql-sqlca
-        ./esql-cobol-data
-        ./esql-misc
-        ./esql-sql-data
-        ./esql-utf8
+        ./esql-basic -j4
+        ./esql-sqlca -j4
+        ./esql-cobol-data -j4
+        ./esql-misc -j4
+        ./esql-sql-data -j4
+        ./esql-utf8 -j4
 
     - name: Upload log files if tests fail
       if: failure()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -251,7 +251,8 @@ esql_sqlca_DEPENDENCIES = \
 	esql-sqlca.src/open-fetch-close.at \
 	esql-sqlca.src/prepare-execute.at \
 	esql-sqlca.src/fetch-loop.at \
-	esql-sqlca.src/errml-errmc.at
+	esql-sqlca.src/errml-errmc.at \
+	esql-sqlca.src/bulk-fetch.at
 
 esql_cobol_data_DEPENDENCIES = \
 	esql-cobol-data.at \
@@ -261,18 +262,24 @@ esql_cobol_data_DEPENDENCIES = \
 	esql-cobol-data.src/comp3_signed.at \
 	esql-cobol-data.src/alphanumeric.at \
 	esql-cobol-data.src/japanese.at \
-	esql-cobol-data.src/varying.at
+	esql-cobol-data.src/varying.at \
+	esql-cobol-data.src/subscript.at
 
 esql_misc_DEPENDENCIES = \
 	esql-misc.at \
+	esql-misc.src/logging.at \
 	esql-misc.src/long-sql.at \
 	esql-misc.src/include.at \
 	esql-misc.src/fetch-sqlca.at \
 	esql-misc.src/compile.at \
 	esql-misc.src/sql-convert.at \
 	esql-misc.src/implicit-declare.at \
+	esql-misc.src/declare-section.at \
 	esql-misc.src/sql-format.at \
-	esql-misc.src/null-without-indicator.at
+	esql-misc.src/host-var-wrap.at \
+	esql-misc.src/null-without-indicator.at \
+	esql-misc.src/sqlca-warning.at \
+	esql-misc.src/group-sub.at
 
 esql_sql_data_DEPENDENCIES = \
 	esql-sql-data.at \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -801,7 +801,8 @@ esql_sqlca_DEPENDENCIES = \
 	esql-sqlca.src/open-fetch-close.at \
 	esql-sqlca.src/prepare-execute.at \
 	esql-sqlca.src/fetch-loop.at \
-	esql-sqlca.src/errml-errmc.at
+	esql-sqlca.src/errml-errmc.at \
+	esql-sqlca.src/bulk-fetch.at
 
 esql_cobol_data_DEPENDENCIES = \
 	esql-cobol-data.at \
@@ -811,18 +812,24 @@ esql_cobol_data_DEPENDENCIES = \
 	esql-cobol-data.src/comp3_signed.at \
 	esql-cobol-data.src/alphanumeric.at \
 	esql-cobol-data.src/japanese.at \
-	esql-cobol-data.src/varying.at
+	esql-cobol-data.src/varying.at \
+	esql-cobol-data.src/subscript.at
 
 esql_misc_DEPENDENCIES = \
 	esql-misc.at \
+	esql-misc.src/logging.at \
 	esql-misc.src/long-sql.at \
 	esql-misc.src/include.at \
 	esql-misc.src/fetch-sqlca.at \
 	esql-misc.src/compile.at \
 	esql-misc.src/sql-convert.at \
 	esql-misc.src/implicit-declare.at \
+	esql-misc.src/declare-section.at \
 	esql-misc.src/sql-format.at \
-	esql-misc.src/null-without-indicator.at
+	esql-misc.src/host-var-wrap.at \
+	esql-misc.src/null-without-indicator.at \
+	esql-misc.src/sqlca-warning.at \
+	esql-misc.src/group-sub.at
 
 esql_sql_data_DEPENDENCIES = \
 	esql-sql-data.at \

--- a/tests/esql-basic.src/commit-rollback.at
+++ b/tests/esql-basic.src/commit-rollback.at
@@ -51,7 +51,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_COMMITROLL VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -65,7 +65,8 @@ AT_DATA([prog.cbl], [
       *    DELETE
            MOVE 5 TO EMP-NO.
            EXEC SQL
-              UPDATE EMP SET EMP_NAME = 'NO_NAME' WHERE EMP_NO > :EMP-NO
+              UPDATE EMP_COMMITROLL SET EMP_NAME = 'NO_NAME'
+                WHERE EMP_NO > :EMP-NO
            END-EXEC.
 
       *    ROLLBACK
@@ -78,7 +79,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_COMMITROLL
                       ORDER BY EMP_NO
            END-EXEC.
 
@@ -121,16 +122,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_COMMITROLL
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_COMMITROLL
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_COMMITROLL PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -142,7 +143,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_COMMITROLL
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/declare-bind-var.at
+++ b/tests/esql-basic.src/declare-bind-var.at
@@ -67,18 +67,18 @@ AT_DATA([prog.cbl], [
            
       *    DROP TABLE
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_DECLBINDVAR
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
            
       *    CREATE TABLE 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_DECLBINDVAR
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                    EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_DECLBINDVAR PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN STOP RUN.
@@ -89,7 +89,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_DECLBINDVAR VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
               IF  SQLCODE NOT = ZERO 
@@ -106,7 +106,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       WHERE EMP_NO >= :EMP-NO-MIN
                         AND EMP_NO <= :EMP-NO-MAX
                       ORDER BY EMP_NO
@@ -139,7 +139,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C2 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       WHERE EMP_NO >= :EMP-NO-MIN-U
                         AND EMP_NO <= :EMP-NO-MAX-U
                       ORDER BY EMP_NO
@@ -171,7 +171,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C3 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       WHERE EMP_NAME = :EMP-NAME-X
                       ORDER BY EMP_NO
            END-EXEC.
@@ -204,7 +204,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C4 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       WHERE EMP_NAME != :EMP-NAME-X
                         AND EMP_NO >= :EMP-NO-MIN-U
                         AND EMP_NO <= :EMP-NO-MAX-U
@@ -237,7 +237,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C5 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       GROUP BY EMP_NO
                       HAVING EMP_NO = :EMP-NO
                       ORDER BY EMP_NO
@@ -270,7 +270,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C6 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DECLBINDVAR
                       WHERE EMP_NO >= :EMP-NO-MIN-U
                       GROUP BY EMP_NO
                       HAVING EMP_NO <= :EMP-NO-MAX-U

--- a/tests/esql-basic.src/declare.at
+++ b/tests/esql-basic.src/declare.at
@@ -29,21 +29,22 @@ AT_DATA([prog.cbl], [
 
       * Test case 0001 *************************************************
        EXEC SQL
-           DECLARE CURSOR1 CURSOR FOR SELECT * FROM EMP
+           DECLARE CURSOR1 CURSOR FOR SELECT * FROM EMP_DECLARE
        END-EXEC.
        PERFORM DISPLAY-TEST-RESULT.
       ******************************************************************
 
       * Test case 0002 *************************************************
        EXEC SQL
-           DECLARE CURSOR2 CURSOR FOR SELECT EMP-NO FROM EMP
+           DECLARE CURSOR2 CURSOR FOR SELECT EMP-NO FROM EMP_DECLARE
        END-EXEC.
        PERFORM DISPLAY-TEST-RESULT.
       ******************************************************************
 
       * Test case 0003 *************************************************
        EXEC SQL
-           DECLARE CURSOR3 CURSOR FOR SELECT EMP-NO, EMP-SALARY FROM EMP
+           DECLARE CURSOR3 CURSOR FOR
+               SELECT EMP-NO, EMP-SALARY FROM EMP_DECLARE
        END-EXEC.
        PERFORM DISPLAY-TEST-RESULT.
       ******************************************************************
@@ -70,16 +71,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_DECLARE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_DECLARE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_DECLARE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -87,7 +88,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_DECLARE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/delete.at
+++ b/tests/esql-basic.src/delete.at
@@ -51,7 +51,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_DELETE VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -59,7 +59,7 @@ AT_DATA([prog.cbl], [
       *    DELETE
            MOVE 5 TO EMP-NO.
            EXEC SQL
-              DELETE FROM EMP WHERE EMP_NO > :EMP-NO
+              DELETE FROM EMP_DELETE WHERE EMP_NO > :EMP-NO
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
@@ -67,7 +67,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_DELETE
                       ORDER BY EMP_NO
            END-EXEC.
 
@@ -111,16 +111,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_DELETE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_DELETE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_DELETE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
@@ -133,7 +133,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_DELETE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/fetch.at
+++ b/tests/esql-basic.src/fetch.at
@@ -77,16 +77,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_FETCH
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_FETCH
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_FETCH PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -96,7 +96,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_FETCH VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -104,7 +104,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_FETCH
                       ORDER BY EMP_NO
            END-EXEC.
       *    OPEN CURSOR
@@ -120,7 +120,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_FETCH
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/insert.at
+++ b/tests/esql-basic.src/insert.at
@@ -51,7 +51,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_INSERT VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
               PERFORM DISPLAY-TEST-RESULT
@@ -79,16 +79,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_INSERT
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_INSERT
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_INSERT PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -96,7 +96,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_INSERT
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/open-close.at
+++ b/tests/esql-basic.src/open-close.at
@@ -28,7 +28,7 @@ AT_DATA([prog.cbl], [
        PERFORM SETUP-DB.
 
        EXEC SQL
-           DECLARE CURSOR1 CURSOR FOR SELECT * FROM EMP
+           DECLARE CURSOR1 CURSOR FOR SELECT * FROM EMP_OPENCLOSE
        END-EXEC.
 
       * Test case 0001 *************************************************
@@ -67,16 +67,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_OPENCLOSE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_OPENCLOSE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_OPENCLOSE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -84,7 +84,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_OPENCLOSE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/other-sql.at
+++ b/tests/esql-basic.src/other-sql.at
@@ -30,23 +30,23 @@ AT_DATA([prog.cbl], [
        PERFORM CONNECT-DB.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_OTHERSQL
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_OTHERSQL
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_OTHERSQL PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_OTHERSQL
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 

--- a/tests/esql-basic.src/prepare-execute.at
+++ b/tests/esql-basic.src/prepare-execute.at
@@ -49,8 +49,9 @@ AT_DATA([prog.cbl], [
        PERFORM SETUP-DB.
 
       *    Set the VARYING host variable (SQL text + length)
-           MOVE "DELETE FROM EMP WHERE EMP_NO > ?" TO SQL-COMMAND-ARR.
-           MOVE 32 TO SQL-COMMAND-LEN.
+           MOVE "DELETE FROM EMP_PREPEXEC1 WHERE EMP_NO > ?"
+             TO SQL-COMMAND-ARR.
+           MOVE 42 TO SQL-COMMAND-LEN.
 
       *    PREPARE
            EXEC SQL
@@ -68,7 +69,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_PREPEXEC1
                       ORDER BY EMP_NO
            END-EXEC.
 
@@ -112,16 +113,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_PREPEXEC1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_PREPEXEC1
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_PREPEXEC1 PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -131,7 +132,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_PREPEXEC1 VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -144,7 +145,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_PREPEXEC1
            END-EXEC.
 
            EXEC SQL
@@ -212,7 +213,7 @@ AT_DATA([prog.cbl], [
       *    A plain PIC X(n) must work: prepare reads the whole field
       *    and trims trailing spaces.
        01  SQL-COMMAND   PIC X(50)
-            VALUE "DELETE FROM EMP WHERE EMP_NO > ?".
+            VALUE "DELETE FROM EMP_PREPEXEC2 WHERE EMP_NO > ?".
        01  SQL-COMMAND-ARG         PIC  99 VALUE 5.
        01  DBNAME                  PIC  X(30) VALUE SPACE.
        01  USERNAME                PIC  X(30) VALUE SPACE.
@@ -229,9 +230,9 @@ AT_DATA([prog.cbl], [
            EXEC SQL
                CONNECT :USERNAME IDENTIFIED BY :PASSWD USING :DBNAME
            END-EXEC.
-           EXEC SQL DROP TABLE IF EXISTS EMP END-EXEC.
+           EXEC SQL DROP TABLE IF EXISTS EMP_PREPEXEC2 END-EXEC.
            EXEC SQL
-               CREATE TABLE EMP (EMP_NO NUMERIC(4,0) NOT NULL,
+               CREATE TABLE EMP_PREPEXEC2 (EMP_NO NUMERIC(4,0) NOT NULL,
                EMP_NAME CHAR(20), EMP_SALARY NUMERIC(4,0))
            END-EXEC.
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -239,7 +240,8 @@ AT_DATA([prog.cbl], [
               MOVE "NAME" TO EMP-NAME
               COMPUTE EMP-SALARY = IDX * 100
               EXEC SQL
-                 INSERT INTO EMP VALUES (:EMP-NO,:EMP-NAME,:EMP-SALARY)
+                 INSERT INTO EMP_PREPEXEC2 VALUES
+                        (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
            EXEC SQL COMMIT WORK END-EXEC.
@@ -248,7 +250,7 @@ AT_DATA([prog.cbl], [
            DISPLAY "PREPARE SQLCODE=" SQLCODE.
            EXEC SQL EXECUTE st USING :SQL-COMMAND-ARG END-EXEC.
            DISPLAY "EXECUTE SQLCODE=" SQLCODE.
-           EXEC SQL DROP TABLE IF EXISTS EMP END-EXEC.
+           EXEC SQL DROP TABLE IF EXISTS EMP_PREPEXEC2 END-EXEC.
            EXEC SQL DISCONNECT ALL END-EXEC.
            STOP RUN.
 ])

--- a/tests/esql-basic.src/sample.at
+++ b/tests/esql-basic.src/sample.at
@@ -56,32 +56,32 @@ AT_DATA([prog.cbl], [
            
       *    DROP TABLE
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_SAMPLE
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
            
       *    CREATE TABLE 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_SAMPLE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_SAMPLE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN STOP RUN.
            
       *    INSERT ROWS USING LITERAL
            EXEC SQL
-      *         INSERT INTO EMP VALUES (46, 'KAGOSHIMA ROKURO', -320)
-               INSERT INTO EMP VALUES (46, '鹿児島　六郎', -320)
+      *    INSERT INTO EMP_SAMPLE VALUES (46, 'KAGOSHIMA ROKURO', -320)
+               INSERT INTO EMP_SAMPLE VALUES (46, '鹿児島　六郎', -320)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
            EXEC SQL
-      *         INSERT INTO EMP VALUES (47, 'OKINAWA SHICHIRO', 480)
-               INSERT INTO EMP VALUES (47, '沖縄　七郎', 480)
+      *    INSERT INTO EMP_SAMPLE VALUES (47, 'OKINAWA SHICHIRO', 480)
+               INSERT INTO EMP_SAMPLE VALUES (47, '沖縄　七郎', 480)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
@@ -91,7 +91,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_SAMPLE VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
               IF  SQLCODE NOT = ZERO 

--- a/tests/esql-basic.src/select.at
+++ b/tests/esql-basic.src/select.at
@@ -53,7 +53,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT * INTO :READ-TBL FROM EMP WHERE EMP_NO > 4
+               SELECT * INTO :READ-TBL FROM EMP_SELECT WHERE EMP_NO > 4
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
@@ -87,16 +87,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_SELECT
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_SELECT
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_SELECT PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -106,7 +106,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_SELECT VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -124,7 +124,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_SELECT
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-basic.src/update.at
+++ b/tests/esql-basic.src/update.at
@@ -51,7 +51,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UPDATE VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -59,7 +59,8 @@ AT_DATA([prog.cbl], [
       *    UPDATE
            MOVE 5 TO EMP-NO.
            EXEC SQL
-              UPDATE EMP SET EMP_NAME = 'NO_NAME' WHERE EMP_NO > :EMP-NO
+              UPDATE EMP_UPDATE SET EMP_NAME = 'NO_NAME'
+                WHERE EMP_NO > :EMP-NO
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
@@ -67,7 +68,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_UPDATE
                       ORDER BY EMP_NO
            END-EXEC.
 
@@ -111,16 +112,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UPDATE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UPDATE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_UPDATE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -132,7 +133,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UPDATE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/alphanumeric.at
+++ b/tests/esql-cobol-data.src/alphanumeric.at
@@ -47,7 +47,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL FROM TESTTABLE ORDER BY N
+               SELECT FIELD INTO :READ-TBL FROM TT_ALPHANUM ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -76,11 +76,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_ALPHANUM
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_ALPHANUM
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     CHAR(10)
@@ -91,7 +91,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D(IDX)     TO  V
               EXEC SQL
-                 INSERT INTO TESTTABLE VALUES (:IDX, :V)
+                 INSERT INTO TT_ALPHANUM VALUES (:IDX, :V)
               END-EXEC
            END-PERFORM.
 
@@ -104,7 +104,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_ALPHANUM
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/comp3.at
+++ b/tests/esql-cobol-data.src/comp3.at
@@ -152,7 +152,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-V-1
-               FROM TESTTABLEV1 ORDER BY N
+               FROM TTV1_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -163,7 +163,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-V-2
-               FROM TESTTABLEV2 ORDER BY N
+               FROM TTV2_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -174,7 +174,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-P-1
-               FROM TESTTABLEP1 ORDER BY N
+               FROM TTP1_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -185,7 +185,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-P-2
-               FROM TESTTABLEP2 ORDER BY N
+               FROM TTP2_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -195,7 +195,7 @@ AT_DATA([prog.cbl], [
            DISPLAY "================".
 
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-1 FROM TESTTABLE1 ORDER BY N
+               SELECT FIELD INTO :READ-TBL-1 FROM TT1_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -205,7 +205,7 @@ AT_DATA([prog.cbl], [
            DISPLAY "================".
 
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-2 FROM TESTTABLE2 ORDER BY N
+               SELECT FIELD INTO :READ-TBL-2 FROM TT2_COMP3 ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -234,38 +234,38 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV1
+               DROP TABLE IF EXISTS TTV1_COMP3
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV2
+               DROP TABLE IF EXISTS TTV2_COMP3
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP1
+               DROP TABLE IF EXISTS TTP1_COMP3
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP2
+               DROP TABLE IF EXISTS TTP2_COMP3
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE1
+               DROP TABLE IF EXISTS TT1_COMP3
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE2
+               DROP TABLE IF EXISTS TT2_COMP3
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEV1
+                CREATE TABLE TTV1_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(6,2) NOT NULL
                 )
            END-EXEC.
            EXEC SQL
-                CREATE TABLE TESTTABLEV2
+                CREATE TABLE TTV2_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(7,2) NOT NULL
@@ -273,7 +273,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP1
+                CREATE TABLE TTP1_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(6,0) NOT NULL
@@ -281,7 +281,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP2
+                CREATE TABLE TTP2_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(7,0) NOT NULL
@@ -289,7 +289,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE1
+                CREATE TABLE TT1_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(4,0) NOT NULL
@@ -297,7 +297,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE2
+                CREATE TABLE TT2_COMP3
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(5,0) NOT NULL
@@ -307,42 +307,42 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V-1(IDX)     TO  VV-1
               EXEC SQL
-                 INSERT INTO TESTTABLEV1 VALUES (:IDX, :VV-1)
+                 INSERT INTO TTV1_COMP3 VALUES (:IDX, :VV-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V-2(IDX)     TO  VV-2
               EXEC SQL
-                 INSERT INTO TESTTABLEV2 VALUES (:IDX, :VV-2)
+                 INSERT INTO TTV2_COMP3 VALUES (:IDX, :VV-2)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P-1(IDX)     TO  VP-1
               EXEC SQL
-                 INSERT INTO TESTTABLEP1 VALUES (:IDX, :VP-1)
+                 INSERT INTO TTP1_COMP3 VALUES (:IDX, :VP-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P-2(IDX)     TO  VP-2
               EXEC SQL
-                 INSERT INTO TESTTABLEP2 VALUES (:IDX, :VP-2)
+                 INSERT INTO TTP2_COMP3 VALUES (:IDX, :VP-2)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-1(IDX)     TO  V-1
               EXEC SQL
-                 INSERT INTO TESTTABLE1 VALUES (:IDX, :V-1)
+                 INSERT INTO TT1_COMP3 VALUES (:IDX, :V-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-2(IDX)     TO  V-2
               EXEC SQL
-                 INSERT INTO TESTTABLE2 VALUES (:IDX, :V-2)
+                 INSERT INTO TT2_COMP3 VALUES (:IDX, :V-2)
               END-EXEC
            END-PERFORM.
 

--- a/tests/esql-cobol-data.src/comp3_signed.at
+++ b/tests/esql-cobol-data.src/comp3_signed.at
@@ -152,7 +152,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-V-1
-               FROM TESTTABLEV1 ORDER BY N
+               FROM TTV1_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -163,7 +163,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-V-2
-               FROM TESTTABLEV2 ORDER BY N
+               FROM TTV2_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -174,7 +174,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-P-1
-               FROM TESTTABLEP1 ORDER BY N
+               FROM TTP1_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -185,7 +185,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT FIELD INTO :READ-TBL-P-2
-               FROM TESTTABLEP2 ORDER BY N
+               FROM TTP2_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -195,7 +195,7 @@ AT_DATA([prog.cbl], [
            DISPLAY "================".
 
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-1 FROM TESTTABLE1 ORDER BY N
+               SELECT FIELD INTO :READ-TBL-1 FROM TT1_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -205,7 +205,7 @@ AT_DATA([prog.cbl], [
            DISPLAY "================".
 
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-2 FROM TESTTABLE2 ORDER BY N
+               SELECT FIELD INTO :READ-TBL-2 FROM TT2_COMP3S ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -234,38 +234,38 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV1
+               DROP TABLE IF EXISTS TTV1_COMP3S
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV2
+               DROP TABLE IF EXISTS TTV2_COMP3S
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP1
+               DROP TABLE IF EXISTS TTP1_COMP3S
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP2
+               DROP TABLE IF EXISTS TTP2_COMP3S
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE1
+               DROP TABLE IF EXISTS TT1_COMP3S
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE2
+               DROP TABLE IF EXISTS TT2_COMP3S
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEV1
+                CREATE TABLE TTV1_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(6,2) NOT NULL
                 )
            END-EXEC.
            EXEC SQL
-                CREATE TABLE TESTTABLEV2
+                CREATE TABLE TTV2_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(7,2) NOT NULL
@@ -273,7 +273,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP1
+                CREATE TABLE TTP1_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(6,0) NOT NULL
@@ -281,7 +281,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP2
+                CREATE TABLE TTP2_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(7,0) NOT NULL
@@ -289,7 +289,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE1
+                CREATE TABLE TT1_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(4,0) NOT NULL
@@ -297,7 +297,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE2
+                CREATE TABLE TT2_COMP3S
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(5,0) NOT NULL
@@ -307,42 +307,42 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V-1(IDX)     TO  VV-1
               EXEC SQL
-                 INSERT INTO TESTTABLEV1 VALUES (:IDX, :VV-1)
+                 INSERT INTO TTV1_COMP3S VALUES (:IDX, :VV-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V-2(IDX)     TO  VV-2
               EXEC SQL
-                 INSERT INTO TESTTABLEV2 VALUES (:IDX, :VV-2)
+                 INSERT INTO TTV2_COMP3S VALUES (:IDX, :VV-2)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P-1(IDX)     TO  VP-1
               EXEC SQL
-                 INSERT INTO TESTTABLEP1 VALUES (:IDX, :VP-1)
+                 INSERT INTO TTP1_COMP3S VALUES (:IDX, :VP-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P-2(IDX)     TO  VP-2
               EXEC SQL
-                 INSERT INTO TESTTABLEP2 VALUES (:IDX, :VP-2)
+                 INSERT INTO TTP2_COMP3S VALUES (:IDX, :VP-2)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-1(IDX)     TO  V-1
               EXEC SQL
-                 INSERT INTO TESTTABLE1 VALUES (:IDX, :V-1)
+                 INSERT INTO TT1_COMP3S VALUES (:IDX, :V-1)
               END-EXEC
            END-PERFORM.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-2(IDX)     TO  V-2
               EXEC SQL
-                 INSERT INTO TESTTABLE2 VALUES (:IDX, :V-2)
+                 INSERT INTO TT2_COMP3S VALUES (:IDX, :V-2)
               END-EXEC
            END-PERFORM.
 

--- a/tests/esql-cobol-data.src/japanese.at
+++ b/tests/esql-cobol-data.src/japanese.at
@@ -47,7 +47,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL FROM TESTTABLE ORDER BY N
+               SELECT FIELD INTO :READ-TBL FROM TT_CDJAPANESE ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -76,11 +76,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_CDJAPANESE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_CDJAPANESE
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     CHAR(10)
@@ -91,7 +91,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D(IDX)     TO  V
               EXEC SQL
-                 INSERT INTO TESTTABLE VALUES (:IDX, :V)
+                 INSERT INTO TT_CDJAPANESE VALUES (:IDX, :V)
               END-EXEC
            END-PERFORM.
 
@@ -104,7 +104,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
       *    EXEC SQL
-      *        DROP TABLE IF EXISTS TESTTABLE
+      *        DROP TABLE IF EXISTS TT_CDJAPANESE
       *    END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/numeric_signed_v.at
+++ b/tests/esql-cobol-data.src/numeric_signed_v.at
@@ -89,7 +89,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-V FROM TESTTABLEV ORDER BY N
+               SELECT FIELD INTO :READ-TBL-V FROM TTV_NUMSV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -98,7 +98,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-P FROM TESTTABLEP ORDER BY N
+               SELECT FIELD INTO :READ-TBL-P FROM TTP_NUMSV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -107,7 +107,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL FROM TESTTABLE ORDER BY N
+               SELECT FIELD INTO :READ-TBL FROM TT_NUMSV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -136,19 +136,19 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV
+               DROP TABLE IF EXISTS TTV_NUMSV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP
+               DROP TABLE IF EXISTS TTP_NUMSV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_NUMSV
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEV
+                CREATE TABLE TTV_NUMSV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(6,2) NOT NULL
@@ -156,7 +156,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP
+                CREATE TABLE TTP_NUMSV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(6,0) NOT NULL
@@ -164,7 +164,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_NUMSV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(4,0) NOT NULL
@@ -175,7 +175,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V(IDX)     TO  VV
               EXEC SQL
-                 INSERT INTO TESTTABLEV VALUES (:IDX, :VV)
+                 INSERT INTO TTV_NUMSV VALUES (:IDX, :VV)
               END-EXEC
            END-PERFORM.
 
@@ -183,7 +183,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P(IDX)     TO  VP
               EXEC SQL
-                 INSERT INTO TESTTABLEP VALUES (:IDX, :VP)
+                 INSERT INTO TTP_NUMSV VALUES (:IDX, :VP)
               END-EXEC
            END-PERFORM.
 
@@ -191,7 +191,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D(IDX)     TO  V
               EXEC SQL
-                 INSERT INTO TESTTABLE VALUES (:IDX, :V)
+                 INSERT INTO TT_NUMSV VALUES (:IDX, :V)
               END-EXEC
            END-PERFORM.
 
@@ -204,15 +204,15 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV
+               DROP TABLE IF EXISTS TTV_NUMSV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP
+               DROP TABLE IF EXISTS TTP_NUMSV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_NUMSV
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/numeric_v.at
+++ b/tests/esql-cobol-data.src/numeric_v.at
@@ -89,7 +89,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-V FROM TESTTABLEV ORDER BY N
+               SELECT FIELD INTO :READ-TBL-V FROM TTV_NUMV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -98,7 +98,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL-P FROM TESTTABLEP ORDER BY N
+               SELECT FIELD INTO :READ-TBL-P FROM TTP_NUMV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -107,7 +107,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL FROM TESTTABLE ORDER BY N
+               SELECT FIELD INTO :READ-TBL FROM TT_NUMV ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -136,19 +136,19 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV
+               DROP TABLE IF EXISTS TTV_NUMV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP
+               DROP TABLE IF EXISTS TTP_NUMV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_NUMV
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEV
+                CREATE TABLE TTV_NUMV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     DECIMAL(6,2) NOT NULL
@@ -156,7 +156,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLEP
+                CREATE TABLE TTP_NUMV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(6,0) NOT NULL
@@ -164,7 +164,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_NUMV
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(4,0) NOT NULL
@@ -175,7 +175,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-V(IDX)     TO  VV
               EXEC SQL
-                 INSERT INTO TESTTABLEV VALUES (:IDX, :VV)
+                 INSERT INTO TTV_NUMV VALUES (:IDX, :VV)
               END-EXEC
            END-PERFORM.
 
@@ -183,7 +183,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D-P(IDX)     TO  VP
               EXEC SQL
-                 INSERT INTO TESTTABLEP VALUES (:IDX, :VP)
+                 INSERT INTO TTP_NUMV VALUES (:IDX, :VP)
               END-EXEC
            END-PERFORM.
 
@@ -191,7 +191,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D(IDX)     TO  V
               EXEC SQL
-                 INSERT INTO TESTTABLE VALUES (:IDX, :V)
+                 INSERT INTO TT_NUMV VALUES (:IDX, :V)
               END-EXEC
            END-PERFORM.
 
@@ -204,15 +204,15 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEV
+               DROP TABLE IF EXISTS TTV_NUMV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLEP
+               DROP TABLE IF EXISTS TTP_NUMV
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_NUMV
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/subscript.at
+++ b/tests/esql-cobol-data.src/subscript.at
@@ -45,7 +45,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 5
                EXEC SQL
                    SELECT FIELD INTO :GRPA.VAL(IDX)
-                     FROM TESTTABLE WHERE N = :IDX
+                     FROM TT_SUBSCRIPT WHERE N = :IDX
                END-EXEC
            END-PERFORM.
 
@@ -57,7 +57,7 @@ AT_DATA([prog.cbl], [
                MOVE IDX TO TMP-IDX OF GRP2
                EXEC SQL
                    SELECT FIELD INTO :GRPB.VAL(GRP2.TMP-IDX)
-                     FROM TESTTABLE WHERE N = :IDX
+                     FROM TT_SUBSCRIPT WHERE N = :IDX
                END-EXEC
            END-PERFORM.
 
@@ -97,11 +97,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_SUBSCRIPT
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_SUBSCRIPT
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     NUMERIC(4,0) NOT NULL
@@ -121,7 +121,7 @@ AT_DATA([prog.cbl], [
               MOVE IDX TO TMP-IDX OF GRP2
               MOVE VAL OF ROW(IDX) TO VAL OF ROW2(IDX)
               EXEC SQL
-                 INSERT INTO TESTTABLE
+                 INSERT INTO TT_SUBSCRIPT
                    VALUES (:IDX, :GRPB.VAL(GRP2.TMP-IDX))
               END-EXEC
            END-PERFORM.
@@ -142,7 +142,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_SUBSCRIPT
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-cobol-data.src/varying.at
+++ b/tests/esql-cobol-data.src/varying.at
@@ -81,11 +81,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_CDVARYING1
                 (
                     EMP_NUM1   NUMERIC(4, 0),
                     EMP_NAME   VARCHAR(10),
@@ -100,7 +100,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NUM2(IDX)   TO  EMP-NUM2
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_CDVARYING1 VALUES
                         (:EMP-NUM1, :EMP-NAME, :EMP-NUM2)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -109,7 +109,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NUM1, EMP_NAME, EMP_NUM2
-                      FROM EMP
+                      FROM EMP_CDVARYING1
                       ORDER BY EMP_NUM1
            END-EXEC.
 
@@ -126,7 +126,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING1
            END-EXEC.
 
            EXEC SQL
@@ -271,11 +271,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_CDVARYING1
                 (
                     EMP_NAME   VARCHAR(10)
                 )
@@ -286,7 +286,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_CDVARYING1 VALUES
                         (:EMP-NAME)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -295,7 +295,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NAME
-                      FROM EMP
+                      FROM EMP_CDVARYING1
                       ORDER BY EMP_NAME
            END-EXEC.
 
@@ -312,7 +312,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING1
            END-EXEC.
 
            EXEC SQL
@@ -467,11 +467,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_CDVARYING2
                 (
                     EMP_NUM1   NUMERIC(4, 0),
                     EMP_NAME   VARCHAR(10),
@@ -486,7 +486,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NUM2(IDX)   TO  EMP-NUM2
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_CDVARYING2 VALUES
                         (:EMP-NUM1, :EMP-NAME, :EMP-NUM2)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -495,7 +495,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NUM1, EMP_NAME, EMP_NUM2
-                      FROM EMP
+                      FROM EMP_CDVARYING2
                       ORDER BY EMP_NUM1
            END-EXEC.
 
@@ -512,7 +512,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING2
            END-EXEC.
 
            EXEC SQL
@@ -657,11 +657,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_CDVARYING2
                 (
                     EMP_NAME   VARCHAR(10)
                 )
@@ -672,7 +672,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_CDVARYING2 VALUES
                         (:EMP-NAME)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -681,7 +681,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NAME
-                      FROM EMP
+                      FROM EMP_CDVARYING2
                       ORDER BY EMP_NAME
            END-EXEC.
 
@@ -698,7 +698,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CDVARYING2
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/compile.at
+++ b/tests/esql-misc.src/compile.at
@@ -34,11 +34,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_COMPILE
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_COMPILE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/group-sub.at
+++ b/tests/esql-misc.src/group-sub.at
@@ -65,7 +65,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT * INTO :READ-TBL FROM EMP WHERE EMP_NO > 4
+               SELECT * INTO :READ-TBL FROM EMP_GRPSUB WHERE EMP_NO > 4
            END-EXEC.
            PERFORM OUTPUT-RETURN-CODE-TEST.
 
@@ -99,16 +99,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_GRPSUB
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_GRPSUB
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_GRPSUB PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -118,7 +118,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME OF EMP-REC-VARS
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY OF EMP-REC-VARS
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_GRPSUB VALUES
                         (:EMP-REC-VARS.EMP-NO,
                          :EMP-REC-VARS.EMP-NAME,
                          :EMP-REC-VARS.EMP-SALARY)
@@ -138,7 +138,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_GRPSUB
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/implicit-declare.at
+++ b/tests/esql-misc.src/implicit-declare.at
@@ -23,7 +23,7 @@ AT_DATA([prog.cbl], [
        PERFORM SETUP-DB.
 
            EXEC SQL
-              INSERT INTO EMP VALUES
+              INSERT INTO EMP_IMPLDECL VALUES
                      (:EMP-NO,:EMP-NAME,:EMP-SALARY)
            END-EXEC.
 
@@ -37,7 +37,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                SELECT * INTO :EMP-NO, :EMP-NAME, :EMP-SALARY
-               FROM EMP WHERE EMP_NO = 1
+               FROM EMP_IMPLDECL WHERE EMP_NO = 1
            END-EXEC.
 
            IF SQLCODE = ZERO
@@ -66,11 +66,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_IMPLDECL
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_IMPLDECL
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
@@ -86,7 +86,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_IMPLDECL
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/include.at
+++ b/tests/esql-misc.src/include.at
@@ -34,18 +34,18 @@ AT_DATA([DECLARE-SECTION], [
 
 AT_DATA([EXEC-SELECT], [
            EXEC SQL
-               SELECT * INTO :READ-TBL FROM EMP WHERE EMP_NO > 4
+               SELECT * INTO :READ-TBL FROM EMP_MINCL WHERE EMP_NO > 4
            END-EXEC.
 ])
 
 AT_DATA([exec-create-table], [
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_MINCL
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_MINCL PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 ])
@@ -122,7 +122,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL INCLUDE exec-connect END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MINCL
            END-EXEC.
 
            EXEC SQL INCLUDE
@@ -135,7 +135,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_MINCL VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -153,7 +153,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MINCL
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/long-sql.at
+++ b/tests/esql-misc.src/long-sql.at
@@ -108,7 +108,7 @@ AT_DATA([prog.cbl], [
                 EMP_NAME039,
                 EMP_NAME040
             INTO :READ-DATA
-            FROM EMP
+            FROM EMP_MLONGSQL
            END-EXEC.
 
             DISPLAY EMP_NAME001.
@@ -174,11 +174,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MLONGSQL
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_MLONGSQL
                 (
                     EMP_NAME001 CHAR(50),
                     EMP_NAME002 CHAR(50),
@@ -225,7 +225,7 @@ AT_DATA([prog.cbl], [
 
       *    INSERT ROWS USING HOST VARIABLE
            EXEC SQL
-              INSERT INTO EMP VALUES
+              INSERT INTO EMP_MLONGSQL VALUES
              (
              '‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ',
              'a‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ',
@@ -280,7 +280,7 @@ AT_DATA([prog.cbl], [
       ******************************************************************
 
       *    EXEC SQL
-      *        DROP TABLE IF EXISTS EMP
+      *        DROP TABLE IF EXISTS EMP_MLONGSQL
       *    END-EXEC.
 
            EXEC SQL

--- a/tests/esql-misc.src/sql-convert.at
+++ b/tests/esql-misc.src/sql-convert.at
@@ -55,16 +55,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MSQLCONV1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_MSQLCONV1
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_MSQLCONV1 PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -73,7 +73,7 @@ AT_DATA([prog.cbl], [
               MOVE "ñkäCÅ@ëæòY"   TO  EMP-NAME
               MOVE 400 TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_MSQLCONV1 VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
 
@@ -81,7 +81,7 @@ AT_DATA([prog.cbl], [
                                    EXEC SQL 
                                      DECLARE C1 CURSOR FOR
                                      SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                                     FROM EMP
+                                     FROM EMP_MSQLCONV1
                                      ORDER BY EMP_NO
                                    END-EXEC.
       *    OPEN CURSOR
@@ -97,7 +97,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MSQLCONV1
            END-EXEC.
 
            EXEC SQL
@@ -203,16 +203,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MSQLCONV2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_MSQLCONV2
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_ããóø NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_MSQLCONV2 PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -221,7 +221,7 @@ AT_DATA([prog.cbl], [
               MOVE "ñkäCÅ@ëæòY"   TO  EMP-NAME
               MOVE 400 TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_MSQLCONV2 VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
 
@@ -229,7 +229,7 @@ AT_DATA([prog.cbl], [
                                    EXEC SQL 
                                      DECLARE C1 CURSOR FOR
                                      SELECT EMP_NO, EMP_NAME,  EMP_ããóø 
-                                     FROM EMP
+                                     FROM EMP_MSQLCONV2
                                      ORDER BY EMP_NO
                                    END-EXEC.
       *    OPEN CURSOR
@@ -245,7 +245,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_MSQLCONV2
            END-EXEC.
 
            EXEC SQL
@@ -321,14 +321,14 @@ AT_DATA([prog.cbl], [
            
        PERFORM SETUP-DB.
            EXEC SQL
-                 INSERT INTO MSG VALUES ('abcdefghijklmnopqrstuvwxyzabcd             
+            INSERT INTO MSG_MML1 VALUES ('abcdefghijklmnopqrstuvwxyzabcd             
        efghijklmnopqrstuvwxyz
            abcdef')
            END-EXEC.
 
            EXEC SQL 
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_MML1
            END-EXEC.
            
            EXEC SQL
@@ -363,11 +363,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_MML1
                 (
                     MSG_DATA   CHAR(105)
                 )
@@ -377,7 +377,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML1
            END-EXEC.
 
            EXEC SQL
@@ -452,14 +452,14 @@ AT_DATA([prog.cbl], [
            
        PERFORM SETUP-DB.
            EXEC SQL
-                 INSERT INTO MSG VALUES ('abcdefghijklmnopqrstuvwxyz''ab             
+            INSERT INTO MSG_MML2 VALUES ('abcdefghijklmnopqrstuvwxyz''ab             
        cdefghijklmnopqrstuvwxyz''
              abcdef')
            END-EXEC.
 
            EXEC SQL 
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_MML2
            END-EXEC.
            
            EXEC SQL
@@ -494,11 +494,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_MML2
                 (
                     MSG_DATA   CHAR(105)
                 )
@@ -508,7 +508,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML2
            END-EXEC.
 
            EXEC SQL
@@ -574,7 +574,7 @@ AT_DATA([prog.cbl], [
        01  USERNAME                PIC  X(30) VALUE SPACE.
        01  PASSWD                  PIC  X(10) VALUE SPACE.
 
-       01  MSG-DATA                PIC  X(428) VALUE SPACE.
+       01  MSG-DATA                PIC  X(423) VALUE SPACE.
 
       ******************************************************************
        PROCEDURE                   DIVISION.
@@ -583,7 +583,7 @@ AT_DATA([prog.cbl], [
            
        PERFORM SETUP-DB.
        EXEC SQL
-       INSERT INTO MSG VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       INSERT INTO MSG_MML3 VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
        ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
        ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
@@ -594,7 +594,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL 
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_MML3
            END-EXEC.
            
            EXEC SQL
@@ -629,13 +629,13 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML3
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_MML3
                 (
-                    MSG_DATA   CHAR(428)
+                    MSG_DATA   CHAR(423)
                 )
            END-EXEC.
 
@@ -643,7 +643,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_MML3
            END-EXEC.
 
            EXEC SQL
@@ -687,7 +687,7 @@ AT_CHECK([${EMBED_DB_INFO} prog.cbl])
 
 AT_CHECK([${COMPILE_MODULE} prog.cbl])
 AT_CHECK([${RUN_MODULE} prog], [0],
-[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 ])
 
 AT_CLEANUP

--- a/tests/esql-sql-data.src/sql_type.at
+++ b/tests/esql-sql-data.src/sql_type.at
@@ -77,18 +77,18 @@ AT_DATA([prog.cbl], [
        MAIN-RTN.
        PERFORM SETUP-DB.
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD bigint
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-0) -- 01
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-0) -- 01
        END-EXEC
 
        EXEC SQL
@@ -96,25 +96,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-0-ARR FROM TESTTABLE -- 01
+           SELECT FIELD INTO :OUTPUT-DATA-0-ARR FROM TT_SQLTYPE -- 01
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-0(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD bigserial
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-1) -- 02
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-1) -- 02
        END-EXEC
 
        EXEC SQL
@@ -122,25 +122,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-1-ARR FROM TESTTABLE -- 02
+           SELECT FIELD INTO :OUTPUT-DATA-1-ARR FROM TT_SQLTYPE -- 02
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-1(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD char(5)
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-2) -- 03
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-2) -- 03
        END-EXEC
 
        EXEC SQL
@@ -148,25 +148,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-2-ARR FROM TESTTABLE -- 03
+           SELECT FIELD INTO :OUTPUT-DATA-2-ARR FROM TT_SQLTYPE -- 03
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-2(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD date
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-3) -- 04
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-3) -- 04
        END-EXEC
 
        EXEC SQL
@@ -174,25 +174,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-3-ARR FROM TESTTABLE -- 04
+           SELECT FIELD INTO :OUTPUT-DATA-3-ARR FROM TT_SQLTYPE -- 04
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-3(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD double precision
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-4) -- 05
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-4) -- 05
        END-EXEC
 
        EXEC SQL
@@ -200,25 +200,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-4-ARR FROM TESTTABLE -- 05
+           SELECT FIELD INTO :OUTPUT-DATA-4-ARR FROM TT_SQLTYPE -- 05
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-4(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD integer
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-5) -- 06
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-5) -- 06
        END-EXEC
 
        EXEC SQL
@@ -226,25 +226,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-5-ARR FROM TESTTABLE -- 06
+           SELECT FIELD INTO :OUTPUT-DATA-5-ARR FROM TT_SQLTYPE -- 06
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-5(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD numeric(6,2)
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-6) -- 07
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-6) -- 07
        END-EXEC
 
        EXEC SQL
@@ -252,25 +252,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-6-ARR FROM TESTTABLE -- 07
+           SELECT FIELD INTO :OUTPUT-DATA-6-ARR FROM TT_SQLTYPE -- 07
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-6(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD real
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-7) -- 08
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-7) -- 08
        END-EXEC
 
        EXEC SQL
@@ -278,25 +278,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-7-ARR FROM TESTTABLE -- 08
+           SELECT FIELD INTO :OUTPUT-DATA-7-ARR FROM TT_SQLTYPE -- 08
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-7(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD smallint
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-8) -- 09
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-8) -- 09
        END-EXEC
 
        EXEC SQL
@@ -304,25 +304,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-8-ARR FROM TESTTABLE -- 09
+           SELECT FIELD INTO :OUTPUT-DATA-8-ARR FROM TT_SQLTYPE -- 09
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-8(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD smallserial
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-9) -- 10
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-9) -- 10
        END-EXEC
 
        EXEC SQL
@@ -330,25 +330,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-9-ARR FROM TESTTABLE -- 10
+           SELECT FIELD INTO :OUTPUT-DATA-9-ARR FROM TT_SQLTYPE -- 10
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-9(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD serial
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-10) -- 11
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-10) -- 11
        END-EXEC
 
        EXEC SQL
@@ -356,25 +356,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-10-ARR FROM TESTTABLE -- 11
+           SELECT FIELD INTO :OUTPUT-DATA-10-ARR FROM TT_SQLTYPE -- 11
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-10(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD text
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-11) -- 12
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-11) -- 12
        END-EXEC
 
        EXEC SQL
@@ -382,25 +382,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-11-ARR FROM TESTTABLE -- 12
+           SELECT FIELD INTO :OUTPUT-DATA-11-ARR FROM TT_SQLTYPE -- 12
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-11(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD time
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-12) -- 13
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-12) -- 13
        END-EXEC
 
        EXEC SQL
@@ -408,25 +408,25 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-12-ARR FROM TESTTABLE -- 13
+           SELECT FIELD INTO :OUTPUT-DATA-12-ARR FROM TT_SQLTYPE -- 13
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-12(1).
       ******************************************************************
 
        EXEC SQL
-           DROP TABLE IF EXISTS TESTTABLE
+           DROP TABLE IF EXISTS TT_SQLTYPE
        END-EXEC.
 
        EXEC SQL
-            CREATE TABLE TESTTABLE
+            CREATE TABLE TT_SQLTYPE
             (
                 FIELD timestamp
             )
        END-EXEC.
 
        EXEC SQL
-            INSERT INTO TESTTABLE VALUES (:INPUT-DATA-13) -- 14
+            INSERT INTO TT_SQLTYPE VALUES (:INPUT-DATA-13) -- 14
        END-EXEC
 
        EXEC SQL
@@ -434,7 +434,7 @@ AT_DATA([prog.cbl], [
        END-EXEC.
 
        EXEC SQL
-           SELECT FIELD INTO :OUTPUT-DATA-13-ARR FROM TESTTABLE -- 14
+           SELECT FIELD INTO :OUTPUT-DATA-13-ARR FROM TT_SQLTYPE -- 14
        END-EXEC.
 
        DISPLAY OUTPUT-DATA-13(1).
@@ -464,7 +464,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_SQLTYPE
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-sqlca.src/errml-errmc.at
+++ b/tests/esql-sqlca.src/errml-errmc.at
@@ -48,7 +48,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_ERRMLERRMC
                       WHERE EMP_SALARY > 0
                       ORDER BY EMP_NO
            END-EXEC.
@@ -141,14 +141,14 @@ AT_DATA([prog.cbl], [
            DISPLAY "<valid connect> SQLERRMC:" SQLERRMC "|".
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_ERRMLERRMC
            END-EXEC.
 
            EXEC SQL COMMIT END-EXEC.
 
       *    INVALID CREATE TABLE
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_ERRMLERRMC
                 (
                     EMP_NO     NUMERIC(4,0),
                     EMP_NAME   CHAR(20),
@@ -162,7 +162,7 @@ AT_DATA([prog.cbl], [
 
       *    VALID CREATE TABLE
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_ERRMLERRMC
                 (
                     EMP_NO     NUMERIC(4,0),
                     EMP_NAME   CHAR(20),
@@ -178,7 +178,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_ERRMLERRMC VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -187,7 +187,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL COMMIT END-EXEC.
 
            EXEC SQL
-               INSERT INTO EMP VALUES
+               INSERT INTO EMP_ERRMLERRMC VALUES
                       (:EMP-NO,,,,,,,,:EMP-NAME,:EMP-SALARY)
            END-EXEC
            DISPLAY "<invalid insert 1> SQLERRML:" SQLERRML.

--- a/tests/esql-sqlca.src/fetch-loop.at
+++ b/tests/esql-sqlca.src/fetch-loop.at
@@ -48,7 +48,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_FETCHLOOP
                       WHERE EMP_SALARY > 0
                       ORDER BY EMP_NO
            END-EXEC.
@@ -80,7 +80,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C2 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_FETCHLOOP
                       WHERE EMP_SALARY = 9999
                       ORDER BY EMP_NO
            END-EXEC.
@@ -112,7 +112,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL 
                DECLARE C3 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY 
-                      FROM EMP
+                      FROM EMP_FETCHLOOP
                       ++++WHERE++++ EMP_SALARY > 0
                       ORDER BY EMP_NO
            END-EXEC.
@@ -162,11 +162,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_FETCHLOOP
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_FETCHLOOP
                 (
                     EMP_NO     NUMERIC(4,0),
                     EMP_NAME   CHAR(20),
@@ -180,7 +180,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_FETCHLOOP VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -192,7 +192,7 @@ AT_DATA([prog.cbl], [
       ******************************************************************
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_FETCHLOOP
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-sqlca.src/insert-select-update-delete.at
+++ b/tests/esql-sqlca.src/insert-select-update-delete.at
@@ -28,61 +28,61 @@ AT_DATA([prog.cbl], [
        PERFORM SETUP-DB.
 
        EXEC SQL
-         INSERT INTO TESTTABLE VALUES (1, 'hello')
+         INSERT INTO TT_ISUD VALUES (1, 'hello')
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         INSERT INTO TESTTABLE VALUES ('invalid', 'invalid')
+         INSERT INTO TT_ISUD VALUES ('invalid', 'invalid')
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         SELECT V INTO :READ-TBL FROM TESTTABLE
+         SELECT V INTO :READ-TBL FROM TT_ISUD
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         SELECT V INTO :READ-TBL FROM TESTTABLEERROR
+         SELECT V INTO :READ-TBL FROM TTERR_ISUD
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         UPDATE TESTTABLE SET V = 'world' WHERE ID = 1
+         UPDATE TT_ISUD SET V = 'world' WHERE ID = 1
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         UPDATE TESTTABLE SET V = 'world' WHERE ID = 3
+         UPDATE TT_ISUD SET V = 'world' WHERE ID = 3
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         UPDATE TESTTABLEERROR SET V = 'world' WHERE ID = 1
+         UPDATE TTERR_ISUD SET V = 'world' WHERE ID = 1
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         DELETE FROM TESTTABLE WHERE ID = 1
+         DELETE FROM TT_ISUD WHERE ID = 1
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         DELETE FROM TESTTABLE WHERE ID = 3
+         DELETE FROM TT_ISUD WHERE ID = 3
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
 
        EXEC SQL
-         DELETE FROM TESTTABLEERROR WHERE ID = 3
+         DELETE FROM TTERR_ISUD WHERE ID = 3
        END-EXEC.
        PERFORM SHOW-STATUS.
        EXEC SQL COMMIT END-EXEC.
@@ -107,11 +107,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_ISUD
            END-EXEC.
 
            EXEC SQL
-               CREATE TABLE TESTTABLE
+               CREATE TABLE TT_ISUD
                (
                  ID integer,
                  V  char(5)

--- a/tests/esql-sqlca.src/open-fetch-close.at
+++ b/tests/esql-sqlca.src/open-fetch-close.at
@@ -44,7 +44,7 @@ AT_DATA([prog.cbl], [
        EXEC SQL 
          DECLARE C CURSOR FOR
            SELECT V 
-           FROM TESTTABLE
+           FROM TT_OFC
            ORDER BY ID
        END-EXEC.
 
@@ -98,11 +98,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_OFC
            END-EXEC.
 
            EXEC SQL
-               CREATE TABLE TESTTABLE
+               CREATE TABLE TT_OFC
                (
                  ID integer,
                  V  char(5)
@@ -113,7 +113,7 @@ AT_DATA([prog.cbl], [
              MOVE TEST-ID(IDX) TO DATA-ID
              MOVE TEST-V(IDX) TO DATA-V
              EXEC SQL
-               INSERT INTO TESTTABLE VALUES
+               INSERT INTO TT_OFC VALUES
                  (:DATA-ID, :DATA-V)
              END-EXEC
            END-PERFORM.

--- a/tests/esql-sqlca.src/prepare-execute.at
+++ b/tests/esql-sqlca.src/prepare-execute.at
@@ -31,7 +31,7 @@ AT_DATA([prog.cbl], [
        01 SQL-COMMAND-ARG PIC 99 VALUE 2.
 
        01 INVALID-COMMAND PIC X(50)
-         VALUE "DELETE FROM TESTTABLEERROR WHERE ID > ?".
+         VALUE "DELETE FROM TTERR_QPREP WHERE ID > ?".
 
        01 DATA-ID PIC 9(4).
        01 DATA-V PIC X(5).
@@ -47,8 +47,8 @@ AT_DATA([prog.cbl], [
            
          PERFORM SETUP-DB.
 
-         MOVE "DELETE FROM TESTTABLE WHERE ID > ?" TO SQL-COMMAND-ARR.
-         MOVE 34 TO SQL-COMMAND-LEN.
+         MOVE "DELETE FROM TT_QPREP WHERE ID > ?" TO SQL-COMMAND-ARR.
+         MOVE 33 TO SQL-COMMAND-LEN.
 
          EXEC SQL
              PREPARE st FROM :SQL-COMMAND
@@ -61,7 +61,7 @@ AT_DATA([prog.cbl], [
          PERFORM SHOW-STATUS.
 
          MOVE INVALID-COMMAND TO SQL-COMMAND-ARR.
-         MOVE 39 TO SQL-COMMAND-LEN.
+         MOVE 36 TO SQL-COMMAND-LEN.
 
          EXEC SQL
              PREPARE st FROM :SQL-COMMAND
@@ -93,11 +93,11 @@ AT_DATA([prog.cbl], [
          END-EXEC.
 
          EXEC SQL
-             DROP TABLE IF EXISTS TESTTABLE
+             DROP TABLE IF EXISTS TT_QPREP
          END-EXEC.
 
          EXEC SQL
-             CREATE TABLE TESTTABLE
+             CREATE TABLE TT_QPREP
              (
                ID integer,
                V  char(5)
@@ -108,7 +108,7 @@ AT_DATA([prog.cbl], [
            MOVE TEST-ID(IDX) TO DATA-ID
            MOVE TEST-V(IDX) TO DATA-V
            EXEC SQL
-             INSERT INTO TESTTABLE VALUES
+             INSERT INTO TT_QPREP VALUES
                (:DATA-ID, :DATA-V)
            END-EXEC
          END-PERFORM.

--- a/tests/esql-utf8.src/cursor.at
+++ b/tests/esql-utf8.src/cursor.at
@@ -56,30 +56,30 @@ AT_DATA([INSERTTBL.cbl], [
 
       *    DROP TABLE
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_CURSOR
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
       *    CREATE TABLE
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_CURSOR
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_CURSOR PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN STOP RUN.
 
       *    INSERT ROWS USING LITERAL
            EXEC SQL
-               INSERT INTO EMP VALUES (46, '鹿児島　六郎', -320)
+               INSERT INTO EMP_CURSOR VALUES (46, '鹿児島　六郎', -320)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
            EXEC SQL
-               INSERT INTO EMP VALUES (47, '沖縄　七郎', 480)
+               INSERT INTO EMP_CURSOR VALUES (47, '沖縄　七郎', 480)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
@@ -89,7 +89,7 @@ AT_DATA([INSERTTBL.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_CURSOR VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
               IF  SQLCODE NOT = ZERO
@@ -183,7 +183,7 @@ AT_DATA([FETCHTBL.cbl], [
 
       *    SELECT COUNT(*) INTO HOST-VARIABLE
            EXEC SQL
-               SELECT COUNT(*) INTO :EMP-CNT FROM EMP
+               SELECT COUNT(*) INTO :EMP-CNT FROM EMP_CURSOR
            END-EXEC.
            DISPLAY "TOTAL RECORD: " EMP-CNT.
 
@@ -191,7 +191,7 @@ AT_DATA([FETCHTBL.cbl], [
            EXEC SQL
                DECLARE カーソル1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY
-                      FROM EMP
+                      FROM EMP_CURSOR
                       ORDER BY EMP_NO
            END-EXEC.
            EXEC SQL

--- a/tests/esql-utf8.src/include.at
+++ b/tests/esql-utf8.src/include.at
@@ -35,18 +35,18 @@ AT_DATA([ホスト変数の宣言], [
 
 AT_DATA([SELECT文], [
            EXEC SQL
-               SELECT * INTO :READ-TBL FROM EMP WHERE EMP_NO > 4
+               SELECT * INTO :READ-TBL FROM EMP_UINCL WHERE EMP_NO > 4
            END-EXEC.
 ])
 
 AT_DATA([exec-create-table], [
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UINCL
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_UINCL PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 ])
@@ -123,7 +123,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL INCLUDE exec-connect END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UINCL
            END-EXEC.
 
            EXEC SQL INCLUDE
@@ -136,7 +136,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UINCL VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
            END-PERFORM.
@@ -154,7 +154,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UINCL
            END-EXEC.
 
            EXEC SQL

--- a/tests/esql-utf8.src/japanese.at
+++ b/tests/esql-utf8.src/japanese.at
@@ -47,7 +47,7 @@ AT_DATA([prog.cbl], [
 
       *    SHOW RESULT
            EXEC SQL
-               SELECT FIELD INTO :READ-TBL FROM TESTTABLE ORDER BY N
+               SELECT FIELD INTO :READ-TBL FROM TT_UJAPANESE ORDER BY N
            END-EXEC.
 
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
@@ -76,11 +76,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS TESTTABLE
+               DROP TABLE IF EXISTS TT_UJAPANESE
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE TESTTABLE
+                CREATE TABLE TT_UJAPANESE
                 (
                     N         NUMERIC(2,0) NOT NULL,
                     FIELD     CHAR(10)
@@ -91,7 +91,7 @@ AT_DATA([prog.cbl], [
            PERFORM VARYING IDX FROM 1 BY 1 UNTIL IDX > 10
               MOVE D(IDX)     TO  V
               EXEC SQL
-                 INSERT INTO TESTTABLE VALUES (:IDX, :V)
+                 INSERT INTO TT_UJAPANESE VALUES (:IDX, :V)
               END-EXEC
            END-PERFORM.
 
@@ -104,7 +104,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
       *    EXEC SQL
-      *        DROP TABLE IF EXISTS TESTTABLE
+      *        DROP TABLE IF EXISTS TT_UJAPANESE
       *    END-EXEC.
 
            EXEC SQL

--- a/tests/esql-utf8.src/long-sql.at
+++ b/tests/esql-utf8.src/long-sql.at
@@ -109,7 +109,7 @@ AT_DATA([prog.cbl], [
                 EMP_NAME039,
                 EMP_NAME040
             INTO :READ-DATA
-            FROM EMP
+            FROM EMP_ULONGSQL
            END-EXEC.
 
             DISPLAY EMP_NAME001.
@@ -175,11 +175,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_ULONGSQL
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_ULONGSQL
                 (
                     EMP_NAME001 CHAR(50),
                     EMP_NAME002 CHAR(50),
@@ -226,7 +226,7 @@ AT_DATA([prog.cbl], [
 
       *    INSERT ROWS USING HOST VARIABLE
            EXEC SQL
-              INSERT INTO EMP VALUES
+              INSERT INTO EMP_ULONGSQL VALUES
              (
              'あああああああああああああああああああ',
              'aああああああああああああああああああ',
@@ -281,7 +281,7 @@ AT_DATA([prog.cbl], [
       ******************************************************************
 
       *    EXEC SQL
-      *        DROP TABLE IF EXISTS EMP
+      *        DROP TABLE IF EXISTS EMP_ULONGSQL
       *    END-EXEC.
 
            EXEC SQL

--- a/tests/esql-utf8.src/prepare.at
+++ b/tests/esql-utf8.src/prepare.at
@@ -31,7 +31,7 @@ AT_DATA([prog.cbl], [
        01 SQL-COMMAND-ARG PIC 99 VALUE 2.
 
        01 INVALID-COMMAND PIC X(50)
-         VALUE "DELETE FROM TESTTABLEERROR WHERE ID > ?".
+         VALUE "DELETE FROM TTERR_UPREP WHERE ID > ?".
 
        01 DATA-ID PIC 9(4).
        01 DATA-V PIC X(5).
@@ -47,8 +47,8 @@ AT_DATA([prog.cbl], [
 
          PERFORM SETUP-DB.
 
-         MOVE "DELETE FROM TESTTABLE WHERE ID > ?" TO SQL-COMMAND-ARR.
-         MOVE 34 TO SQL-COMMAND-LEN.
+         MOVE "DELETE FROM TT_UPREP WHERE ID > ?" TO SQL-COMMAND-ARR.
+         MOVE 33 TO SQL-COMMAND-LEN.
 
          EXEC SQL
              PREPARE プリペア1 FROM :SQL-COMMAND
@@ -61,7 +61,7 @@ AT_DATA([prog.cbl], [
          PERFORM SHOW-STATUS.
 
          MOVE INVALID-COMMAND TO SQL-COMMAND-ARR.
-         MOVE 39 TO SQL-COMMAND-LEN.
+         MOVE 36 TO SQL-COMMAND-LEN.
 
          EXEC SQL
              PREPARE プリペア2 FROM :SQL-COMMAND
@@ -93,11 +93,11 @@ AT_DATA([prog.cbl], [
          END-EXEC.
 
          EXEC SQL
-             DROP TABLE IF EXISTS TESTTABLE
+             DROP TABLE IF EXISTS TT_UPREP
          END-EXEC.
 
          EXEC SQL
-             CREATE TABLE TESTTABLE
+             CREATE TABLE TT_UPREP
              (
                ID integer,
                V  char(5)
@@ -109,7 +109,7 @@ AT_DATA([prog.cbl], [
            MOVE TEST-ID(IDX) TO DATA-ID
            MOVE TEST-V(IDX) TO DATA-V
            EXEC SQL
-             INSERT INTO TESTTABLE VALUES
+             INSERT INTO TT_UPREP VALUES
                (:DATA-ID, :DATA-V)
            END-EXEC
          END-PERFORM.

--- a/tests/esql-utf8.src/sample.at
+++ b/tests/esql-utf8.src/sample.at
@@ -56,32 +56,32 @@ AT_DATA([INSERTTBL.cbl], [
 
       *    DROP TABLE
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_USAMPLE
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
       *    CREATE TABLE
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_USAMPLE
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_USAMPLE PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN STOP RUN.
 
       *    INSERT ROWS USING LITERAL
            EXEC SQL
-      *         INSERT INTO EMP VALUES (46, 'KAGOSHIMA ROKURO', -320)
-               INSERT INTO EMP VALUES (46, '鹿児島　六郎', -320)
+      *    INSERT INTO EMP_USAMPLE VALUES (46, 'KAGOSHIMA ROKURO', -320)
+               INSERT INTO EMP_USAMPLE VALUES (46, '鹿児島　六郎', -320)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
            EXEC SQL
-      *         INSERT INTO EMP VALUES (47, 'OKINAWA SHICHIRO', 480)
-               INSERT INTO EMP VALUES (47, '沖縄　七郎', 480)
+      *    INSERT INTO EMP_USAMPLE VALUES (47, 'OKINAWA SHICHIRO', 480)
+               INSERT INTO EMP_USAMPLE VALUES (47, '沖縄　七郎', 480)
            END-EXEC.
            IF  SQLCODE NOT = ZERO PERFORM ERROR-RTN.
 
@@ -91,7 +91,7 @@ AT_DATA([INSERTTBL.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME
               MOVE TEST-SALARY(IDX) TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_USAMPLE VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
               IF  SQLCODE NOT = ZERO
@@ -185,7 +185,7 @@ AT_DATA([FETCHTBL.cbl], [
 
       *    SELECT COUNT(*) INTO HOST-VARIABLE
            EXEC SQL
-               SELECT COUNT(*) INTO :EMP-CNT FROM EMP
+               SELECT COUNT(*) INTO :EMP-CNT FROM EMP_USAMPLE
            END-EXEC.
            DISPLAY "TOTAL RECORD: " EMP-CNT.
 
@@ -193,7 +193,7 @@ AT_DATA([FETCHTBL.cbl], [
            EXEC SQL
                DECLARE C1 CURSOR FOR
                SELECT EMP_NO, EMP_NAME, EMP_SALARY
-                      FROM EMP
+                      FROM EMP_USAMPLE
                       ORDER BY EMP_NO
            END-EXEC.
            EXEC SQL

--- a/tests/esql-utf8.src/sql-convert.at
+++ b/tests/esql-utf8.src/sql-convert.at
@@ -55,16 +55,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_USQLCONV1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_USQLCONV1
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_SALARY NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_USQLCONV1 PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -73,7 +73,7 @@ AT_DATA([prog.cbl], [
               MOVE "北海　太郎"   TO  EMP-NAME
               MOVE 400 TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_USQLCONV1 VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
 
@@ -81,7 +81,7 @@ AT_DATA([prog.cbl], [
                                    EXEC SQL
                                      DECLARE C1 CURSOR FOR
                                      SELECT EMP_NO, EMP_NAME, EMP_SALARY
-                                     FROM EMP
+                                     FROM EMP_USQLCONV1
                                      ORDER BY EMP_NO
                                    END-EXEC.
       *    OPEN CURSOR
@@ -97,7 +97,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_USQLCONV1
            END-EXEC.
 
            EXEC SQL
@@ -204,16 +204,16 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_USQLCONV2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_USQLCONV2
                 (
                     EMP_NO     NUMERIC(4,0) NOT NULL,
                     EMP_NAME   CHAR(20),
                     EMP_給料 NUMERIC(4,0),
-                    CONSTRAINT IEMP_0 PRIMARY KEY (EMP_NO)
+                    CONSTRAINT IEMP_USQLCONV2 PRIMARY KEY (EMP_NO)
                 )
            END-EXEC.
 
@@ -222,7 +222,7 @@ AT_DATA([prog.cbl], [
               MOVE "北海　太郎"   TO  EMP-NAME
               MOVE 400 TO  EMP-SALARY
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_USQLCONV2 VALUES
                         (:EMP-NO,:EMP-NAME,:EMP-SALARY)
               END-EXEC
 
@@ -230,7 +230,7 @@ AT_DATA([prog.cbl], [
                                    EXEC SQL
                                      DECLARE C1 CURSOR FOR
                                      SELECT EMP_NO, EMP_NAME,  EMP_給料
-                                     FROM EMP
+                                     FROM EMP_USQLCONV2
                                      ORDER BY EMP_NO
                                    END-EXEC.
       *    OPEN CURSOR
@@ -246,7 +246,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_USQLCONV2
            END-EXEC.
 
            EXEC SQL
@@ -323,14 +323,14 @@ AT_DATA([prog.cbl], [
 
        PERFORM SETUP-DB.
            EXEC SQL
-                 INSERT INTO MSG VALUES ('abcdefghijklmnopqrstuvwxyzabcd
+            INSERT INTO MSG_UML1 VALUES ('abcdefghijklmnopqrstuvwxyzabcd
        efghijklmnopqrstuvwxyz
            abcdef')
            END-EXEC.
 
            EXEC SQL
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_UML1
            END-EXEC.
 
            EXEC SQL
@@ -365,11 +365,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_UML1
                 (
                     MSG_DATA   CHAR(105)
                 )
@@ -379,7 +379,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML1
            END-EXEC.
 
            EXEC SQL
@@ -455,14 +455,14 @@ AT_DATA([prog.cbl], [
 
        PERFORM SETUP-DB.
            EXEC SQL
-                 INSERT INTO MSG VALUES ('abcdefghijklmnopqrstuvwxyz''ab
+            INSERT INTO MSG_UML2 VALUES ('abcdefghijklmnopqrstuvwxyz''ab
        cdefghijklmnopqrstuvwxyz''
              abcdef')
            END-EXEC.
 
            EXEC SQL
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_UML2
            END-EXEC.
 
            EXEC SQL
@@ -497,11 +497,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_UML2
                 (
                     MSG_DATA   CHAR(105)
                 )
@@ -511,7 +511,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML2
            END-EXEC.
 
            EXEC SQL
@@ -578,7 +578,7 @@ AT_DATA([prog.cbl], [
        01  USERNAME                PIC  X(30) VALUE SPACE.
        01  PASSWD                  PIC  X(10) VALUE SPACE.
 
-       01  MSG-DATA                PIC  X(428) VALUE SPACE.
+       01  MSG-DATA                PIC  X(423) VALUE SPACE.
 
       ******************************************************************
        PROCEDURE                   DIVISION.
@@ -587,7 +587,7 @@ AT_DATA([prog.cbl], [
 
        PERFORM SETUP-DB.
        EXEC SQL
-       INSERT INTO MSG VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       INSERT INTO MSG_UML3 VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
        ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
        ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
@@ -598,7 +598,7 @@ AT_DATA([prog.cbl], [
 
            EXEC SQL
                DECLARE C1 CURSOR FOR
-               SELECT MSG_DATA FROM MSG
+               SELECT MSG_DATA FROM MSG_UML3
            END-EXEC.
 
            EXEC SQL
@@ -633,13 +633,13 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML3
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE MSG
+                CREATE TABLE MSG_UML3
                 (
-                    MSG_DATA   CHAR(428)
+                    MSG_DATA   CHAR(423)
                 )
            END-EXEC.
 
@@ -647,7 +647,7 @@ AT_DATA([prog.cbl], [
        CLEANUP-DB.
       ******************************************************************
            EXEC SQL
-               DROP TABLE IF EXISTS MSG
+               DROP TABLE IF EXISTS MSG_UML3
            END-EXEC.
 
            EXEC SQL
@@ -690,7 +690,7 @@ AT_DATA([prog.cbl], [
 AT_CHECK([${EMBED_DB_INFO} prog.cbl])
 AT_CHECK([${COMPILE_MODULE} prog.cbl])
 AT_CHECK([${RUN_MODULE} prog], [0],
-[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 ])
 
 AT_CLEANUP

--- a/tests/esql-utf8.src/varying.at
+++ b/tests/esql-utf8.src/varying.at
@@ -81,11 +81,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UVARYING1
                 (
                     EMP_NUM1   NUMERIC(4, 0),
                     EMP_NAME   VARCHAR(10),
@@ -100,7 +100,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NUM2(IDX)   TO  EMP-NUM2
               MOVE IDX TO EMP-氏名-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UVARYING1 VALUES
                         (:EMP-NUM1, :EMP-氏名, :EMP-NUM2)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -109,7 +109,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL
                DECLARE C1 CURSOR FOR
                SELECT EMP_NUM1, EMP_NAME, EMP_NUM2
-                      FROM EMP
+                      FROM EMP_UVARYING1
                       ORDER BY EMP_NUM1
            END-EXEC.
 
@@ -126,7 +126,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING1
            END-EXEC.
 
            EXEC SQL
@@ -271,11 +271,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING1
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UVARYING1
                 (
                     EMP_NAME   VARCHAR(10)
                 )
@@ -286,7 +286,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UVARYING1 VALUES
                         (:EMP-NAME)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -295,7 +295,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL
                DECLARE C1 CURSOR FOR
                SELECT EMP_NAME
-                      FROM EMP
+                      FROM EMP_UVARYING1
                       ORDER BY EMP_NAME
            END-EXEC.
 
@@ -312,7 +312,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING1
            END-EXEC.
 
            EXEC SQL
@@ -468,11 +468,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UVARYING2
                 (
                     EMP_NUM1   NUMERIC(4, 0),
                     EMP_NAME   VARCHAR(10),
@@ -487,7 +487,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NUM2(IDX)   TO  EMP-NUM2
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UVARYING2 VALUES
                         (:EMP-NUM1, :EMP-NAME, :EMP-NUM2)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -496,7 +496,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL
                DECLARE C1 CURSOR FOR
                SELECT EMP_NUM1, EMP_NAME, EMP_NUM2
-                      FROM EMP
+                      FROM EMP_UVARYING2
                       ORDER BY EMP_NUM1
            END-EXEC.
 
@@ -513,7 +513,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING2
            END-EXEC.
 
            EXEC SQL
@@ -658,11 +658,11 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING2
            END-EXEC.
 
            EXEC SQL
-                CREATE TABLE EMP
+                CREATE TABLE EMP_UVARYING2
                 (
                     EMP_NAME   VARCHAR(10)
                 )
@@ -673,7 +673,7 @@ AT_DATA([prog.cbl], [
               MOVE TEST-NAME(IDX)   TO  EMP-NAME-ARR
               MOVE IDX TO EMP-NAME-LEN
               EXEC SQL
-                 INSERT INTO EMP VALUES
+                 INSERT INTO EMP_UVARYING2 VALUES
                         (:EMP-NAME)
               END-EXEC
       *       PERFORM DISPLAY-TEST-RESULT
@@ -682,7 +682,7 @@ AT_DATA([prog.cbl], [
            EXEC SQL
                DECLARE C1 CURSOR FOR
                SELECT EMP_NAME
-                      FROM EMP
+                      FROM EMP_UVARYING2
                       ORDER BY EMP_NAME
            END-EXEC.
 
@@ -699,7 +699,7 @@ AT_DATA([prog.cbl], [
            END-EXEC.
 
            EXEC SQL
-               DROP TABLE IF EXISTS EMP
+               DROP TABLE IF EXISTS EMP_UVARYING2
            END-EXEC.
 
            EXEC SQL


### PR DESCRIPTION
> このPRは https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/31 と同じ内容です (ベースブランチのみ異なります)。
>
> This PR has the same content as https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/31 (only the base branch differs).

ESQL 関連の autotest スイートを、他の autotest スイートと同じように `-j4` で並列実行できるようにする。

## 背景

これまで ESQL の各テストは、ごく限られた名前のテーブル (`EMP`, `TESTTABLE`, `MSG` など) と、共通の主キー制約名 `IEMP_0` を使っていた。autotest を `-j4` で走らせると同一スイート内の複数テストが同じ PostgreSQL データベースを同時に使うため、互いのテーブルを DROP/CREATE してしまい非決定的に失敗する。そのため ESQL スイートだけが直列実行のまま残っていた。

## 変更内容

- ESQL の各テストグループ (AT_SETUP〜AT_CLEANUP) が、スイート名とテストファイル名に由来する固有のテーブル名・制約名を使うようにリネームした。PostgreSQL では主キー制約が張る索引名がスキーマ全体で一意である必要があるため、制約名もテーブル名に合わせている。
- `.github/workflows/test-esql.yml` / `test-esql-utf8.yml` / `windows-test-esql.yml` の各スイート実行に `-j4` を追加した。
- `tests/Makefile.am` (と `tests/Makefile.in`) の ESQL の `*_DEPENDENCIES` に、記載漏れだった `.at` ファイル (`bulk-fetch.at`, `subscript.at`, `logging.at` など) を追加した。漏れていると、そのテストを変更してもスイートが再生成されない。
- 命名規則を `doc/esql-design.md` / `doc/esql-design_JP.md` と `tests/README.md` / `tests/README_JP.md` に記載した。

## 桁位置に注意が必要だった箇所

- `esql-misc.src/sql-convert.at` と `esql-utf8.src/sql-convert.at` は「72 桁を超える SQL」と「複数行文字列リテラル」を検証するテストで、リテラルの桁位置がそのまま期待値になる。Area B から始まる 2 つのテストは、テーブル名が伸びた分だけ先頭のインデントを詰めることで、引用符の桁 (42) と行長を変更前と完全に一致させた。3 つ目は Area A から始まっていて左に詰められないため、先頭の `'a'` の連続を 5 文字短くし、ホスト変数の `PIC X(n)`、列の `CHAR(n)`、期待出力も合わせて更新した。
- `prepare-execute.at` / `prepare.at` は PREPARE する SQL 文の長さを `SQL-COMMAND-LEN` に直接書いているので、その定数も更新した。
- コンパイルのみで DB に接続しないテスト (`sql-format.at`, `host-var-wrap.at`, `sqlca-warning.at`) は、生成 Java に対する grep パターンを読みやすく保つため、短い汎用名のままにしている。

## 確認

ローカルの PostgreSQL 16 に対して 6 スイートすべてを `-j4` で実行し、繰り返しても安定して通ることを確認した (`esql-utf8` は `--enable-utf8` でビルドし直して実行)。全 ESQL テストグループでテーブル名・制約名が一意であること、リネームによって 72 桁を超えた行が無いことも機械的に検証している。

---

Make the ESQL autotest suites runnable in parallel with `-j4`, the way the other autotest suites already are.

## Background

Every ESQL test used to create tables from a small shared pool of names (`EMP`, `TESTTABLE`, `MSG`, ...) and a shared primary key constraint name (`IEMP_0`). Under `autotest -j4` the concurrent test cases in one suite share a single PostgreSQL database, so they would drop and recreate each other's tables and fail non-deterministically. That is why the ESQL suites were still run serially.

## Changes

- Each ESQL test group (`AT_SETUP`..`AT_CLEANUP`) now uses table and constraint names derived from its suite and test file. Constraints follow the table, because in PostgreSQL the index backing a primary key constraint has to be unique schema-wide.
- Pass `-j4` to every suite invocation in `.github/workflows/test-esql.yml`, `test-esql-utf8.yml` and `windows-test-esql.yml`.
- Add the `.at` files that were missing from the ESQL `*_DEPENDENCIES` lists in `tests/Makefile.am` (and `tests/Makefile.in`) — `bulk-fetch.at`, `subscript.at`, `logging.at` and others. While they were missing, changing one of those tests did not regenerate its suite.
- Document the naming rule in `doc/esql-design.md` / `doc/esql-design_JP.md` and `tests/README.md` / `tests/README_JP.md`.

## Column-sensitive spots

- `esql-misc.src/sql-convert.at` and `esql-utf8.src/sql-convert.at` verify SQL that crosses column 72 and multi-line string literals, so the literal's columns *are* the expected value. For the two tests whose `INSERT` starts in area B, the leading indentation is shortened by exactly as much as the table name grew, keeping the quote in column 42 and the line length identical. The third one starts in area A and cannot shift left, so its leading run of `'a'` is 5 characters shorter, with the host variable `PIC X(n)`, the column `CHAR(n)` and the expected output updated to match.
- `prepare-execute.at` / `prepare.at` hardcode the length of the prepared statement text in `SQL-COMMAND-LEN`; those constants are updated too.
- Compile-only tests that never connect to the database (`sql-format.at`, `host-var-wrap.at`, `sqlca-warning.at`) keep their short generic names, so the expected `grep` patterns stay readable.

## Verification

All six suites were run with `-j4` against a local PostgreSQL 16 and pass repeatedly (`esql-utf8` after rebuilding with `--enable-utf8`). Table and constraint name uniqueness across all ESQL test groups, and the absence of any line pushed past column 72, were both checked mechanically.
