### PR TITLE
Use System.arraycopy and Arrays.fill in CobolDataStorage.memcpy/memset

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/common/CobolString.java
@@ -253,12 +253,17 @@ public class CobolString {
                     .memcpy(src.getDataStorage(), srcSize);
             stringOffset += srcSize;
         } else {
+            // 連結先が日本語項目の場合、stringInitがバイト数との比較を2倍補正の前に行うため、
+            // stringOffsetが連結先のバイト数を超えている(=残り領域が負になる)ことがある。
+            // その場合は何も連結せずオーバーフローとして扱う。
             int size = stringDst.getSize() - stringOffset;
-            stringDst
-                    .getDataStorage()
-                    .getSubDataStorage(stringOffset)
-                    .memcpy(src.getDataStorage(), size);
-            stringOffset += size;
+            if (size > 0) {
+                stringDst
+                        .getDataStorage()
+                        .getSubDataStorage(stringOffset)
+                        .memcpy(src.getDataStorage(), size);
+            }
+            stringOffset = stringDst.getSize();
             CobolRuntimeException.setException(CobolExceptionId.COB_EC_OVERFLOW_STRING);
         }
     }

--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorage.java
@@ -20,6 +20,7 @@ package jp.osscons.opensourcecobol.libcobj.data;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import jp.osscons.opensourcecobol.libcobj.common.CobolModule;
 
 /**
@@ -282,9 +283,7 @@ public class CobolDataStorage {
      * @param size コピーするバイト数
      */
     public void memcpy(CobolDataStorage buf, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(i, buf.getByte(i));
-        }
+        System.arraycopy(buf.data, buf.index, this.data, this.index, size);
     }
 
     /**
@@ -294,9 +293,7 @@ public class CobolDataStorage {
      * @param size コピーするバイト数
      */
     public void memcpy(byte[] buf, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(i, buf[i]);
-        }
+        System.arraycopy(buf, 0, this.data, this.index, size);
     }
 
     /**
@@ -317,9 +314,7 @@ public class CobolDataStorage {
      * @param size コピーするバイト数
      */
     public void memcpy(int offset, byte[] buf, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(offset + i, buf[i]);
-        }
+        System.arraycopy(buf, 0, this.data, this.index + offset, size);
     }
 
     /**
@@ -330,16 +325,14 @@ public class CobolDataStorage {
      * @param size コピーするバイト数
      */
     public void memcpy(int offset, CobolDataStorage buf, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(offset + i, buf.getByte(i));
-        }
+        System.arraycopy(buf.data, buf.index, this.data, this.index + offset, size);
     }
 
     /**
      * C言語のmemcpyに相当するメソッド
      *
      * @param buf コピー元のデータ
-     * @param offset コピー先のthis.indexからの相対位置
+     * @param offset コピー元bufの先頭からの相対位置
      * @param size コピーするバイト数
      */
     public void memcpy(byte[] buf, int offset, int size) {
@@ -362,9 +355,7 @@ public class CobolDataStorage {
      * @param size 代入先のバイト数
      */
     public void memset(byte ch, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(i, ch);
-        }
+        Arrays.fill(this.data, this.index, this.index + size, ch);
     }
 
     /**
@@ -385,9 +376,7 @@ public class CobolDataStorage {
      * @param size 代入先のバイト数
      */
     public void memset(int offset, byte ch, int size) {
-        for (int i = 0; i < size; ++i) {
-            this.setByte(offset + i, ch);
-        }
+        Arrays.fill(this.data, this.index + offset, this.index + offset + size, ch);
     }
 
     /**

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolStringTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/common/CobolStringTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2021-2022 TOKYO SYSTEM HOUSE Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3.0,
+ * or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; see the file COPYING.LIB.  If
+ * not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1301 USA
+ */
+package jp.osscons.opensourcecobol.libcobj.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jp.osscons.opensourcecobol.libcobj.data.AbstractCobolField;
+import jp.osscons.opensourcecobol.libcobj.data.CobolDataStorage;
+import jp.osscons.opensourcecobol.libcobj.data.CobolFieldAttribute;
+import jp.osscons.opensourcecobol.libcobj.data.CobolFieldFactory;
+import jp.osscons.opensourcecobol.libcobj.exceptions.CobolRuntimeException;
+import org.junit.jupiter.api.Test;
+
+class CobolStringTest {
+
+    private static AbstractCobolField makeField(int size, String value, int type, int digits) {
+        CobolFieldAttribute attr = new CobolFieldAttribute(type, digits, 0, 0, null);
+        CobolDataStorage storage = new CobolDataStorage(size);
+        storage.memset((byte) ' ', size);
+        if (value != null) {
+            storage.memcpy(value, value.length());
+        }
+        return CobolFieldFactory.makeCobolField(size, storage, attr);
+    }
+
+    /**
+     * STRING文の連結先が日本語項目で、WITH POINTERが項目の文字数を超えている場合。<br>
+     * stringInitがバイト数との比較を2倍補正の前に行うため連結先の残り領域が負になるが、
+     * 例外を送出せずオーバーフロー状態になることを確認する。
+     */
+    @Test
+    void stringAppendIntoNationalWithPointerBeyondItemSetsOverflow() {
+        // PIC N(5) 相当 (5文字 = 10バイト)
+        AbstractCobolField dst = makeField(10, null, CobolFieldAttribute.COB_TYPE_NATIONAL, 0);
+        AbstractCobolField ptr =
+                makeField(2, "07", CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY, 2);
+        AbstractCobolField src = makeField(4, "ABCD", CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0);
+
+        CobolString.stringInit(dst, ptr);
+        CobolString.stringDelimited(null);
+        CobolString.stringAppend(src);
+        CobolString.stringFinish();
+
+        assertNotEquals(0, CobolRuntimeException.code);
+        assertEquals(6, ptr.getInt());
+        CobolRuntimeException.code = 0;
+    }
+
+    /** 連結先に収まる通常のSTRING文が連結先と文字位置を正しく更新することを確認する。 */
+    @Test
+    void stringAppendWithinDestinationUpdatesPointer() {
+        AbstractCobolField dst = makeField(6, null, CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0);
+        AbstractCobolField ptr =
+                makeField(2, "02", CobolFieldAttribute.COB_TYPE_NUMERIC_DISPLAY, 2);
+        AbstractCobolField src = makeField(3, "XYZ", CobolFieldAttribute.COB_TYPE_ALPHANUMERIC, 0);
+
+        CobolString.stringInit(dst, ptr);
+        CobolString.stringDelimited(null);
+        CobolString.stringAppend(src);
+        CobolString.stringFinish();
+
+        assertEquals(0, CobolRuntimeException.code);
+        assertEquals(" XYZ  ", dst.getString());
+        assertEquals(5, ptr.getInt());
+    }
+}

--- a/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorageTest.java
+++ b/libcobj/app/src/test/java/jp/osscons/opensourcecobol/libcobj/data/CobolDataStorageTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2021-2022 TOKYO SYSTEM HOUSE Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 3.0,
+ * or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; see the file COPYING.LIB.  If
+ * not, write to the Free Software Foundation, 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1301 USA
+ */
+package jp.osscons.opensourcecobol.libcobj.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/** memcpy / memset の各オーバーロードが相対位置(index)を維持したまま動作することを確認する。 */
+class CobolDataStorageTest {
+
+    /** 全バイトが0xFFで埋められたバイト配列を返す。書き込み範囲外が変化していないことの検出に使う。 */
+    private static byte[] filledArray(int size) {
+        byte[] array = new byte[size];
+        java.util.Arrays.fill(array, (byte) 0xFF);
+        return array;
+    }
+
+    @Test
+    void memcpyByteArrayRespectsIndex() {
+        byte[] data = filledArray(8);
+        CobolDataStorage storage = new CobolDataStorage(data, 2);
+        storage.memcpy(new byte[] {1, 2, 3, 4}, 3);
+        assertArrayEquals(
+                new byte[] {
+                    (byte) 0xFF, (byte) 0xFF, 1, 2, 3, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+                },
+                data);
+    }
+
+    @Test
+    void memcpyByteArrayWithOffsetRespectsIndex() {
+        byte[] data = filledArray(8);
+        CobolDataStorage storage = new CobolDataStorage(data, 2);
+        storage.memcpy(3, new byte[] {1, 2, 3, 4}, 2);
+        assertArrayEquals(
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    1,
+                    2,
+                    (byte) 0xFF
+                },
+                data);
+    }
+
+    @Test
+    void memcpyStorageRespectsBothIndexes() {
+        byte[] srcData = new byte[] {9, 8, 7, 6, 5};
+        byte[] dstData = filledArray(6);
+        CobolDataStorage src = new CobolDataStorage(srcData, 1);
+        CobolDataStorage dst = new CobolDataStorage(dstData, 2);
+        dst.memcpy(src, 3);
+        assertArrayEquals(new byte[] {(byte) 0xFF, (byte) 0xFF, 8, 7, 6, (byte) 0xFF}, dstData);
+    }
+
+    @Test
+    void memcpyStorageWithOffsetRespectsBothIndexes() {
+        byte[] srcData = new byte[] {9, 8, 7, 6, 5};
+        byte[] dstData = filledArray(8);
+        CobolDataStorage src = new CobolDataStorage(srcData, 2);
+        CobolDataStorage dst = new CobolDataStorage(dstData, 1);
+        dst.memcpy(4, src, 2);
+        assertArrayEquals(
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    7,
+                    6,
+                    (byte) 0xFF
+                },
+                dstData);
+    }
+
+    @Test
+    void memcpyStringEncodesWithShiftJis() {
+        byte[] data = filledArray(4);
+        CobolDataStorage storage = new CobolDataStorage(data, 1);
+        storage.memcpy("あ", 2);
+        assertArrayEquals(new byte[] {(byte) 0xFF, (byte) 0x82, (byte) 0xA0, (byte) 0xFF}, data);
+    }
+
+    /** memcpy(byte[], int, int)のoffsetはコピー元、memcpy(int, byte[], int)のoffsetはコピー先を指す。 */
+    @Test
+    void memcpyByteArrayTrailingOffsetIsSourceOffset() {
+        byte[] data = filledArray(5);
+        CobolDataStorage storage = new CobolDataStorage(data, 1);
+        storage.memcpy(new byte[] {1, 2, 3, 4}, 2, 2);
+        assertArrayEquals(new byte[] {(byte) 0xFF, 3, 4, (byte) 0xFF, (byte) 0xFF}, data);
+    }
+
+    @Test
+    void memcpyByteArrayCopiesWholeArray() {
+        byte[] data = filledArray(5);
+        CobolDataStorage storage = new CobolDataStorage(data, 2);
+        storage.memcpy(new byte[] {1, 2, 3});
+        assertArrayEquals(new byte[] {(byte) 0xFF, (byte) 0xFF, 1, 2, 3}, data);
+    }
+
+    @Test
+    void memsetRespectsIndex() {
+        byte[] data = filledArray(6);
+        CobolDataStorage storage = new CobolDataStorage(data, 2);
+        storage.memset((byte) ' ', 3);
+        assertArrayEquals(
+                new byte[] {(byte) 0xFF, (byte) 0xFF, 0x20, 0x20, 0x20, (byte) 0xFF}, data);
+    }
+
+    @Test
+    void memsetWithOffsetRespectsIndex() {
+        byte[] data = filledArray(8);
+        CobolDataStorage storage = new CobolDataStorage(data, 2);
+        storage.memset(3, (byte) '0', 2);
+        assertArrayEquals(
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) '0',
+                    (byte) '0',
+                    (byte) 0xFF
+                },
+                data);
+    }
+
+    @Test
+    void memsetWithIntValueTruncatesToByte() {
+        byte[] data = filledArray(3);
+        CobolDataStorage storage = new CobolDataStorage(data, 0);
+        storage.memset(0x141, 2);
+        assertArrayEquals(new byte[] {0x41, 0x41, (byte) 0xFF}, data);
+    }
+
+    @Test
+    void memcpyOfZeroSizeChangesNothing() {
+        byte[] data = filledArray(3);
+        CobolDataStorage storage = new CobolDataStorage(data, 3);
+        storage.memcpy(new byte[] {1}, 0);
+        storage.memset((byte) 0, 0);
+        assertArrayEquals(filledArray(3), data);
+    }
+
+    @Test
+    void memcpyBetweenOverlappingRegionsMovesBytes() {
+        byte[] data = new byte[] {1, 2, 3, 4, 5, 6};
+        CobolDataStorage src = new CobolDataStorage(data, 0);
+        CobolDataStorage dst = new CobolDataStorage(data, 2);
+        dst.memcpy(src, 4);
+        assertArrayEquals(new byte[] {1, 2, 1, 2, 3, 4}, data);
+    }
+}


### PR DESCRIPTION
opensourcecobol/opensourcecobol4j#844 への対応。

## 概要

`CobolDataStorage` の `memcpy` / `memset` のうち、`setByte` / `getByte` を使って1バイトずつコピー・フィルしていたオーバーロードを `System.arraycopy` / `Arrays.fill` に置き換えた。これらは JIT のイントリンシックであり、要素ごとの境界チェックとメソッド呼び出しのオーバーヘッドを避けられる。`memcpy(byte[], int, int)` はすでに `System.arraycopy` を使っており、今回の変更で他のオーバーロードもそれに揃う形になる。

対象:

- `memcpy(byte[] buf, int size)`
- `memcpy(int offset, byte[] buf, int size)`
- `memcpy(CobolDataStorage buf, int size)`
- `memcpy(int offset, CobolDataStorage buf, int size)`
- `memset(byte ch, int size)`
- `memset(int offset, byte ch, int size)`

`this.index` による相対アドレッシングはそのまま維持しているため、部分項目や `OCCURS` の扱いは変わらない。公開APIの変更もない。

## 付随する修正

`System.arraycopy` は長さが負の場合に例外を投げるが、置き換え前の for ループは何もしないだけだった。この差分によって、日本語項目への `STRING ... WITH POINTER` で異常終了する経路が1つ生じることが分かったため併せて修正した。

`stringInit` は `WITH POINTER` の値を、日本語項目向けの2倍補正を行う **前** に連結先のバイト数と比較している。そのため `PIC N(5)` に対して POINTER が 7〜10 の場合、補正後の `stringOffset` が連結先のバイト数(10)を超え、`stringAppend` で残り領域が負になっていた。従来はその `memcpy` が実質 no-op となりオーバーフロー状態になるだけだったが、`System.arraycopy` では `ArrayIndexOutOfBoundsException` で異常終了する。

`stringAppend` で残り領域が0以下の場合はコピーを行わないようにし、従来と同じ結果(何も連結せずオーバーフロー条件を設定、文字位置は連結先の末尾)になるようにした。

また、`memcpy(byte[] buf, int offset, int size)` の `@param offset` の説明が実装(コピー元 `buf` 内のオフセット)と食い違っていたため修正した。

## テスト

- `CobolDataStorageTest` を新規追加。変更した各オーバーロードについて、相対位置(`index`)が維持されること、書き込み範囲外が変化しないことを確認する。
- `CobolStringTest` を新規追加。上記 `STRING` の回帰テストを含む(`stringAppend` のガードが無い状態では失敗することを確認済み)。
- CI は全ジョブ成功。

---

Addresses opensourcecobol/opensourcecobol4j#844.

## Summary

Several `memcpy` / `memset` overloads in `CobolDataStorage` copied or filled the backing array one byte at a time through `setByte` / `getByte`. They now use `System.arraycopy` and `Arrays.fill`, which are JIT intrinsics and avoid the per-element bounds checks and call overhead. `memcpy(byte[], int, int)` already used `System.arraycopy`, so the remaining overloads are now consistent with it.

Changed overloads:

- `memcpy(byte[] buf, int size)`
- `memcpy(int offset, byte[] buf, int size)`
- `memcpy(CobolDataStorage buf, int size)`
- `memcpy(int offset, CobolDataStorage buf, int size)`
- `memset(byte ch, int size)`
- `memset(int offset, byte ch, int size)`

Relative addressing through `this.index` is preserved, so sub-fields and `OCCURS` items behave exactly as before. There is no public API change.

## Accompanying fix

`System.arraycopy` throws on a negative length, whereas the previous `for` loop simply did nothing. That difference exposed one path where `STRING ... WITH POINTER` into a national item would abort.

`stringInit` compares the `WITH POINTER` value against the destination size in bytes **before** doubling the offset for national items. For a `PIC N(5)` item and a pointer of 7 through 10, the doubled `stringOffset` ends up past the item's 10 bytes, so `stringAppend` computed a negative remaining size. Previously that `memcpy` was effectively a no-op and the statement just raised the overflow condition; with `System.arraycopy` it aborted with `ArrayIndexOutOfBoundsException`.

`stringAppend` now skips the copy when nothing fits, which reproduces the previous outcome: nothing is appended, the overflow condition is set, and the pointer ends at the end of the destination.

The `@param offset` of `memcpy(byte[] buf, int offset, int size)` also described the destination, while the implementation uses it as an offset into the source array; the Javadoc is corrected.

## Tests

- New `CobolDataStorageTest` covering each changed overload: relative addressing via `index` is preserved and bytes outside the written range are untouched.
- New `CobolStringTest`, including a regression test for the `STRING` case above (verified to fail without the `stringAppend` guard).
- CI is green.

---

このPRの内容は https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/33 と同一です(ベースブランチのみ異なります)。

The contents of this pull request are identical to https://github.com/yutaro-sakamoto/opensourcecobol4j/pull/33; only the base branch differs.
