### PR TITLE
Run the CI workflows on AWS CodeBuild-hosted runners (fallback, do not merge yet)

### DIFF
--- a/.github/workflows/build-gcc9.yml
+++ b/.github/workflows/build-gcc9.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps: 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,23 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
     steps: 
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - uses: actions/setup-java@v5
         if: inputs.os == 'ubuntu:24.04'
         with:

--- a/.github/workflows/check-dev-container.yml
+++ b/.github/workflows/check-dev-container.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   hadolint:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
 
@@ -18,7 +18,7 @@ jobs:
           dockerfile: .devcontainer/Dockerfile
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     needs: hadolint
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/check-missing-javadoc.yml
+++ b/.github/workflows/check-missing-javadoc.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps: 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps: 
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps: 
       - uses: actions/setup-java@v5

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,7 +27,7 @@ jobs:
 
   create-release:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: write
     env:
@@ -58,7 +58,7 @@ jobs:
   # publish libcobj.jar to GitHub Packages
   publish:
     needs: check-workflows
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps: 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   static_analysis:
-    runs-on: ubuntu-22.04
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: almalinux:9
     steps:

--- a/.github/workflows/test-cobj-api.yml
+++ b/.github/workflows/test-cobj-api.yml
@@ -19,10 +19,23 @@ env:
 
 jobs:
   test-other:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-esql-examples.yml
+++ b/.github/workflows/test-esql-examples.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test-esql-examples:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
 
@@ -36,6 +36,19 @@ jobs:
           --health-retries 5
 
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-esql-utf8.yml
+++ b/.github/workflows/test-esql-utf8.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test-esql-utf8:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
 
@@ -36,6 +36,19 @@ jobs:
           --health-retries 5
 
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-esql.yml
+++ b/.github/workflows/test-esql.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test-esql:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
 
@@ -36,6 +36,19 @@ jobs:
           --health-retries 5
 
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-nist.yml
+++ b/.github/workflows/test-nist.yml
@@ -25,10 +25,23 @@ env:
 
 jobs:
   test-other:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -22,10 +22,23 @@ env:
 
 jobs:
   test-other:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ${{ inputs.os }}
     steps:
+      # The CodeBuild runner host runs kernel 4.14, but tar in Ubuntu 26.04 uses
+      # openat2(2) and fchmodat2(2), which that kernel does not provide, so every
+      # extraction fails with ENOSYS. Replace it with the Ubuntu 24.04 build,
+      # which actions/setup-java and `tar zxf` then can use.
+      - name: Install a tar that runs on the runner kernel
+        if: inputs.os == 'ubuntu:26.04'
+        run: |
+          echo 'deb http://archive.ubuntu.com/ubuntu noble main' > /etc/apt/sources.list.d/noble.list
+          printf 'Package: *\nPin: release n=noble\nPin-Priority: 100\n' > /etc/apt/preferences.d/noble
+          apt-get update -y
+          apt-get install -y --allow-downgrades "tar=$(apt-cache madison tar | awk '/noble/ {print $3; exit}')"
+          apt-mark hold tar
+
       - name: Get the artifact name
         run: echo "ARTIFACT_NAME=${{ inputs.os }}" | sed 's/:/-/g' >> "$GITHUB_ENV"
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout opensource COBOL 4J
         uses: actions/checkout@v7

--- a/.github/workflows/update-github-pages.yml
+++ b/.github/workflows/update-github-pages.yml
@@ -31,7 +31,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,13 +13,23 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: codebuild-opensourcecobol4j-windows-${{ github.run_id }}-${{ github.run_attempt }}
     steps: 
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
       
+      # The CodeBuild Windows image ships Visual Studio 2019 Build Tools without
+      # the C++ workload and without a Windows SDK, so MSBuild cannot load
+      # Microsoft.Cpp.Default.props. Install the 2022 build tools with MSVC.
+      - name: Install the MSVC build tools
+        shell: pwsh
+        run: |
+          choco install -y --no-progress visualstudio2022buildtools
+          choco install -y --no-progress visualstudio2022-workload-vctools `
+            --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2.0.0
 

--- a/.github/workflows/windows-generate-test-scripts.yml
+++ b/.github/workflows/windows-generate-test-scripts.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-opensourcecobol4j-ubuntu-${{ github.run_id }}-${{ github.run_attempt }}
     container:
       image: ubuntu:24.04
     steps:

--- a/.github/workflows/windows-test-esql.yml
+++ b/.github/workflows/windows-test-esql.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: codebuild-opensourcecobol4j-windows-${{ github.run_id }}-${{ github.run_attempt }}
 
     env:
       CLASSPATH: ".;C:/opensourcecobol4j/lib/libcobj.jar"

--- a/.github/workflows/windows-test-other.yml
+++ b/.github/workflows/windows-test-other.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: codebuild-opensourcecobol4j-windows-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: codebuild-opensourcecobol4j-windows-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
## 概要

CI のワークフローを AWS CodeBuild ホストの GitHub Actions ランナーで実行できるようにする。

**このPRは今すぐマージすることを意図していない。** GitHub Actions (GitHub-hosted runner) に障害が発生した場合の代替手段を用意しておくためのものであり、必要になるまでマージせず放置する。

## 前提条件

https://docs.aws.amazon.com/ja_jp/codebuild/latest/userguide/action-runner.html を参考に、`opensourcecobol4j-ubuntu` と `opensourcecobol4j-windows` という名前の CodeBuild プロジェクトを事前に2つ作成してあることを前提とする。`runs-on` に指定しているランナーラベルはこれらのプロジェクト名に対応しており、この設定がない環境ではジョブがキューに残ったままになる。

## 変更内容

### 1. すべてのジョブを CodeBuild ランナーラベルに変更

`ubuntu-latest` / `ubuntu-22.04` / `windows-latest` を `codebuild-opensourcecobol4j-{ubuntu,windows}-${{ github.run_id }}-${{ github.run_attempt }}` に置き換える。

### 2. Ubuntu 26.04 コンテナ内の tar を差し替え

CodeBuild ランナーのホストカーネルは 4.14 (Amazon Linux 2) である。一方 Ubuntu 26.04 の tar は `openat2(2)` (要 5.6 以降) と `fchmodat2(2)` (要 6.6 以降) を使うため、すべての展開処理が `ENOSYS` で失敗する。

```
openat2(4, "subdir/", {..., resolve=RESOLVE_BENEATH}) = -1 ENOSYS (Function not implemented)
fchmodat2(4, "subdir", 0755, AT_SYMLINK_NOFOLLOW)     = -1 ENOSYS (Function not implemented)
```

これにより `actions/setup-java` の JDK 展開、`actions/checkout` のアーカイブ展開、`tar zxf opensourcecobol4j.tar.gz` がいずれも失敗する。`--security-opt seccomp=unconfined` や `--privileged` では解決しない (カーネル側の制約のため)。

対応として、各コンテナジョブの先頭で tar を Ubuntu 24.04 (noble) 版に差し替える。この版は当該カーネルにあるシステムコールしか使わない。

現在の develop はコンテナイメージが `ubuntu:24.04` のためこのステップは条件によりスキップされるが、イメージを 26.04 に更新した場合に必要となるため含めている。AlmaLinux 9 の tar 1.34 は影響を受けない。

### 3. Windows に MSVC ビルドツールを導入

CodeBuild の Windows イメージには Visual Studio 2019 Build Tools が入っているが、C++ ワークロードと Windows SDK が含まれていない。そのため cobj.exe のビルドが `MSB4019: Microsoft.Cpp.Default.props was not found` で失敗する。

対応として、Chocolatey から VS2022 Build Tools と VCTools ワークロードを導入する (所要時間は約9分半)。

## 動作確認

フォーク側 (コンテナイメージ `ubuntu:26.04`) の CodeBuild ランナーで、`test on push` の全ジョブが成功することを確認済み (85 jobs success)。

---

## Overview

This makes the CI workflows runnable on AWS CodeBuild-hosted GitHub Actions runners.

**This PR is not meant to be merged now.** It exists as a fallback for the case where GitHub-hosted runners suffer an outage, and should be left open until it is actually needed.

## Prerequisites

This assumes that two CodeBuild projects named `opensourcecobol4j-ubuntu` and `opensourcecobol4j-windows` have been created beforehand, following https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html. The runner labels in `runs-on` refer to those project names; without that setup the jobs stay queued.

## Changes

### 1. Every job moves to a CodeBuild runner label

`ubuntu-latest`, `ubuntu-22.04` and `windows-latest` are replaced with `codebuild-opensourcecobol4j-{ubuntu,windows}-${{ github.run_id }}-${{ github.run_attempt }}`.

### 2. tar is replaced inside Ubuntu 26.04 containers

The CodeBuild runner host runs kernel 4.14 (Amazon Linux 2), while tar in Ubuntu 26.04 uses `openat2(2)` (requires 5.6+) and `fchmodat2(2)` (requires 6.6+), so every extraction fails with `ENOSYS`.

```
openat2(4, "subdir/", {..., resolve=RESOLVE_BENEATH}) = -1 ENOSYS (Function not implemented)
fchmodat2(4, "subdir", 0755, AT_SYMLINK_NOFOLLOW)     = -1 ENOSYS (Function not implemented)
```

This breaks the JDK extraction in `actions/setup-java`, the archive extraction in `actions/checkout`, and `tar zxf opensourcecobol4j.tar.gz`. Neither `--security-opt seccomp=unconfined` nor `--privileged` helps, because the limitation is in the host kernel.

The fix replaces tar with the Ubuntu 24.04 (noble) build as the first step of each container job, since that build only uses syscalls the host kernel provides.

On the current develop the container image is `ubuntu:24.04`, so the step is skipped by its condition; it is included because it becomes necessary once the image is bumped to 26.04. tar 1.34 on AlmaLinux 9 is unaffected.

### 3. The MSVC build tools are installed on Windows

The CodeBuild Windows image ships Visual Studio 2019 Build Tools without the C++ workload and without a Windows SDK, so building cobj.exe fails with `MSB4019: Microsoft.Cpp.Default.props was not found`.

The fix installs the VS2022 Build Tools and the VCTools workload through Chocolatey (about 9.5 minutes).

## Verification

All jobs of `test on push` pass on the CodeBuild runners of the fork, where the container image is `ubuntu:26.04` (85 jobs succeeded).
