### PR TITLE
Update Javadoc for Const.java

### DIFF
--- a/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
+++ b/libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java
@@ -19,9 +19,15 @@
 
 package jp.osscons.opensourcecobol.libcobj;
 
-/** TODO: 準備中 */
+/**
+ * opensource COBOL 4Jのランタイムライブラリ(libcobj)全体で共有する定数を保持するクラス
+ */
 public class Const {
 
-    /** TODO: 準備中 */
+    /**
+     * opensource COBOL 4Jのバージョン番号<br>
+     * {@code cobj-idx --version}などのバージョン表示に用いられる。リリース時には{@code update-version.sh}によって
+     * {@code configure.ac}や{@code build.gradle.kts}などのバージョン番号とまとめて更新されるため、この値を単独で書き換えてはならない。
+     */
     public static final String version = "2.1.0";
 }


### PR DESCRIPTION
https://github.com/opensourcecobol/opensourcecobol4j/issues/787 に関する修正

# 概要

`libcobj` の `Const.java` に記載されていた「TODO: 準備中」のプレースホルダのJavadocを、実際の内容を説明するJavadocに置き換えた。

ドキュメントコメントのみの変更であり、実行時の挙動やAPIには一切変更はなし。

# 変更点

`libcobj/app/src/main/java/jp/osscons/opensourcecobol/libcobj/Const.java`

- クラス `Const` のJavadoc
  - 「TODO: 準備中」を削除し、opensource COBOL 4Jのランタイムライブラリ(libcobj)全体で共有する定数を保持するクラスである旨を記述。
- フィールド `Const.version` のJavadoc

# その他

- ソースコードの変更はJavadocコメントのみ。
